### PR TITLE
[Chore]: Docker 및 CI 설정

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.gradle
+build
+out
+bin
+.idea
+*.iml
+.env
+.git
+
+# OS
+.DS_Store
+Thumbs.db
+
+# compose volume (로컬 바인드 쓰면 생길 수 있음)
+db_data

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+DB_NAME=hampouch
+DB_USERNAME=hampouch_user
+DB_PASSWORD=hampouch1234
+DB_PORT=3307
+
+MYSQL_ROOT_PASSWORD=local_root_password
+
+APP_PORT=8080
+JPA_DDL_AUTO=update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  #develop이나 main 브랜치로 PR 할 때 실행
+  pull_request:
+    branches: [ "develop", "main" ]
+  #develop 브랜치에 push 될 때 실행
+  push:
+    branches: [ "develop" ]
+
+#github actions가 레포 내용을 읽을 수 있는 권한 설정
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      #현재 github 레포 코드들 actions 실행 환경으로 가져옴
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      #자바 개발 환경 설정
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: gradle
+
+      #gradlew 실행 권한 부여
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      #gradle 빌드 및 테스트 실행
+      - name: Build and test
+        run: ./gradlew clean build
+
+      #Dockerfile이 정상적으로 이미지 빌드되는지 확인
+      - name: Build Docker image
+        run: docker build -t hampouch-server .

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 HELP.md
+.env
 .gradle
 build/
 !gradle/wrapper/gradle-wrapper.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+#-- 빌드용 이미지 --
+#JDK가 포함된 java 21 이미지를 사용해서 프로젝트 빌드
+FROM eclipse-temurin:21-jdk AS build
+#컨테이너 내부 작업 디렉토리를 /app으로 설정
+WORKDIR /app
+
+#gradle wrapper 실행 파일을 컨테이너로 복사
+COPY gradlew .
+#gradle wrapper가 사용하는 gradle 폴더를 컨테이너로 복사
+COPY gradle gradle
+#gradle 빌드 설정 파일들을 컨테이너로 복사
+COPY build.gradle settings.gradle ./
+#실제 소스코드를 컨테이너로 복사
+COPY src src
+
+#gradlew 파일에 실행 권한을 부여
+RUN chmod +x gradlew
+#실행 가능한 jar 파일 생성
+# clean은 기존 빌드 결과 삭제, bootJar는 실행 가능한 jar 생성, --no-daemon은 CI/Docker 환경에서 Gradle 데몬을 쓰지 않도록 하는 옵션
+RUN ./gradlew clean bootJar --no-daemon
+
+#-- 실행용 이미지 --
+#빌드에는 JDK가 필요하지만 실행에는 JRE만 있으면 되므로 더 가벼운 JRE 이미지를 사용
+FROM eclipse-temurin:21-jre
+#실행용 컨테이너의 작업 디렉토리를 /app으로 설정
+WORKDIR /app
+
+#빌드 단계에서 생성된 jar 파일을 실행용 이미지로 복사(복사하면서 이름을 app.jar로 바꿈)
+COPY --from=build /app/build/libs/*.jar app.jar
+
+#이 컨테이너가 8080 포트를 사용한다는 것을 명시
+#실제 포트 연결은 docker-compose.yml이나 docker run -p 옵션에서 설정될 예정
+EXPOSE 8080
+
+#컨테이너가 실행될 때 Spring Boot jar 파일을 실행
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+services:
+  db:
+    image: mysql:8.0
+    container_name: hampouch-mysql
+    ports:
+      - "${DB_PORT}:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${DB_NAME}
+      MYSQL_USER: ${DB_USERNAME}
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+    volumes:
+      - db_data:/var/lib/mysql
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+    healthcheck:
+      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${MYSQL_ROOT_PASSWORD}" ]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 20s
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: hampouch-server
+    ports:
+      - "${APP_PORT}:8080"
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:mysql://db:3306/${DB_NAME}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=utf8
+      SPRING_DATASOURCE_USERNAME: ${DB_USERNAME}
+      SPRING_DATASOURCE_PASSWORD: ${DB_PASSWORD}
+      JPA_DDL_AUTO: ${JPA_DDL_AUTO}
+      PORT: 8080
+
+#docker compose down을 해도 DB 데이터가 남아있도록 볼륨 정의
+#DB 데이터까지 지우고 싶다면 docker compose down -v
+volumes:
+  db_data:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,9 +3,9 @@ spring:
     name: server
 
   datasource:
-    url: ${DB_URL:jdbc:mysql://localhost:3306/${DB_NAME:hampouch}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=utf8}
-    username: ${DB_USERNAME:root}
-    password: ${DB_PASSWORD:1234}
+    url: ${SPRING_DATASOURCE_URL:jdbc:mysql://localhost:3307/${DB_NAME:hampouch}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=utf8}
+    username: ${SPRING_DATASOURCE_USERNAME:root}
+    password: ${SPRING_DATASOURCE_PASSWORD:1234}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:


### PR DESCRIPTION
## 📎연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) closes #1

- close: #2 

## 📄 작업 내용 요약
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.

-  application.yml 환경 변수 수정
- .env.example 추가
- Dockerfile 및 docker-compose.yml 추가 (MySQL 컨테이너 및 Spring Boot 앱 컨테이너 실행 설정) + dockerignore 추가
- Github Actions CI 워크플로우 추가 (PR 시 검증)

## 👀 중요 변경 사항
> API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요
- docker compose 실행 시 Spring Boot는 db:3306으로 mysql 컨테이너에 연결됩니다.
- 로컬에서 mysql로 접속할 때는 .env의 DB_PORT 값을 사용합니다. 기본 값은 localhost:3307입니다.
- **실제 환경변수 파일인 .env는 git에 포함하지 않으니, .env.example을 참고해 각자 생성해주세요.** MYSQL_ROOT_PASSWORD만 본인 계정 비밀번호로 설정하면 됩니다.

## 🔖 Uncompleted Tasks
> 후속 작업 예정인 사항이 있다면 작성해주세요.
- EC2 배포용 docker-compose.prod.yml 작성
- 배포 자동화를 위한 deploy.yml 작성
- 운영 환경 변수 및 서버 배포 설정

## 📢 To Reviewers
> Reviewer가 주로 확인해주었으면 하는 부분을 적어주세요.