### PR TITLE
feat: 챌린지 연동용 일별 지출 합계 조회 메서드 구현(getDaySpending)

### DIFF
--- a/src/main/java/Hampouch/server/domain/challenge/dto/DaySpending.java
+++ b/src/main/java/Hampouch/server/domain/challenge/dto/DaySpending.java
@@ -1,0 +1,15 @@
+package Hampouch.server.domain.challenge.dto;
+
+/**
+ * Challenge 도메인이 일별 예산 초과 여부를 판단할 때 쓰는 조회 결과
+ * Challenge domain에서 그 날의 Challenge 성공 / 실패 여부 확인을 위한 DTO
+ * hasRecord: 그날 기록 자체가 없음과 기록의 합계가 0원을 구분
+ * 다만 현재 Expense 등록 API는 @Min(1), 현재는 @Min(0)으로 변경 예정이지만 향후 협의 필요
+ * hasRecord는 그 결정과 무관하게 "해당 날짜에 ACTIVE 행이 존재하는가"만
+ * 보므로, 나중에 0원 기록이 허용돼도 코드 변경 없이 정상 동작한다.
+ */
+public record DaySpending(
+        int totalAmount,
+        boolean hasRecord
+) {
+}

--- a/src/main/java/Hampouch/server/domain/expense/repository/ExpenseRepository.java
+++ b/src/main/java/Hampouch/server/domain/expense/repository/ExpenseRepository.java
@@ -3,6 +3,8 @@ package Hampouch.server.domain.expense.repository;
 import Hampouch.server.domain.expense.entity.Expense;
 import Hampouch.server.domain.expense.entity.ExpenseStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -24,4 +26,20 @@ public interface ExpenseRepository extends JpaRepository<Expense, Long> {
      * ChallengeDayRepository의 언더스코어 경로 컨벤션과 동일(User_Id = user 연관관계를 타고 들어간 id).
      */
     List<Expense> findByUser_IdAndExpenseDateAndStatus(Long userId, LocalDate expenseDate, ExpenseStatus status);
+
+    /**
+     * Spring Data 파생 쿼리는 SUM 같은 집계를 지원하지 않아
+     * sumPriceByUserIdAndExpenseDateAndStatus를 @Query로 직접 작성하고, coalesce로 감싸 그 날짜에
+     * 지출이 하나도 없을 때도 null 대신 0을 반환하게 한다.
+     */
+
+    @Query("select coalesce(sum(e.price), 0) from Expense e "
+            + "where e.user.id = :userId and e.expenseDate = :date and e.status = :status")
+    int sumPriceByUserIdAndExpenseDateAndStatus(@Param("userId") Long userId, @Param("date") LocalDate date, @Param("status") ExpenseStatus status);
+
+    /**
+     * ExpenseService.getDaySpending()에서 DaySpending.hasRecord를 채우는 용도 — 합계(sum)만으로는
+     * 그 날짜에 기록 자체가 없음과 그 날짜 기록의 합계가 0원임을 구분할 수 없어 별도 존재 확인 쿼리로 둔다.
+     */
+    boolean existsByUser_IdAndExpenseDateAndStatus(Long userId, LocalDate expenseDate, ExpenseStatus status);
 }

--- a/src/main/java/Hampouch/server/domain/expense/service/ExpenseService.java
+++ b/src/main/java/Hampouch/server/domain/expense/service/ExpenseService.java
@@ -5,6 +5,7 @@ import Hampouch.server.domain.challenge.repository.ChallengeRepository;
 import Hampouch.server.domain.expense.dto.ExpenseCreateRequest;
 import Hampouch.server.domain.expense.dto.ExpenseCreateResponse;
 import Hampouch.server.domain.expense.dto.ExpenseDayListResponse;
+import Hampouch.server.domain.challenge.dto.DaySpending;
 import Hampouch.server.domain.expense.dto.ExpenseDetailResponse;
 import Hampouch.server.domain.expense.entity.*;
 import Hampouch.server.domain.expense.repository.CustomCategoryRepository;
@@ -88,6 +89,16 @@ public class ExpenseService {
         return ExpenseDayListResponse.from(date, expenses);
     }
 
+    /**
+     * Challenge 도메인이 일별 예산 초과 여부를 판단할 때 호출
+     * 특정 유저의 특정 날짜 ACTIVE 지출 합계(원)와 그 날짜에 기록 자체가 있었는지를 반환
+     */
+    public DaySpending getDaySpending(Long userId, LocalDate date) {
+        int totalAmount = expenseRepository.sumPriceByUserIdAndExpenseDateAndStatus(userId, date, ExpenseStatus.ACTIVE);
+        boolean hasRecord = expenseRepository.existsByUser_IdAndExpenseDateAndStatus(userId, date, ExpenseStatus.ACTIVE);
+        return new DaySpending(totalAmount, hasRecord);
+    }
+
     /** GET/PUT/DELETE 공통 조회 진입점 — ChallengeService.loadOwned()와 동일한 이름/구조.
      *  ExpenseStatus = DELETED인 Expense의 경우 실제로는 table 상에 존재하지만 사용자에게는 삭제된 것으로 인식되도록
      *  CustomException 설정 X
@@ -105,6 +116,7 @@ public class ExpenseService {
      * 진행 중인 메인 챌린지 기간 검증.
      * 챌린지가 아예 없으면 검증 자체를 건너뛰고 통과시킨다.
      * 챌린지가 있을 때만 그 기간(startDate~endDate) 밖 날짜를 막는다.
+     * ChallengeService가 이 class의 getDaySpending를 사용하므로, 순환 의존성 방지를 위해 ChallengeRepository를 참조
      */
     private void validateWithinChallengePeriod(Long userId, LocalDate date) {
         challengeRepository.findByUserIdAndStatus(userId, ChallengeStatus.IN_PROGRESS)

--- a/src/test/java/Hampouch/server/domain/expense/service/ExpenseServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/expense/service/ExpenseServiceTest.java
@@ -6,6 +6,7 @@ import Hampouch.server.domain.challenge.repository.ChallengeRepository;
 import Hampouch.server.domain.expense.dto.ExpenseCreateRequest;
 import Hampouch.server.domain.expense.dto.ExpenseCreateResponse;
 import Hampouch.server.domain.expense.dto.ExpenseDayListResponse;
+import Hampouch.server.domain.challenge.dto.DaySpending;
 import Hampouch.server.domain.expense.dto.ExpenseDetailResponse;
 import Hampouch.server.domain.expense.entity.*;
 import Hampouch.server.domain.expense.repository.CustomCategoryRepository;
@@ -384,6 +385,32 @@ class ExpenseServiceTest {
 
         assertThat(res.expenses()).hasSize(2);
         assertThat(res.totalAmount()).isEqualTo(e1.getPrice() + e2.getPrice());
+    }
+
+    // ---------- getDaySpending ----------
+
+    @Test
+    @DisplayName("getDaySpending은 리포지토리의 합계·존재 여부를 그대로 DaySpending에 담아 반환한다")
+    void getDaySpending_buildsFromRepository() {
+        LocalDate date = LocalDate.of(2026, 6, 5);
+        when(expenseRepository.sumPriceByUserIdAndExpenseDateAndStatus(OWNER, date, ExpenseStatus.ACTIVE)).thenReturn(8000);
+        when(expenseRepository.existsByUser_IdAndExpenseDateAndStatus(OWNER, date, ExpenseStatus.ACTIVE)).thenReturn(true);
+
+        DaySpending result = service().getDaySpending(OWNER, date);
+
+        assertThat(result).isEqualTo(new DaySpending(8000, true));
+    }
+
+    @Test
+    @DisplayName("해당 날짜에 기록이 하나도 없으면 totalAmount=0, hasRecord=false로 구분된다")
+    void getDaySpending_returnsZeroAndNoRecordWhenNothingLogged() {
+        LocalDate date = LocalDate.of(2026, 6, 5);
+        when(expenseRepository.sumPriceByUserIdAndExpenseDateAndStatus(OWNER, date, ExpenseStatus.ACTIVE)).thenReturn(0);
+        when(expenseRepository.existsByUser_IdAndExpenseDateAndStatus(OWNER, date, ExpenseStatus.ACTIVE)).thenReturn(false);
+
+        DaySpending result = service().getDaySpending(OWNER, date);
+
+        assertThat(result).isEqualTo(new DaySpending(0, false));
     }
 
     // ---------- fixtures ----------


### PR DESCRIPTION
## 📎연관된 이슈
- close: #32

## 📄 작업 내용 요약
- Challenge 도메인이 일별 예산 초과 여부를 판단할 때 쓸 수 있도록 `ExpenseService.getDaySpending(userId, date)` 구현
- 반환 타입은 `DaySpending(totalAmount, hasRecord)` record — 해당 날짜 ACTIVE 지출 합계와, 그 날짜에 기록 자체가 있었는지 여부를 함께 전달
- `ExpenseRepository`에 합계 쿼리(`sumPriceByUserIdAndExpenseDateAndStatus`, `@Query` + `coalesce`로 무기록 시 0 반환)와 존재 확인 쿼리(`existsByUser_IdAndExpenseDateAndStatus`) 추가
- `ExpenseServiceTest`에 단위 테스트 추가 (정상 합산+기록 존재 케이스, 기록 없음 케이스)

## 👀 중요 변경 사항
- `DaySpending`은 Challenge 도메인이 소비하는 값이라 `Hampouch.server.domain.challenge.dto` 패키지에 뒀습니다.
- `hasRecord`는 "그 날짜에 ACTIVE 지출 행이 존재하는가"만 봅니다. 다만 현재 `ExpenseCreateRequest.price`가 `@Min(1)`이라 0원 지출 자체를 생성할 수 없어서, 지금 시점엔 `hasRecord`가 사실상 `totalAmount > 0`과 항상 같은 값입니다. "0원, 오늘 안 썼어요" 같은 명시적 무지출 기록을 지원하려면 이 검증을 완화하는 별도 논의가 필요합니다.
- `validateWithinChallengePeriod`는 여전히 `ChallengeRepository`를 직접 참조합니다(Service 아님) — Challenge가 `getDaySpending()`을 쓰게 되면서 `ExpenseService`가 `ChallengeService`까지 의존하면 양방향 의존이 생겨 순환 참조(`BeanCurrentlyInCreationException`) 위험이 있어 이를 피하기 위함입니다.

## 🔖 Uncompleted Tasks
- `hasRecord`와 `price` `@Min(1)`→`@Min(0)` 완화 여부는 아직 미정 — 팀 논의 필요
- Challenge 쪽에서 실제로 `getDaySpending()`을 호출하는 연동 로직은 이 PR 범위 밖(Challenge 도메인 작업)

## 📢 To Reviewers
- `DaySpending`을 Challenge 패키지에 둔 위치가 적절한지 확인 부탁드립니다.
- `getDaySpending()` 반환 타입/필드 네이밍이 요청하신 포맷과 맞는지 확인 부탁드립니다.