### PR TITLE
[Feat]: 공통 예외 처리 및 security 설정

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 ## 📎연관된 이슈
->PR과 연관된 이슈 번호를 작성해주세요. ex) closes #1
+>PR과 연관된 이슈 번호를 작성해주세요. ex) closes #[issue number]
 
-- close: #[issue number]
+- close: #
 
 ## 📄 작업 내용 요약
 >해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.

--- a/src/main/java/Hampouch/server/global/common/exception/ApiException.java
+++ b/src/main/java/Hampouch/server/global/common/exception/ApiException.java
@@ -1,0 +1,19 @@
+package Hampouch.server.global.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ApiException extends RuntimeException {
+
+    private final BaseErrorCode baseErrorCode;
+
+    public ApiException(BaseErrorCode baseErrorCode) {
+        super(baseErrorCode.getMessage());
+        this.baseErrorCode = baseErrorCode;
+    }
+
+    public ApiException(BaseErrorCode baseErrorCode, String message) {
+        super(message);
+        this.baseErrorCode = baseErrorCode;
+    }
+}

--- a/src/main/java/Hampouch/server/global/common/exception/BaseErrorCode.java
+++ b/src/main/java/Hampouch/server/global/common/exception/BaseErrorCode.java
@@ -1,0 +1,9 @@
+package Hampouch.server.global.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface BaseErrorCode {
+    HttpStatus getHttpStatus();
+    String getCode();
+    String getMessage();
+}

--- a/src/main/java/Hampouch/server/global/common/exception/CustomException.java
+++ b/src/main/java/Hampouch/server/global/common/exception/CustomException.java
@@ -1,0 +1,19 @@
+package Hampouch.server.global.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final BaseErrorCode errorCode;
+
+    public CustomException(BaseErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public CustomException(BaseErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/Hampouch/server/global/common/exception/ErrorResponse.java
+++ b/src/main/java/Hampouch/server/global/common/exception/ErrorResponse.java
@@ -1,0 +1,39 @@
+package Hampouch.server.global.common.exception;
+
+import Hampouch.server.global.common.exception.domain.CommonErrorCode;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.Map;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ErrorResponse(
+        String code,
+        String message,
+        int status,
+        Map<String, String> fieldErrors
+) {
+    public static ErrorResponse from(BaseErrorCode errorCode) {
+        return new ErrorResponse(
+                errorCode.getCode(),
+                errorCode.getMessage(),
+                errorCode.getHttpStatus().value(),
+                null
+        );
+    }
+
+    public static ErrorResponse validation() {
+        return from(CommonErrorCode.VALIDATION_ERROR);
+    }
+
+    public static ErrorResponse validation(Map<String, String> fieldErrors) {
+        if (fieldErrors == null || fieldErrors.isEmpty()) {
+            return validation();
+        }
+
+        return new ErrorResponse(
+                CommonErrorCode.VALIDATION_ERROR.getCode(),
+                CommonErrorCode.VALIDATION_ERROR.getMessage(),
+                CommonErrorCode.VALIDATION_ERROR.getHttpStatus().value(),
+                fieldErrors
+        );
+    }
+}

--- a/src/main/java/Hampouch/server/global/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/Hampouch/server/global/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,125 @@
+package Hampouch.server.global.common.exception;
+
+import Hampouch.server.global.common.exception.domain.CommonErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    /**
+     * 직접 정의한 비즈니스 예외 처리
+     *
+     * 사용 예:
+     * throw new CustomException(UserErrorCode.USER_NOT_FOUND);
+     * throw new CustomException(ChallengeErrorCode.CHALLENGE_NOT_FOUND);
+     */
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(
+            CustomException e,
+            HttpServletRequest request
+    ) {
+        BaseErrorCode errorCode = e.getErrorCode();
+
+        String auth = request.getHeader("Authorization");
+        boolean hasAuth = auth != null && !auth.isBlank();
+
+        Object userId = request.getAttribute("userId");
+
+        log.warn(
+                "[CustomException] {} {} | status={} code={} | userId={} | hasAuth={} | ua={}",
+                request.getMethod(),
+                request.getRequestURI(),
+                errorCode.getHttpStatus().value(),
+                errorCode.getCode(),
+                userId,
+                hasAuth,
+                request.getHeader("User-Agent")
+        );
+
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ErrorResponse.from(errorCode));
+    }
+
+    /**
+     * @RequestBody + @Valid 검증 실패 처리
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
+            MethodArgumentNotValidException e,
+            HttpServletRequest request
+    ) {
+        Map<String, String> fieldErrors = new LinkedHashMap<>();
+
+        for (FieldError fieldError : e.getBindingResult().getFieldErrors()) {
+            fieldErrors.putIfAbsent(
+                    fieldError.getField(),
+                    fieldError.getDefaultMessage()
+            );
+        }
+
+        log.warn(
+                "[ValidationException] {} {} | fieldErrors={} | globalErrors={}",
+                request.getMethod(),
+                request.getRequestURI(),
+                fieldErrors,
+                e.getBindingResult().getGlobalErrors()
+        );
+
+        return ResponseEntity
+                .status(CommonErrorCode.VALIDATION_ERROR.getHttpStatus())
+                .body(ErrorResponse.validation(fieldErrors));
+    }
+
+    /**
+     * @RequestParam, @PathVariable 등에 붙은 검증 실패 처리
+     */
+    @ExceptionHandler(HandlerMethodValidationException.class)
+    public ResponseEntity<ErrorResponse> handleHandlerMethodValidationException(
+            HandlerMethodValidationException e,
+            HttpServletRequest request
+    ) {
+        log.warn(
+                "[HandlerMethodValidationException] {} {} | message={}",
+                request.getMethod(),
+                request.getRequestURI(),
+                e.getMessage()
+        );
+
+        return ResponseEntity
+                .status(CommonErrorCode.VALIDATION_ERROR.getHttpStatus())
+                .body(ErrorResponse.from(CommonErrorCode.VALIDATION_ERROR));
+    }
+
+    /**
+     * 처리하지 못한 모든 예외 처리
+     * 클라이언트에는 500 에러 내려주고, 서버 로그에만 실제 예외를 남긴다.
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(
+            Exception e,
+            HttpServletRequest request
+    ) {
+        log.error(
+                "[UnhandledException] {} {}",
+                request.getMethod(),
+                request.getRequestURI(),
+                e
+        );
+
+        return ResponseEntity
+                .status(CommonErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
+                .body(ErrorResponse.from(CommonErrorCode.INTERNAL_SERVER_ERROR));
+    }
+}

--- a/src/main/java/Hampouch/server/global/common/exception/domain/AuthErrorCode.java
+++ b/src/main/java/Hampouch/server/global/common/exception/domain/AuthErrorCode.java
@@ -1,0 +1,42 @@
+package Hampouch.server.global.common.exception.domain;
+
+import Hampouch.server.global.common.exception.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 실제 코드에서 사용 예:
+ * throw new CustomException(AuthErrorCode.INVALID_EMAIL_OR_PASSWORD);
+ */
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthErrorCode implements BaseErrorCode {
+
+    INVALID_EMAIL_OR_PASSWORD(HttpStatus.UNAUTHORIZED, "INVALID_EMAIL_OR_PASSWORD", "이메일 또는 비밀번호가 올바르지 않습니다."),
+
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "인증이 필요합니다."),
+
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "INVALID_TOKEN", "유효하지 않은 토큰입니다."),
+
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "EXPIRED_TOKEN", "만료된 토큰입니다."),
+
+    UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "UNSUPPORTED_TOKEN", "지원하지 않는 토큰입니다."),
+
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "REFRESH_TOKEN_NOT_FOUND", "리프레시 토큰을 찾을 수 없습니다."),
+
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "INVALID_REFRESH_TOKEN", "유효하지 않은 리프레시 토큰입니다."),
+
+    EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "EXPIRED_REFRESH_TOKEN", "만료된 리프레시 토큰입니다."),
+
+    FORBIDDEN(HttpStatus.FORBIDDEN, "FORBIDDEN", "접근 권한이 없습니다."),
+
+    SOCIAL_ACCOUNT_ONLY(HttpStatus.BAD_REQUEST, "SOCIAL_ACCOUNT_ONLY", "소셜 로그인으로 가입된 계정입니다."),
+
+    LOCAL_ACCOUNT_ONLY(HttpStatus.BAD_REQUEST, "LOCAL_ACCOUNT_ONLY", "일반 로그인으로 가입된 계정입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/Hampouch/server/global/common/exception/domain/CommonErrorCode.java
+++ b/src/main/java/Hampouch/server/global/common/exception/domain/CommonErrorCode.java
@@ -1,0 +1,22 @@
+package Hampouch.server.global.common.exception.domain;
+
+import Hampouch.server.global.common.exception.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommonErrorCode implements BaseErrorCode {
+
+    VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", "입력값이 올바르지 않습니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "BAD_REQUEST", "잘못된 요청입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "인증이 필요합니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "FORBIDDEN", "접근 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "NOT_FOUND", "요청한 리소스를 찾을 수 없습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/Hampouch/server/global/common/exception/domain/CommunityErrorCode.java
+++ b/src/main/java/Hampouch/server/global/common/exception/domain/CommunityErrorCode.java
@@ -1,0 +1,4 @@
+package Hampouch.server.global.common.exception.domain;
+
+public class CommunityErrorCode {
+}

--- a/src/main/java/Hampouch/server/global/security/SecurityConfig.java
+++ b/src/main/java/Hampouch/server/global/security/SecurityConfig.java
@@ -1,0 +1,49 @@
+package Hampouch.server.global.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                // 나중에 JWT를 사용할 예정이므로 세션 사용 안 함
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                // 초기 개발 단계에서는 모든 요청 허용
+                // TODO: JWT 인증 구현 시 CustomAuthenticationEntryPoint, CustomAccessDeniedHandler 추가
+                // TODO: JWT 인증 구현 후 인증 필요한 API는 토큰 없이 오면 막도록 변경
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest().permitAll()
+//                        .requestMatchers(
+//                                "/auth/**",
+//                                "/swagger-ui/**",
+//                                "/v3/api-docs/**",
+//                                "/swagger-ui.html"
+//                        ).permitAll()
+//                        .anyRequest().authenticated()
+                )
+                .build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}


### PR DESCRIPTION
## 📎연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) closes #

- close: #12

## 📄 작업 내용 요약
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.

- 공통 예외 처리 구조 추가
  - BaseErrorCode, CommonErrorCode
  - ErrorResponse
  - ApiException, CustomException, GlobalExceptionHandler
- validation 에러 응답 형식 통일
  - 상세한 에러 응답이 필요한 경우 fieldErrors 사용
- spring security 기본 설정 추가
  - CSRF, formLogin, httpBasic 비활성화
  - 인증 도메인 개발 전이므로 모든 API 요청 permitAll() 처리 (추후 수정 예정)

## 👀 중요 변경 사항
> API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요
- 에러 응답 형식이 아래 구조로 통일됩니다.
{ 
   "code": "VALIDATION_ERROR", 
   "message": "입력값이 올바르지 않습니다.", 
   "status": 400, 
   "fieldErrors": { "필드이름": "에러 메시지" } 
}
- fieldErrors가 없는 에러의 경우 fieldErrors 부분은 응답에서 제외됩니다.
- 도메인 로직에서 예외가 필요한 경우 도메인별 ErrorCode를 사용하시면 됩니다.
  - 예시로 AuthErrorCode를 작성해두었으니 참고해주세요.

## 🔖 Uncompleted Tasks
> 후속 작업 예정인 사항이 있다면 작성해주세요.
- JWT 인증 필터 추가
- 로그인/회원가입 API 구현 (이후 인증 필요한 API에 대한 authenticated() 설정 및 CustomAuthenticationEntryPoint, CustomAccessDeniedHandler 추가)
- Refresh Token 처리

## 📢 To Reviewers
> Reviewer가 주로 확인해주었으면 하는 부분을 적어주세요.
- 이 PR이 merge된 후 개발하면서 GlobalExceptionHandler에서 validation 에러가 의도한 형식으로 내려가는지, security 설정이 현재 전체 허용 상태인지 확인 부탁드립니다.