### PR TITLE
feat: 추천에서 미니 추가 배선 구현 (#19)

### DIFF
--- a/src/main/java/Hampouch/server/domain/minichallenge/service/MiniChallengeService.java
+++ b/src/main/java/Hampouch/server/domain/minichallenge/service/MiniChallengeService.java
@@ -3,8 +3,10 @@ package Hampouch.server.domain.minichallenge.service;
 import Hampouch.server.domain.minichallenge.dto.*;
 import Hampouch.server.domain.minichallenge.entity.MiniChallenge;
 import Hampouch.server.domain.minichallenge.entity.MiniChallengeDay;
+import Hampouch.server.domain.minichallenge.entity.RecommendedMiniChallenge;
 import Hampouch.server.domain.minichallenge.repository.MiniChallengeDayRepository;
 import Hampouch.server.domain.minichallenge.repository.MiniChallengeRepository;
+import Hampouch.server.domain.minichallenge.repository.RecommendedMiniChallengeRepository;
 import Hampouch.server.global.common.exception.CustomException;
 import Hampouch.server.global.common.exception.domain.CommonErrorCode;
 import Hampouch.server.global.common.exception.domain.MiniChallengeErrorCode;
@@ -40,6 +42,8 @@ public class MiniChallengeService {
 
     private final MiniChallengeRepository miniChallengeRepository;
     private final MiniChallengeDayRepository miniChallengeDayRepository;
+    // 추천 카탈로그(#10) 조회용 — "추천에서 추가"(§3)가 여기서 title·durationDays를 복사해 온다(#19 배선)
+    private final RecommendedMiniChallengeRepository recommendedMiniChallengeRepository;
     // "지금"의 단일 출처(ClockConfig, Asia/Seoul) — 인자 없는 now()는 서버 OS 시간대를 타고 테스트 고정도 불가(#1과 동일 이유)
     private final Clock clock;
 
@@ -110,17 +114,21 @@ public class MiniChallengeService {
         }
 
         if (byRecommended) {
-            // TODO(#9·#10 머지 후 배선 — 별도 후속 커밋 필수): RecommendedMiniChallengeRepository.findById(recommendedId)로
-            // 카탈로그(#10)를 조회해, 없으면 지금처럼 404, 있으면 title/durationDays를 복사해
-            // MiniChallenge.create(userId, rec.getTitle(), rec.getDurationDays(), LocalDate.now(clock))로 생성 + 통합 테스트 1건.
-            // 주의: #10은 카탈로그 조회 GET(§2)만 구현한다 — 이 분기를 교체하지 않으면 두 브랜치가 모두 머지돼도
-            // 유효한 recommendedId로 POST하면 계속 404인 반쪽 상태가 된다("추천에서 추가"는 명세 확정 기능).
-            // 지금은 카탈로그 엔티티(#10 담당)가 이 브랜치에 없어 조회 자체가 불가 — 어떤 recommendedId도
-            // "카탈로그에 없음"이라 즉시 404. 명세 §3의 404(recommendedId 카탈로그에 없음)와 의미가
-            // 일치한다(빈 카탈로그와 동등).
+            // 추천에서 추가(#19 배선) — 카탈로그(recommended_mini_challenge, #10)에서 조회해 없으면 404(§3),
+            // 있으면 title·durationDays만 복사해 유저 소유 행을 새로 만든다. 참조(FK)가 아니라 값 복사인 이유(§2):
+            // 카탈로그는 기획이 관리하는 공용 목록이라, 문구 수정·항목 삭제가 이미 시작한 유저 미니를 흔들면 안 된다.
+            // 커스텀 경로의 값 검증(비공백·길이·화이트리스트)을 여기엔 안 거는 이유 — 카탈로그 값은 유저 입력이
+            // 아니라 서버가 시드로 관리하는 데이터라, 이상하면 그건 400이 아니라 시드 수정 사안이다.
             // 잠정: §3의 409(같은 추천을 이미 진행 중 — 명세도 잠정 표기)는 미구현 — 추천/커스텀 통일로
-            // origin 컬럼이 ERD에 없어 "같은 추천에서 온 미니"를 식별할 수 없음. 확정되면 식별 수단부터 재설계.
-            throw new CustomException(MiniChallengeErrorCode.MINI_RECOMMENDED_NOT_FOUND);
+            // origin 컬럼이 ERD에 없어 "같은 추천에서 온 미니"를 식별할 수 없음. 확정되면 식별 수단부터 재설계(질문 10).
+            // findById는 Optional(값이 있을 수도, 없을 수도 있는 상자)을 반환 — orElseThrow는 값이 있으면
+            // 꺼내 주고, 비어 있으면(해당 id 없음) 람다가 만든 예외를 그때 생성해 던진다. null 검사 if문의 한 줄 대체.
+            RecommendedMiniChallenge rec = recommendedMiniChallengeRepository.findById(req.recommendedId())
+                    .orElseThrow(() -> new CustomException(MiniChallengeErrorCode.MINI_RECOMMENDED_NOT_FOUND));
+            MiniChallenge mini = MiniChallenge.create(
+                    userId, rec.getTitle(), rec.getDurationDays(), LocalDate.now(clock));
+            miniChallengeRepository.save(mini);
+            return CreateMiniChallengeResponse.from(mini);
         }
 
         CreateMiniChallengeRequest.Custom custom = req.custom();

--- a/src/test/java/Hampouch/server/domain/minichallenge/MiniChallengeFlowIntegrationTest.java
+++ b/src/test/java/Hampouch/server/domain/minichallenge/MiniChallengeFlowIntegrationTest.java
@@ -1,5 +1,7 @@
 package Hampouch.server.domain.minichallenge;
 
+import Hampouch.server.domain.minichallenge.entity.RecommendedMiniChallenge;
+import Hampouch.server.domain.minichallenge.repository.RecommendedMiniChallengeRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,6 +32,8 @@ class MiniChallengeFlowIntegrationTest {
     MockMvc mvc;
     @Autowired
     ObjectMapper om;
+    @Autowired
+    RecommendedMiniChallengeRepository recommendedMiniChallengeRepository;
 
     @Test
     @DisplayName("생성 → 오늘 체크 → 그날 조회가 '1/1 완료·연속 1일째'를 돌려주는지 확인 → 해제 두 번(멱등 200) → 삭제(204) → 지운 미니 재삭제(404)까지, 미니 하나의 전체 흐름이 모킹 없이 실제 스택으로 끝까지 동작한다")
@@ -97,5 +101,54 @@ class MiniChallengeFlowIntegrationTest {
         mvc.perform(delete("/api/mini-challenges/" + id).header("X-User-Id", USER))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value("MINI_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("추천에서 추가하면 카탈로그 행의 제목·기간이 복사된 유저 소유 미니가 새 id로 만들어지고, 없는 recommendedId는 404가 난다 (#19 배선, 통합)")
+    void recommendedWiringFlow() throws Exception {
+        // fullFlow(유저 9)의 집계 단언과 데이터가 섞이지 않게 이 시나리오 전용 유저를 따로 쓴다
+        String user = "19";
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        // 시더(기획 임시 12건)의 내용·id에 기대지 않도록 이 테스트 전용 카탈로그 행을 직접 심는다 — 시드가 바뀌어도 안 깨짐
+        RecommendedMiniChallenge rec = recommendedMiniChallengeRepository.save(
+                RecommendedMiniChallenge.of("통합 테스트용 추천 미니", 3));
+
+        // 1) 추천에서 추가: 카탈로그 값 복사 + 시작일=오늘, 새 miniChallengeId 발급(카탈로그 id와 별개)
+        String created = mvc.perform(post("/api/mini-challenges")
+                        .header("X-User-Id", user)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"recommendedId\":" + rec.getId() + "}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.title").value("통합 테스트용 추천 미니"))
+                .andExpect(jsonPath("$.data.durationDays").value(3))
+                .andExpect(jsonPath("$.data.startDate").value(today.toString()))
+                .andExpect(jsonPath("$.data.endDate").value(today.plusDays(2).toString()))
+                .andReturn().getResponse().getContentAsString();
+        long miniId = om.readTree(created).path("data").path("miniChallengeId").asLong();
+
+        // 2) 만들어진 건 유저 미니라 체크·삭제가 miniChallengeId로 동작한다
+        mvc.perform(put("/api/mini-challenges/" + miniId + "/check")
+                        .header("X-User-Id", user)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"checked\":true}"))
+                .andExpect(status().isOk());
+        mvc.perform(delete("/api/mini-challenges/" + miniId).header("X-User-Id", user))
+                .andExpect(status().isNoContent());
+
+        // 3) 유저 미니가 지워져도 카탈로그 행은 그대로다 — 값 복사(FK 없음)의 확인
+        mvc.perform(post("/api/mini-challenges")
+                        .header("X-User-Id", user)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"recommendedId\":" + rec.getId() + "}"))
+                .andExpect(status().isCreated());
+
+        // 4) 카탈로그에 없는 id는 404
+        mvc.perform(post("/api/mini-challenges")
+                        .header("X-User-Id", user)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"recommendedId\":999999}"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("MINI_RECOMMENDED_NOT_FOUND"));
     }
 }

--- a/src/test/java/Hampouch/server/domain/minichallenge/MiniChallengeFlowIntegrationTest.java
+++ b/src/test/java/Hampouch/server/domain/minichallenge/MiniChallengeFlowIntegrationTest.java
@@ -104,7 +104,7 @@ class MiniChallengeFlowIntegrationTest {
     }
 
     @Test
-    @DisplayName("추천에서 추가하면 카탈로그 행의 제목·기간이 복사된 유저 소유 미니가 새 id로 만들어지고, 없는 recommendedId는 404가 난다 (#19 배선, 통합)")
+    @DisplayName("추천에서 추가하면 카탈로그 행의 제목·기간이 복사된 유저 소유 미니가 새 id로 만들어지고, 없는 recommendedId는 404가 난다")
     void recommendedWiringFlow() throws Exception {
         // fullFlow(유저 9)의 집계 단언과 데이터가 섞이지 않게 이 시나리오 전용 유저를 따로 쓴다
         String user = "19";

--- a/src/test/java/Hampouch/server/domain/minichallenge/service/MiniChallengeServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/minichallenge/service/MiniChallengeServiceTest.java
@@ -3,8 +3,10 @@ package Hampouch.server.domain.minichallenge.service;
 import Hampouch.server.domain.minichallenge.dto.*;
 import Hampouch.server.domain.minichallenge.entity.MiniChallenge;
 import Hampouch.server.domain.minichallenge.entity.MiniChallengeDay;
+import Hampouch.server.domain.minichallenge.entity.RecommendedMiniChallenge;
 import Hampouch.server.domain.minichallenge.repository.MiniChallengeDayRepository;
 import Hampouch.server.domain.minichallenge.repository.MiniChallengeRepository;
+import Hampouch.server.domain.minichallenge.repository.RecommendedMiniChallengeRepository;
 import Hampouch.server.global.common.exception.CustomException;
 import Hampouch.server.global.common.exception.domain.CommonErrorCode;
 import Hampouch.server.global.common.exception.domain.MiniChallengeErrorCode;
@@ -43,10 +45,15 @@ class MiniChallengeServiceTest {
     MiniChallengeRepository miniChallengeRepository;
     @Mock
     MiniChallengeDayRepository miniChallengeDayRepository;
+    @Mock
+    RecommendedMiniChallengeRepository recommendedMiniChallengeRepository;
 
-    private MiniChallengeService serviceAt(LocalDate today) {
-        Clock clock = Clock.fixed(today.atTime(12, 0).atZone(SEOUL).toInstant(), SEOUL);
-        return new MiniChallengeService(miniChallengeRepository, miniChallengeDayRepository, clock);
+    // 클록을 TODAY(7/10) 정오·서울로 고정한 서비스 — 이 파일 테스트는 전부 같은 "오늘" 위에서 돈다.
+    // 테스트마다 날짜를 달리 넘기는 ChallengeServiceTest와 달리 여기선 항상 같아 파라미터를 없앴다(필요해지면 그때 복원).
+    private MiniChallengeService service() {
+        Clock clock = Clock.fixed(TODAY.atTime(12, 0).atZone(SEOUL).toInstant(), SEOUL);
+        return new MiniChallengeService(
+                miniChallengeRepository, miniChallengeDayRepository, recommendedMiniChallengeRepository, clock);
     }
 
     @Test
@@ -55,7 +62,7 @@ class MiniChallengeServiceTest {
         var req = new CreateMiniChallengeRequest(null,
                 new CreateMiniChallengeRequest.Custom("오늘 커피 사먹지 않기", 7));
 
-        CreateMiniChallengeResponse res = serviceAt(TODAY).create(USER, req);
+        CreateMiniChallengeResponse res = service().create(USER, req);
 
         assertThat(res.title()).isEqualTo("오늘 커피 사먹지 않기");
         assertThat(res.durationDays()).isEqualTo(7);
@@ -70,7 +77,7 @@ class MiniChallengeServiceTest {
         var req = new CreateMiniChallengeRequest(7L,
                 new CreateMiniChallengeRequest.Custom("커스텀", 7));
 
-        assertThatThrownBy(() -> serviceAt(TODAY).create(USER, req))
+        assertThatThrownBy(() -> service().create(USER, req))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", MiniChallengeErrorCode.MINI_INVALID_BODY);
     }
@@ -80,7 +87,7 @@ class MiniChallengeServiceTest {
     void create_rejectsNeitherForm() {
         var req = new CreateMiniChallengeRequest(null, null);
 
-        assertThatThrownBy(() -> serviceAt(TODAY).create(USER, req))
+        assertThatThrownBy(() -> service().create(USER, req))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", MiniChallengeErrorCode.MINI_INVALID_BODY);
     }
@@ -91,7 +98,7 @@ class MiniChallengeServiceTest {
         var req = new CreateMiniChallengeRequest(null,
                 new CreateMiniChallengeRequest.Custom("   ", 7));
 
-        assertThatThrownBy(() -> serviceAt(TODAY).create(USER, req))
+        assertThatThrownBy(() -> service().create(USER, req))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", MiniChallengeErrorCode.MINI_INVALID_BODY);
     }
@@ -102,7 +109,7 @@ class MiniChallengeServiceTest {
         var req = new CreateMiniChallengeRequest(null,
                 new CreateMiniChallengeRequest.Custom("가".repeat(256), 7)); // varchar(255) 초과 — 검증 없으면 INSERT에서 500
 
-        assertThatThrownBy(() -> serviceAt(TODAY).create(USER, req))
+        assertThatThrownBy(() -> service().create(USER, req))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", MiniChallengeErrorCode.MINI_INVALID_BODY);
     }
@@ -113,17 +120,36 @@ class MiniChallengeServiceTest {
         var req = new CreateMiniChallengeRequest(null,
                 new CreateMiniChallengeRequest.Custom("5일 도전", 5));
 
-        assertThatThrownBy(() -> serviceAt(TODAY).create(USER, req))
+        assertThatThrownBy(() -> service().create(USER, req))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", MiniChallengeErrorCode.MINI_INVALID_DURATION);
     }
 
     @Test
-    @DisplayName("recommendedId로 추가는 지금 어떤 id를 보내도 404(MINI_RECOMMENDED_NOT_FOUND)다 — 카탈로그가 #10 브랜치에 있어 여기엔 아직 없음(빈 카탈로그와 동일, 머지 후 #19에서 실제 조회로 교체)")
-    void create_recommendedNotFoundUntilCatalogMerged() {
+    @DisplayName("recommendedId로 추가하면 카탈로그의 제목·기간을 복사해 시작일=오늘인 유저 소유 미니가 새로 만들어진다 — 참조가 아니라 값 복사(#19 배선)")
+    void create_copiesFromCatalogByRecommendedId() {
+        when(recommendedMiniChallengeRepository.findById(7L))
+                .thenReturn(Optional.of(RecommendedMiniChallenge.of("편의점 디저트 안 먹기", 7)));
         var req = new CreateMiniChallengeRequest(7L, null);
 
-        assertThatThrownBy(() -> serviceAt(TODAY).create(USER, req))
+        CreateMiniChallengeResponse res = service().create(USER, req);
+
+        assertThat(res.title()).isEqualTo("편의점 디저트 안 먹기"); // 카탈로그 값 복사
+        assertThat(res.durationDays()).isEqualTo(7);
+        assertThat(res.startDate()).isEqualTo(TODAY);              // 시작일은 카탈로그가 아니라 추가한 날
+        assertThat(res.endDate()).isEqualTo(TODAY.plusDays(6));
+        ArgumentCaptor<MiniChallenge> captor = ArgumentCaptor.forClass(MiniChallenge.class);
+        verify(miniChallengeRepository).save(captor.capture());    // 유저 소유의 새 행이 저장됨
+        assertThat(captor.getValue().isOwnedBy(USER)).isTrue();
+    }
+
+    @Test
+    @DisplayName("recommendedId가 카탈로그에 없으면 404(MINI_RECOMMENDED_NOT_FOUND)로 거절한다")
+    void create_recommendedNotFoundWhenMissingInCatalog() {
+        when(recommendedMiniChallengeRepository.findById(999L)).thenReturn(Optional.empty());
+        var req = new CreateMiniChallengeRequest(999L, null);
+
+        assertThatThrownBy(() -> service().create(USER, req))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", MiniChallengeErrorCode.MINI_RECOMMENDED_NOT_FOUND);
     }
@@ -133,7 +159,7 @@ class MiniChallengeServiceTest {
     void delete_notFound() {
         when(miniChallengeRepository.findById(99L)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> serviceAt(TODAY).delete(USER, 99L))
+        assertThatThrownBy(() -> service().delete(USER, 99L))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", MiniChallengeErrorCode.MINI_NOT_FOUND);
     }
@@ -144,7 +170,7 @@ class MiniChallengeServiceTest {
         MiniChallenge others = MiniChallenge.create(2L, "남의 미니", 7, TODAY.minusDays(1));
         when(miniChallengeRepository.findById(10L)).thenReturn(Optional.of(others));
 
-        assertThatThrownBy(() -> serviceAt(TODAY).delete(USER, 10L))
+        assertThatThrownBy(() -> service().delete(USER, 10L))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", MiniChallengeErrorCode.MINI_FORBIDDEN);
     }
@@ -155,7 +181,7 @@ class MiniChallengeServiceTest {
         MiniChallenge mine = MiniChallenge.create(USER, "내 미니", 7, TODAY.minusDays(1));
         when(miniChallengeRepository.findById(10L)).thenReturn(Optional.of(mine));
 
-        serviceAt(TODAY).delete(USER, 10L);
+        service().delete(USER, 10L);
 
         InOrder order = inOrder(miniChallengeDayRepository, miniChallengeRepository);
         order.verify(miniChallengeDayRepository).deleteByMiniChallenge_Id(10L);
@@ -168,7 +194,7 @@ class MiniChallengeServiceTest {
         MiniChallenge mine = MiniChallenge.create(USER, "내 미니", 31, TODAY.minusDays(1));
         when(miniChallengeRepository.findById(10L)).thenReturn(Optional.of(mine));
 
-        assertThatThrownBy(() -> serviceAt(TODAY)
+        assertThatThrownBy(() -> service()
                 .check(USER, 10L, new MiniCheckRequest(TODAY.plusDays(1).toString(), true)))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", MiniChallengeErrorCode.MINI_FUTURE_CHECK);
@@ -181,7 +207,7 @@ class MiniChallengeServiceTest {
         when(miniChallengeRepository.findById(10L)).thenReturn(Optional.of(mine));
 
         // 내일(7/11)은 미래이면서 기간(7/9~7/9) 밖 — 검사 순서가 바뀌면 코드가 조용히 바뀌므로 테스트로 고정
-        assertThatThrownBy(() -> serviceAt(TODAY)
+        assertThatThrownBy(() -> service()
                 .check(USER, 10L, new MiniCheckRequest(TODAY.plusDays(1).toString(), true)))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", MiniChallengeErrorCode.MINI_FUTURE_CHECK);
@@ -193,7 +219,7 @@ class MiniChallengeServiceTest {
         MiniChallenge mine = MiniChallenge.create(USER, "내 미니", 7, TODAY.minusDays(5)); // 7/5~7/11
         when(miniChallengeRepository.findById(10L)).thenReturn(Optional.of(mine));
 
-        assertThatThrownBy(() -> serviceAt(TODAY)
+        assertThatThrownBy(() -> service()
                 .check(USER, 10L, new MiniCheckRequest(TODAY.minusDays(7).toString(), true))) // 7/3 = 시작 전(과거이면서 기간 밖)
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", MiniChallengeErrorCode.MINI_DATE_OUT_OF_RANGE);
@@ -207,7 +233,7 @@ class MiniChallengeServiceTest {
         when(miniChallengeDayRepository.existsByMiniChallenge_IdAndCheckDate(10L, TODAY.minusDays(4)))
                 .thenReturn(false);
 
-        MiniCheckResponse res = serviceAt(TODAY)
+        MiniCheckResponse res = service()
                 .check(USER, 10L, new MiniCheckRequest(TODAY.minusDays(4).toString(), true)); // 7/6 과거·기간 안
 
         assertThat(res.checked()).isTrue();
@@ -222,7 +248,7 @@ class MiniChallengeServiceTest {
         when(miniChallengeRepository.findById(10L)).thenReturn(Optional.of(mine));
         when(miniChallengeDayRepository.existsByMiniChallenge_IdAndCheckDate(10L, TODAY)).thenReturn(true);
 
-        MiniCheckResponse res = serviceAt(TODAY).check(USER, 10L, new MiniCheckRequest(TODAY.toString(), true));
+        MiniCheckResponse res = service().check(USER, 10L, new MiniCheckRequest(TODAY.toString(), true));
 
         assertThat(res.checked()).isTrue();
         verify(miniChallengeDayRepository, never()).save(any());
@@ -235,7 +261,7 @@ class MiniChallengeServiceTest {
         when(miniChallengeRepository.findById(10L)).thenReturn(Optional.of(mine));
         when(miniChallengeDayRepository.deleteByMiniChallenge_IdAndCheckDate(10L, TODAY)).thenReturn(0);
 
-        MiniCheckResponse res = serviceAt(TODAY).check(USER, 10L, new MiniCheckRequest(TODAY.toString(), false));
+        MiniCheckResponse res = service().check(USER, 10L, new MiniCheckRequest(TODAY.toString(), false));
 
         assertThat(res.checked()).isFalse();
         assertThat(res.date()).isEqualTo(TODAY);
@@ -248,7 +274,7 @@ class MiniChallengeServiceTest {
         when(miniChallengeRepository.findById(10L)).thenReturn(Optional.of(mine));
         when(miniChallengeDayRepository.existsByMiniChallenge_IdAndCheckDate(10L, TODAY)).thenReturn(false);
 
-        serviceAt(TODAY).check(USER, 10L, new MiniCheckRequest(null, true));
+        service().check(USER, 10L, new MiniCheckRequest(null, true));
 
         ArgumentCaptor<MiniChallengeDay> captor = ArgumentCaptor.forClass(MiniChallengeDay.class);
         verify(miniChallengeDayRepository).save(captor.capture());
@@ -262,7 +288,7 @@ class MiniChallengeServiceTest {
         when(miniChallengeRepository.findById(10L)).thenReturn(Optional.of(mine));
 
         // 제로패딩 누락(2026-7-6)처럼 LocalDate였다면 Jackson 역직렬화에서 500이 됐을 입력
-        assertThatThrownBy(() -> serviceAt(TODAY).check(USER, 10L, new MiniCheckRequest("2026-7-6", true)))
+        assertThatThrownBy(() -> service().check(USER, 10L, new MiniCheckRequest("2026-7-6", true)))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", CommonErrorCode.BAD_REQUEST);
     }
@@ -270,7 +296,7 @@ class MiniChallengeServiceTest {
     @Test
     @DisplayName("date 파라미터가 이상한 형식이면 500이 아니라 400(BAD_REQUEST)으로 거절한다")
     void getDaily_badRequestWhenDateMalformed() {
-        assertThatThrownBy(() -> serviceAt(TODAY).getDaily(USER, "2026-13-99"))
+        assertThatThrownBy(() -> service().getDaily(USER, "2026-13-99"))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", CommonErrorCode.BAD_REQUEST);
     }
@@ -280,7 +306,7 @@ class MiniChallengeServiceTest {
     void getDaily_defaultsToTodayAndEmptySummary() {
         when(miniChallengeRepository.findByUserId(USER)).thenReturn(List.of());
 
-        DailyMiniChallengesResponse res = serviceAt(TODAY).getDaily(USER, null);
+        DailyMiniChallengesResponse res = service().getDaily(USER, null);
 
         assertThat(res.date()).isEqualTo(TODAY);
         assertThat(res.summary().checkedCount()).isZero();
@@ -298,13 +324,13 @@ class MiniChallengeServiceTest {
         when(miniChallengeDayRepository.findByMiniChallenge_IdInAndCheckDateLessThanEqual(any(), any()))
                 .thenReturn(List.of());
 
-        DailyMiniChallengesResponse res = serviceAt(TODAY).getDaily(USER, TODAY.toString());
+        DailyMiniChallengesResponse res = service().getDaily(USER, TODAY.toString());
 
         assertThat(res.summary().totalCount()).isEqualTo(1);
         assertThat(res.items()).hasSize(1);
-        assertThat(res.items().get(0).miniChallengeId()).isEqualTo(2L);
-        assertThat(res.items().get(0).progressDays()).isEqualTo(2); // 7/9 시작 → 7/10 조회 = 2일차
-        assertThat(res.items().get(0).checked()).isFalse();
+        assertThat(res.items().getFirst().miniChallengeId()).isEqualTo(2L);
+        assertThat(res.items().getFirst().progressDays()).isEqualTo(2); // 7/9 시작 → 7/10 조회 = 2일차
+        assertThat(res.items().getFirst().checked()).isFalse();
     }
 
     @Test
@@ -317,21 +343,21 @@ class MiniChallengeServiceTest {
                         MiniChallengeDay.of(mine, TODAY.minusDays(1)),
                         MiniChallengeDay.of(mine, TODAY)));
 
-        DailyMiniChallengesResponse res = serviceAt(TODAY).getDaily(USER, null);
+        DailyMiniChallengesResponse res = service().getDaily(USER, null);
 
         assertThat(res.summary().checkedCount()).isEqualTo(1);
         assertThat(res.summary().totalCount()).isEqualTo(1);
         assertThat(res.summary().streakDays()).isEqualTo(2); // 7/9·7/10 전부 체크(=이 미니 하나), 7/8 미체크로 끊김
-        assertThat(res.items().get(0).progressDays()).isEqualTo(3);
-        assertThat(res.items().get(0).itemStreak()).isEqualTo(2);
-        assertThat(res.items().get(0).checked()).isTrue();
+        assertThat(res.items().getFirst().progressDays()).isEqualTo(3);
+        assertThat(res.items().getFirst().itemStreak()).isEqualTo(2);
+        assertThat(res.items().getFirst().checked()).isTrue();
     }
 
     @Test
     @DisplayName("미래 date 조회는 400(MINI_FUTURE_DATE)으로 차단한다 — 날짜 스트립이 미래로 못 가서 조회될 일이 없는 요청이다")
     void getDaily_rejectsFutureDate() {
         // 검증이 리포지토리 조회보다 앞이라 목 스터빙이 필요 없다 — 미래면 DB에 갈 일 없이 바로 400
-        assertThatThrownBy(() -> serviceAt(TODAY).getDaily(USER, TODAY.plusDays(1).toString())) // 내일(7/11)
+        assertThatThrownBy(() -> service().getDaily(USER, TODAY.plusDays(1).toString())) // 내일(7/11)
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", MiniChallengeErrorCode.MINI_FUTURE_DATE);
     }

--- a/src/test/java/Hampouch/server/domain/minichallenge/service/MiniChallengeServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/minichallenge/service/MiniChallengeServiceTest.java
@@ -126,7 +126,7 @@ class MiniChallengeServiceTest {
     }
 
     @Test
-    @DisplayName("recommendedId로 추가하면 카탈로그의 제목·기간을 복사해 시작일=오늘인 유저 소유 미니가 새로 만들어진다 — 참조가 아니라 값 복사(#19 배선)")
+    @DisplayName("recommendedId로 추가하면 카탈로그의 제목·기간을 복사해 시작일=오늘인 유저 소유 미니가 새로 만들어진다 — 참조가 아니라 값 복사다")
     void create_copiesFromCatalogByRecommendedId() {
         when(recommendedMiniChallengeRepository.findById(7L))
                 .thenReturn(Optional.of(RecommendedMiniChallenge.of("편의점 디저트 안 먹기", 7)));


### PR DESCRIPTION
## 📎연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) closes #[issue number]

- close: #19

## 📄 작업 내용 요약
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.

- **`MiniChallengeService.create()`의 `recommendedId` 분기를 스텁(무조건 404)에서 실제 배선으로 교체** (명세 §3)
  - 카탈로그(`recommended_mini_challenge`, #10)에서 `findById` 조회 — 없으면 404(`MINI_RECOMMENDED_NOT_FOUND`) 그대로, 있으면 `title`·`durationDays`를 **값 복사**해 시작일=오늘·종료일=시작+기간−1 스냅샷으로 유저 소유 미니를 새로 생성합니다.
  - FK 참조가 아니라 값 복사인 이유 — 카탈로그는 기획이 관리하는 공용 목록이라, 문구 수정·항목 삭제가 이미 시작한 유저 미니를 흔들면 안 됩니다(서비스 주석에 정리).
  - 커스텀 경로의 값 검증(비공백·길이·화이트리스트)은 이 분기에 걸지 않았습니다 — 카탈로그 값은 유저 입력이 아니라 서버가 시드로 관리하는 데이터라, 값이 이상하면 400이 아니라 시드 수정 사안입니다.
- **알람 역할을 못 하던 기존 테스트 갱신** — 이슈 노트의 경고대로, 배선을 잊어도 통과하던 `create_recommendedNotFoundUntilCatalogMerged`를 "카탈로그에서 복사 생성"과 "없는 id 404 거절" 2건으로 분리해 다시 썼습니다. 카탈로그 시드→POST→조회까지 실제 DB로 도는 통합 테스트 1건도 추가했습니다.
- **테스트 정리** — 서비스 테스트의 클록 헬퍼에서 항상 같은 값이던 매개변수를 제거하고(`service()`로 단순화), `get(0)`을 Java 21 `getFirst()`로 교체했습니다. 이 브랜치 전체 스위트 114개 통과.

## 👀 중요 변경 사항
> API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요

- PR #21 본문의 "추천으로 추가는 지금 어떤 id를 보내도 404" 안내가 이 PR로 해소됩니다 — 유효한 `recommendedId` POST가 201 + 복사 생성으로 동작합니다.
- **base가 `feat/9-mini-challenge`인 스택 PR입니다** — #21이 머지되면 자동으로 develop으로 재타게팅되고, 이 PR의 리뷰 범위는 배선 커밋 1개(3파일)뿐입니다. #9 본문은 PR #21에서 리뷰해 주세요.

## 🔖 Uncompleted Tasks
> 후속 작업 예정인 사항이 있다면 작성해주세요.

- 같은 추천 중복 추가 409(명세 ⚠️잠정)는 이 이슈 범위 밖 — 추천/커스텀 통일 구조로 "같은 추천에서 온 미니"를 식별할 수단(origin 컬럼)이 없어, 확정되면 식별 수단부터 재설계해야 합니다(질문 10).

## 📢 To Reviewers
> Reviewer가 주로 확인해주었으면 하는 부분을 적어주세요.

- **값 복사 vs FK 참조 판단이 이 PR의 핵심입니다** — 근거는 서비스 코드 주석에 정리했으니, 그 판단이 팀 감각과 맞는지 봐 주세요.
- 새 테스트 3개의 DisplayName만 읽어도 배선 동작 전체가 읽히도록 썼습니다.
