### PR TITLE
feat: 커스텀 태그 목록 조회 API 구현

### DIFF
--- a/src/main/java/Hampouch/server/domain/expense/controller/ExpenseController.java
+++ b/src/main/java/Hampouch/server/domain/expense/controller/ExpenseController.java
@@ -4,6 +4,7 @@ import Hampouch.server.domain.expense.dto.ExpenseCreateRequest;
 import Hampouch.server.domain.expense.dto.ExpenseCreateResponse;
 import Hampouch.server.domain.expense.dto.ExpenseDayListResponse;
 import Hampouch.server.domain.expense.dto.ExpenseDetailResponse;
+import Hampouch.server.domain.expense.dto.ExpenseSummaryResponse;
 import Hampouch.server.domain.expense.service.ExpenseService;
 import Hampouch.server.global.common.response.ApiResponse;
 import Hampouch.server.global.security.LoginUserId;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 import java.time.LocalDate;
+import java.time.YearMonth;
 
 /**
  * 지출 5개 우선순위 API(POST/GET/PUT/DELETE /expenses, GET /expenses/day).
@@ -83,5 +85,24 @@ public class ExpenseController {
             @LoginUserId Long userId,
             @RequestParam LocalDate date) {
         return ApiResponse.success(expenseService.getDayList(userId, date));
+    }
+
+    /**
+     * GET /api/expenses/summary/week — stDate(?stDate=2026-06-05)가 속한 주(일~토)의 합계·일별 내역(이슈 #36).
+     * getDayList()와 동일하게 화면 진입 자체가 날짜를 고르고 들어오는 흐름이라 stDate 생략 불가.
+     */
+    @GetMapping("/summary/week")
+    public ApiResponse<ExpenseSummaryResponse> getWeekSummary(
+            @LoginUserId Long userId,
+            @RequestParam LocalDate stDate) {
+        return ApiResponse.success(expenseService.getWeekSummary(userId, stDate));
+    }
+
+    /** GET /api/expenses/summary/month — stMonth(?stMonth=2026-06) 해당 월의 합계·일별 내역(이슈 #36). */
+    @GetMapping("/summary/month")
+    public ApiResponse<ExpenseSummaryResponse> getMonthSummary(
+            @LoginUserId Long userId,
+            @RequestParam YearMonth stMonth) {
+        return ApiResponse.success(expenseService.getMonthSummary(userId, stMonth));
     }
 }

--- a/src/main/java/Hampouch/server/domain/expense/controller/ExpenseController.java
+++ b/src/main/java/Hampouch/server/domain/expense/controller/ExpenseController.java
@@ -2,6 +2,7 @@ package Hampouch.server.domain.expense.controller;
 
 import Hampouch.server.domain.expense.dto.ExpenseCreateRequest;
 import Hampouch.server.domain.expense.dto.ExpenseCreateResponse;
+import Hampouch.server.domain.expense.dto.ExpenseCustomTagsResponse;
 import Hampouch.server.domain.expense.dto.ExpenseDayListResponse;
 import Hampouch.server.domain.expense.dto.ExpenseDetailResponse;
 import Hampouch.server.domain.expense.dto.ExpenseSummaryResponse;
@@ -104,5 +105,15 @@ public class ExpenseController {
             @LoginUserId Long userId,
             @RequestParam YearMonth stMonth) {
         return ApiResponse.success(expenseService.getMonthSummary(userId, stMonth));
+    }
+
+    /**
+     * GET /api/expenses/custom-tags — 유저가 등록한 커스텀 카테고리/감정 태그 목록
+     * 직접 입력을 통해 추가한 커스텀 태그만 내려준다.
+     * 등록한 태그가 하나도 없어도 에러가 아니라 200 + 빈 배열로 응답한다.
+     */
+    @GetMapping("/custom-tags")
+    public ApiResponse<ExpenseCustomTagsResponse> getCustomTags(@LoginUserId Long userId) {
+        return ApiResponse.success(expenseService.getCustomTags(userId));
     }
 }

--- a/src/main/java/Hampouch/server/domain/expense/controller/ExpenseController.java
+++ b/src/main/java/Hampouch/server/domain/expense/controller/ExpenseController.java
@@ -6,6 +6,7 @@ import Hampouch.server.domain.expense.dto.ExpenseDayListResponse;
 import Hampouch.server.domain.expense.dto.ExpenseDetailResponse;
 import Hampouch.server.domain.expense.service.ExpenseService;
 import Hampouch.server.global.common.response.ApiResponse;
+import Hampouch.server.global.security.LoginUserId;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,9 +17,8 @@ import java.time.LocalDate;
 
 /**
  * 지출 5개 우선순위 API(POST/GET/PUT/DELETE /expenses, GET /expenses/day).
- *
- * TODO(로그인 연동): 유저 식별은 ChallengeController와 동일하게 연동 전까지 X-User-Id 헤더 스텁(기본 1) —
- * 연동 시 JWT sub 클레임(@AuthenticationPrincipal)으로 교체.
+ * 유저 식별은 @LoginUserId(SecurityContext의 인증된 principal, JwtFilter가 채워둠)로 주입받는다
+ * AuthController.logout()/deleteMe()와 동일 패턴
  */
 @RestController
 @RequestMapping(ExpenseController.BASE_PATH)
@@ -28,14 +28,12 @@ public class ExpenseController {
     /** 클래스 매핑과 Location 헤더 조립이 공유하는 기본 경로. */
     static final String BASE_PATH = "/api/expenses";
 
-    private static final String USER_HEADER = "X-User-Id";
-
     private final ExpenseService expenseService;
 
     /** POST /api/expenses — 201 + Location 헤더(ChallengeController.create()와 동일 컨벤션). */
     @PostMapping
     public ResponseEntity<ApiResponse<ExpenseCreateResponse>> create(
-            @RequestHeader(value = USER_HEADER, required = false, defaultValue = "1") Long userId,
+            @LoginUserId Long userId,
             @Valid @RequestBody ExpenseCreateRequest request) {
         ExpenseCreateResponse res = expenseService.create(userId, request);
         return ResponseEntity
@@ -46,7 +44,7 @@ public class ExpenseController {
     /** GET /api/expenses/{expenseId} — 상세 조회. */
     @GetMapping("/{expenseId}")
     public ApiResponse<ExpenseDetailResponse> getDetail(
-            @RequestHeader(value = USER_HEADER, required = false, defaultValue = "1") Long userId,
+            @LoginUserId Long userId,
             @PathVariable Long expenseId) {
         return ApiResponse.success(expenseService.getDetail(userId, expenseId));
     }
@@ -57,7 +55,7 @@ public class ExpenseController {
      */
     @PutMapping("/{expenseId}")
     public ApiResponse<ExpenseCreateResponse> update(
-            @RequestHeader(value = USER_HEADER, required = false, defaultValue = "1") Long userId,
+            @LoginUserId Long userId,
             @PathVariable Long expenseId,
             @Valid @RequestBody ExpenseCreateRequest request) {
         return ApiResponse.success(expenseService.update(userId, expenseId, request));
@@ -69,7 +67,7 @@ public class ExpenseController {
      */
     @DeleteMapping("/{expenseId}")
     public ResponseEntity<ApiResponse<Void>> delete(
-            @RequestHeader(value = USER_HEADER, required = false, defaultValue = "1") Long userId,
+            @LoginUserId Long userId,
             @PathVariable Long expenseId) {
         expenseService.delete(userId, expenseId);
         return ResponseEntity.ok(ApiResponse.success("지출 내역이 삭제되었습니다.", null));
@@ -82,7 +80,7 @@ public class ExpenseController {
      */
     @GetMapping("/day")
     public ApiResponse<ExpenseDayListResponse> getDayList(
-            @RequestHeader(value = USER_HEADER, required = false, defaultValue = "1") Long userId,
+            @LoginUserId Long userId,
             @RequestParam LocalDate date) {
         return ApiResponse.success(expenseService.getDayList(userId, date));
     }

--- a/src/main/java/Hampouch/server/domain/expense/dto/ExpenseCustomTagsResponse.java
+++ b/src/main/java/Hampouch/server/domain/expense/dto/ExpenseCustomTagsResponse.java
@@ -1,0 +1,34 @@
+package Hampouch.server.domain.expense.dto;
+
+import Hampouch.server.domain.expense.entity.CustomCategory;
+import Hampouch.server.domain.expense.entity.CustomEmotion;
+
+import java.util.List;
+
+/**
+ * GET /expenses/custom-tags 응답
+ * 고정 enum(ExpenseCategory/ExpenseEmotion) 값은 front에서 보유 중이라는 가정, 이 응답은 유저가 직접
+ * 등록한 커스텀 카테고리/감정 태그만 책임진다. 태그가 하나도 없어도 에러가 아니라 빈 배열로 정상 응답
+ */
+public record ExpenseCustomTagsResponse(
+        List<Tag> emotions,
+        List<Tag> categories
+) {
+
+    /** id를 함께 내려주는 이유: 추후 커스텀 태그 수정/삭제 API가 생기면 프론트가 이 id로 대상을 지정해야 하기 때문. */
+    public record Tag(Long id, String name) {
+        private static Tag from(CustomEmotion emotion) {
+            return new Tag(emotion.getId(), emotion.getName());
+        }
+
+        private static Tag from(CustomCategory category) {
+            return new Tag(category.getId(), category.getName());
+        }
+    }
+
+    public static ExpenseCustomTagsResponse of(List<CustomEmotion> emotions, List<CustomCategory> categories) {
+        return new ExpenseCustomTagsResponse(
+                emotions.stream().map(Tag::from).toList(),
+                categories.stream().map(Tag::from).toList());
+    }
+}

--- a/src/main/java/Hampouch/server/domain/expense/dto/ExpenseSummaryResponse.java
+++ b/src/main/java/Hampouch/server/domain/expense/dto/ExpenseSummaryResponse.java
@@ -1,0 +1,49 @@
+package Hampouch.server.domain.expense.dto;
+
+import Hampouch.server.domain.expense.repository.ExpenseDailyTotal;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+/**
+ * GET /expenses/summary/week, /expenses/summary/month 공용 응답
+ */
+public record ExpenseSummaryResponse(
+        LocalDate periodStart,
+        LocalDate periodEnd,
+        int totalAmount,
+        int dailyAverage,
+        List<DailyAmount> dailyBreakdown
+) {
+
+    /** 지출이 있던 날짜만 담기는 한 줄 — sumGroupedByDate()가 이미 GROUP BY로 지출 없는 날짜를 뺀 채로 넘겨준다. */
+    public record DailyAmount(LocalDate date, int totalAmount) {
+        private static DailyAmount from(ExpenseDailyTotal daily) {
+            return new DailyAmount(daily.date(), Math.toIntExact(daily.totalAmount()));
+        }
+    }
+
+    /**
+     * dailyAverage = totalAmount / (경과일수) - 오늘까지 경과한 일수 기준 -> 미래는 어차피 0원이므로
+     * - today가 periodEnd 이후일 경우 경과일수 = 기간 전체 일수, 아니라면 경과일수 계산 필요
+     * - 아직 시작 안 한 미래 기간이면 totalAmount가 항상 0 - 앱에서는 미래시점 조회를 가급적 하지 않겠지만 로직상의 방어
+     */
+    public static ExpenseSummaryResponse of(LocalDate periodStart, LocalDate periodEnd,
+                                             List<ExpenseDailyTotal> dailyTotals, LocalDate today) {
+        int totalAmount = dailyTotals
+                .stream()
+                .mapToInt(daily -> Math.toIntExact(daily.totalAmount()))
+                .sum();
+
+        int dailyAverage = 0;
+        if (totalAmount > 0) {
+            LocalDate elapsedUntil = today.isBefore(periodEnd) ? today : periodEnd;
+            long elapsedDays = ChronoUnit.DAYS.between(periodStart, elapsedUntil) + 1;
+            dailyAverage = (int) (totalAmount / elapsedDays);
+        }
+
+        List<DailyAmount> dailyBreakdown = dailyTotals.stream().map(DailyAmount::from).toList();
+        return new ExpenseSummaryResponse(periodStart, periodEnd, totalAmount, dailyAverage, dailyBreakdown);
+    }
+}

--- a/src/main/java/Hampouch/server/domain/expense/repository/CustomCategoryRepository.java
+++ b/src/main/java/Hampouch/server/domain/expense/repository/CustomCategoryRepository.java
@@ -3,6 +3,7 @@ package Hampouch.server.domain.expense.repository;
 import Hampouch.server.domain.expense.entity.CustomCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -12,4 +13,7 @@ import java.util.Optional;
 public interface CustomCategoryRepository extends JpaRepository<CustomCategory, Long> {
 
     Optional<CustomCategory> findByUser_IdAndName(Long userId, String name);
+
+    /** GET /expenses/custom-tags — 유저가 등록한 커스텀 카테고리 태그 전체를 등록(생성) 순서로 조회 */
+    List<CustomCategory> findAllByUser_IdOrderByCreatedAtAsc(Long userId);
 }

--- a/src/main/java/Hampouch/server/domain/expense/repository/CustomEmotionRepository.java
+++ b/src/main/java/Hampouch/server/domain/expense/repository/CustomEmotionRepository.java
@@ -3,10 +3,14 @@ package Hampouch.server.domain.expense.repository;
 import Hampouch.server.domain.expense.entity.CustomEmotion;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 /** CustomCategoryRepository와 동일한 find-or-create 진입점. */
 public interface CustomEmotionRepository extends JpaRepository<CustomEmotion, Long> {
 
     Optional<CustomEmotion> findByUser_IdAndName(Long userId, String name);
+
+    /** GET /expenses/custom-tags — 유저가 등록한 커스텀 감정 태그 전체를 등록(생성) 순서로 조회 */
+    List<CustomEmotion> findAllByUser_IdOrderByCreatedAtAsc(Long userId);
 }

--- a/src/main/java/Hampouch/server/domain/expense/repository/ExpenseDailyTotal.java
+++ b/src/main/java/Hampouch/server/domain/expense/repository/ExpenseDailyTotal.java
@@ -1,0 +1,10 @@
+package Hampouch.server.domain.expense.repository;
+
+import java.time.LocalDate;
+
+/**
+ * ExpenseRepository.sumGroupedByDate() 전용 JPQL 생성자 표현식 DTO
+ * SUM(e.price)는 JPQL에서 Long으로 집계되므로 필드 타입도 long으로 설정
+ */
+public record ExpenseDailyTotal(LocalDate date, long totalAmount) {
+}

--- a/src/main/java/Hampouch/server/domain/expense/repository/ExpenseRepository.java
+++ b/src/main/java/Hampouch/server/domain/expense/repository/ExpenseRepository.java
@@ -3,6 +3,8 @@ package Hampouch.server.domain.expense.repository;
 import Hampouch.server.domain.expense.entity.Expense;
 import Hampouch.server.domain.expense.entity.ExpenseStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -24,4 +26,18 @@ public interface ExpenseRepository extends JpaRepository<Expense, Long> {
      * ChallengeDayRepository의 언더스코어 경로 컨벤션과 동일(User_Id = user 연관관계를 타고 들어간 id).
      */
     List<Expense> findByUser_IdAndExpenseDateAndStatus(Long userId, LocalDate expenseDate, ExpenseStatus status);
+
+    /**
+     * GET /expenses/summary/week, /summary/month 공용 — 기간 내 유저의 ACTIVE 지출을 날짜별로 SUM해서 가져온다.
+     * 건수가 하루 단위(findByUser_IdAndExpenseDateAndStatus)보다 커질 수 있어 SUM을 DB에 위임
+     */
+    @Query("""
+            SELECT new Hampouch.server.domain.expense.repository.ExpenseDailyTotal(e.expenseDate, SUM(e.price))
+            FROM Expense e
+            WHERE e.user.id = :userId AND e.status = :status AND e.expenseDate BETWEEN :start AND :end
+            GROUP BY e.expenseDate
+            ORDER BY e.expenseDate
+            """)
+    List<ExpenseDailyTotal> sumGroupedByDate(@Param("userId") Long userId, @Param("status") ExpenseStatus status,
+                                              @Param("start") LocalDate start, @Param("end") LocalDate end);
 }

--- a/src/main/java/Hampouch/server/domain/expense/service/ExpenseService.java
+++ b/src/main/java/Hampouch/server/domain/expense/service/ExpenseService.java
@@ -19,6 +19,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -35,6 +36,9 @@ public class ExpenseService {
     private final CustomEmotionRepository customEmotionRepository;
     private final ChallengeRepository challengeRepository;
     private final UserRepository userRepository;
+    private final Clock clock; //validateWithinChallengePeriod()가 챌린지가 없을 때 오늘 / 어제 날짜를 확인하기 위한 기준
+    // 한국 시간 기준으로 통일 된 Bean 활용
+
 
     /**
      * POST /expenses.
@@ -103,16 +107,25 @@ public class ExpenseService {
 
     /**
      * 진행 중인 메인 챌린지 기간 검증.
-     * 챌린지가 아예 없으면 검증 자체를 건너뛰고 통과시킨다.
-     * 챌린지가 있을 때만 그 기간(startDate~endDate) 밖 날짜를 막는다.
+     * 챌린지가 있으면 그 기간(startDate~endDate) 밖 날짜를 막는다.
+     * 챌린지가 아예 없으면 오늘/어제 날짜만 허용한다
+     * 제한을 아예 두지 않으면 챌린지 휴식기에 모든 날짜의 지출을 입력할 수 있게 되어
+     * 데이터 비일관성이 발생할 수 있다
      */
     private void validateWithinChallengePeriod(Long userId, LocalDate date) {
-        challengeRepository.findByUserIdAndStatus(userId, ChallengeStatus.IN_PROGRESS)
-                .ifPresent(challenge -> {
+        challengeRepository.findByUserIdAndStatus(userId, ChallengeStatus.IN_PROGRESS).ifPresentOrElse(
+                challenge -> {
                     if (date.isBefore(challenge.getStartDate()) || date.isAfter(challenge.getEndDate())) {
                         throw new CustomException(ExpenseErrorCode.EXPENSE_DATE_OUT_OF_CHALLENGE_PERIOD);
                     }
-                });
+                },
+                () -> {
+                    LocalDate today = LocalDate.now(clock);
+                    if (!date.equals(today) && !date.equals(today.minusDays(1))) {
+                        throw new CustomException(ExpenseErrorCode.EXPENSE_DATE_OUT_OF_RECENT_RANGE);
+                    }
+                }
+        );
     }
 
     /**

--- a/src/main/java/Hampouch/server/domain/expense/service/ExpenseService.java
+++ b/src/main/java/Hampouch/server/domain/expense/service/ExpenseService.java
@@ -4,6 +4,7 @@ import Hampouch.server.domain.challenge.entity.ChallengeStatus;
 import Hampouch.server.domain.challenge.repository.ChallengeRepository;
 import Hampouch.server.domain.expense.dto.ExpenseCreateRequest;
 import Hampouch.server.domain.expense.dto.ExpenseCreateResponse;
+import Hampouch.server.domain.expense.dto.ExpenseCustomTagsResponse;
 import Hampouch.server.domain.expense.dto.ExpenseDayListResponse;
 import Hampouch.server.domain.expense.dto.ExpenseDetailResponse;
 import Hampouch.server.domain.expense.dto.ExpenseSummaryResponse;
@@ -26,12 +27,9 @@ import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
 
-/**
- * 지출 5개 우선순위 API(POST/GET/PUT/DELETE /expenses, GET /expenses/day)의 서비스 계층.
- */
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true) // 기본은 읽기 전용 — 쓰기 메서드만 개별적으로 @Transactional로 덮어씀(ChallengeService와 동일 컨벤션)
+@Transactional(readOnly = true) // 기본은 읽기 전용 — 쓰기 메서드만 개별적으로 @Transactional로 덮어씀
 public class ExpenseService {
 
     private final ExpenseRepository expenseRepository;
@@ -67,9 +65,9 @@ public class ExpenseService {
     }
 
     /**
-     * PUT /expenses/{expenseId}. ExpenseCreateRequest/Response를 그대로 재사용(두 DTO의 자체 Javadoc 참조).
-     * attachCustomTags를 매번 다시 호출하는 이유는 Expense.update() Javadoc과 동일 — category/emotion이 ETC에서
-     * 다른 값으로(또는 그 반대로) 바뀌었을 수 있어 customCategory/customEmotion을 매번 새 상태 기준으로 재확정해야 함.
+     * PUT /expenses/{expenseId}. ExpenseCreateRequest/Response를 그대로 재사용
+     * attachCustomTags를 매번 다시 호출하는 이유: category/emotion이 ETC에서 다른 값으로(또는 그 반대로)
+     * 바뀌었을 수 있어 customCategory/customEmotion을 매번 새 상태 기준으로 재확정해야 함.
      */
     @Transactional
     public ExpenseCreateResponse update(Long userId, Long expenseId, ExpenseCreateRequest request) {
@@ -95,7 +93,14 @@ public class ExpenseService {
         return ExpenseDayListResponse.from(date, expenses);
     }
 
-    /** GET /expenses/summary/week — stDate가 속한 주(일~토)의 합계·일별 내역(이슈 #36). */
+    /** GET /expenses/custom-tags — 유저가 등록한 커스텀 카테고리/감정 태그 목록(이슈 #37). 없어도 빈 배열로 정상 응답. */
+    public ExpenseCustomTagsResponse getCustomTags(Long userId) {
+        List<CustomEmotion> emotions = customEmotionRepository.findAllByUser_IdOrderByCreatedAtAsc(userId);
+        List<CustomCategory> categories = customCategoryRepository.findAllByUser_IdOrderByCreatedAtAsc(userId);
+        return ExpenseCustomTagsResponse.of(emotions, categories);
+    }
+
+    /** GET /expenses/summary/week — stDate가 속한 주(일~토)의 합계·일별 내역 */
     public ExpenseSummaryResponse getWeekSummary(Long userId, LocalDate stDate) {
         int daysSinceSunday = stDate.getDayOfWeek().getValue() % 7; // MONDAY=1..SATURDAY=6, SUNDAY=7→0
         LocalDate periodStart = stDate.minusDays(daysSinceSunday);
@@ -103,7 +108,7 @@ public class ExpenseService {
         return buildSummary(userId, periodStart, periodEnd);
     }
 
-    /** GET /expenses/summary/month — stMonth 해당 월의 합계·일별 내역(이슈 #36). */
+    /** GET /expenses/summary/month — stMonth 해당 월의 합계·일별 내역 */
     public ExpenseSummaryResponse getMonthSummary(Long userId, YearMonth stMonth) {
         LocalDate periodStart = stMonth.atDay(1);
         LocalDate periodEnd = stMonth.atEndOfMonth();

--- a/src/main/java/Hampouch/server/domain/expense/service/ExpenseService.java
+++ b/src/main/java/Hampouch/server/domain/expense/service/ExpenseService.java
@@ -6,9 +6,11 @@ import Hampouch.server.domain.expense.dto.ExpenseCreateRequest;
 import Hampouch.server.domain.expense.dto.ExpenseCreateResponse;
 import Hampouch.server.domain.expense.dto.ExpenseDayListResponse;
 import Hampouch.server.domain.expense.dto.ExpenseDetailResponse;
+import Hampouch.server.domain.expense.dto.ExpenseSummaryResponse;
 import Hampouch.server.domain.expense.entity.*;
 import Hampouch.server.domain.expense.repository.CustomCategoryRepository;
 import Hampouch.server.domain.expense.repository.CustomEmotionRepository;
+import Hampouch.server.domain.expense.repository.ExpenseDailyTotal;
 import Hampouch.server.domain.expense.repository.ExpenseRepository;
 import Hampouch.server.domain.user.entity.User;
 import Hampouch.server.domain.user.repository.UserRepository;
@@ -21,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.List;
 
 /**
@@ -90,6 +93,28 @@ public class ExpenseService {
     public ExpenseDayListResponse getDayList(Long userId, LocalDate date) {
         List<Expense> expenses = expenseRepository.findByUser_IdAndExpenseDateAndStatus(userId, date, ExpenseStatus.ACTIVE);
         return ExpenseDayListResponse.from(date, expenses);
+    }
+
+    /** GET /expenses/summary/week — stDate가 속한 주(일~토)의 합계·일별 내역(이슈 #36). */
+    public ExpenseSummaryResponse getWeekSummary(Long userId, LocalDate stDate) {
+        int daysSinceSunday = stDate.getDayOfWeek().getValue() % 7; // MONDAY=1..SATURDAY=6, SUNDAY=7→0
+        LocalDate periodStart = stDate.minusDays(daysSinceSunday);
+        LocalDate periodEnd = periodStart.plusDays(6);
+        return buildSummary(userId, periodStart, periodEnd);
+    }
+
+    /** GET /expenses/summary/month — stMonth 해당 월의 합계·일별 내역(이슈 #36). */
+    public ExpenseSummaryResponse getMonthSummary(Long userId, YearMonth stMonth) {
+        LocalDate periodStart = stMonth.atDay(1);
+        LocalDate periodEnd = stMonth.atEndOfMonth();
+        return buildSummary(userId, periodStart, periodEnd);
+    }
+
+    /** week/month 공용 조립 — 날짜별 합계 조회 후 DTO에 위임(오늘 날짜는 dailyAverage의 경과일수 계산에 필요). */
+    private ExpenseSummaryResponse buildSummary(Long userId, LocalDate periodStart, LocalDate periodEnd) {
+        List<ExpenseDailyTotal> dailyTotals = expenseRepository.sumGroupedByDate(
+                userId, ExpenseStatus.ACTIVE, periodStart, periodEnd);
+        return ExpenseSummaryResponse.of(periodStart, periodEnd, dailyTotals, LocalDate.now(clock));
     }
 
     /** GET/PUT/DELETE 공통 조회 진입점 — ChallengeService.loadOwned()와 동일한 이름/구조.

--- a/src/main/java/Hampouch/server/global/common/exception/domain/ExpenseErrorCode.java
+++ b/src/main/java/Hampouch/server/global/common/exception/domain/ExpenseErrorCode.java
@@ -20,6 +20,8 @@ public enum ExpenseErrorCode implements BaseErrorCode {
 
     EXPENSE_DATE_OUT_OF_CHALLENGE_PERIOD(HttpStatus.BAD_REQUEST, "EXPENSE_DATE_OUT_OF_CHALLENGE_PERIOD", "진행 중인 메인 챌린지 기간 내에서만 지출 입력이 가능합니다."),
 
+    EXPENSE_DATE_OUT_OF_RECENT_RANGE(HttpStatus.BAD_REQUEST, "EXPENSE_DATE_OUT_OF_RECENT_RANGE", "진행 중인 챌린지가 없는 경우 오늘 또는 어제 날짜만 입력할 수 있습니다."),
+
     EXPENSE_CUSTOM_CATEGORY_NAME_DUPLICATED(HttpStatus.CONFLICT, "EXPENSE_CUSTOM_CATEGORY_NAME_DUPLICATED", "카테고리를 직접 입력한 경우 기존 카테고리와 명칭이 달라야 합니다."),
 
     EXPENSE_CUSTOM_EMOTION_NAME_DUPLICATED(HttpStatus.CONFLICT, "EXPENSE_CUSTOM_EMOTION_NAME_DUPLICATED", "이유를 직접 입력한 경우 기존 제시된 이유와 달라야 합니다.");

--- a/src/test/java/Hampouch/server/domain/expense/controller/ExpenseControllerTest.java
+++ b/src/test/java/Hampouch/server/domain/expense/controller/ExpenseControllerTest.java
@@ -1,6 +1,7 @@
 package Hampouch.server.domain.expense.controller;
 
 import Hampouch.server.domain.expense.dto.ExpenseCreateResponse;
+import Hampouch.server.domain.expense.dto.ExpenseCustomTagsResponse;
 import Hampouch.server.domain.expense.dto.ExpenseDayListResponse;
 import Hampouch.server.domain.expense.dto.ExpenseDetailResponse;
 import Hampouch.server.domain.expense.dto.ExpenseSummaryResponse;
@@ -264,5 +265,34 @@ class ExpenseControllerTest {
                 .andExpect(jsonPath("$.data.periodEnd").value("2026-06-30"))
                 .andExpect(jsonPath("$.data.totalAmount").value(60000))
                 .andExpect(jsonPath("$.data.dailyAverage").value(2000));
+    }
+
+    @Test
+    @DisplayName("커스텀 태그 목록 조회가 정상이면 200과 emotions/categories를 함께 돌려준다")
+    void getCustomTags_200() throws Exception {
+        when(service.getCustomTags(anyLong())).thenReturn(new ExpenseCustomTagsResponse(
+                List.of(new ExpenseCustomTagsResponse.Tag(12L, "번아웃"), new ExpenseCustomTagsResponse.Tag(15L, "루틴")),
+                List.of(new ExpenseCustomTagsResponse.Tag(45L, "자판기"))));
+
+        mvc.perform(get("/api/expenses/custom-tags"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.emotions[0].id").value(12))
+                .andExpect(jsonPath("$.data.emotions[0].name").value("번아웃"))
+                .andExpect(jsonPath("$.data.emotions[1].name").value("루틴"))
+                .andExpect(jsonPath("$.data.categories[0].id").value(45))
+                .andExpect(jsonPath("$.data.categories[0].name").value("자판기"));
+    }
+
+    @Test
+    @DisplayName("등록한 커스텀 태그가 없으면 200과 emotions/categories 빈 배열을 돌려준다")
+    void getCustomTags_200_whenNoTagsRegistered() throws Exception {
+        when(service.getCustomTags(anyLong())).thenReturn(new ExpenseCustomTagsResponse(List.of(), List.of()));
+
+        mvc.perform(get("/api/expenses/custom-tags"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.emotions").isArray())
+                .andExpect(jsonPath("$.data.emotions").isEmpty())
+                .andExpect(jsonPath("$.data.categories").isArray())
+                .andExpect(jsonPath("$.data.categories").isEmpty());
     }
 }

--- a/src/test/java/Hampouch/server/domain/expense/controller/ExpenseControllerTest.java
+++ b/src/test/java/Hampouch/server/domain/expense/controller/ExpenseControllerTest.java
@@ -3,6 +3,7 @@ package Hampouch.server.domain.expense.controller;
 import Hampouch.server.domain.expense.dto.ExpenseCreateResponse;
 import Hampouch.server.domain.expense.dto.ExpenseDayListResponse;
 import Hampouch.server.domain.expense.dto.ExpenseDetailResponse;
+import Hampouch.server.domain.expense.dto.ExpenseSummaryResponse;
 import Hampouch.server.domain.expense.entity.ExpenseCategory;
 import Hampouch.server.domain.expense.entity.ExpenseEmotion;
 import Hampouch.server.domain.expense.service.ExpenseService;
@@ -25,6 +26,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import Hampouch.server.global.jwt.JwtProvider;
 
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -231,5 +233,37 @@ class ExpenseControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.date").value("2026-06-05"))
                 .andExpect(jsonPath("$.data.totalAmount").value(5000));
+    }
+
+    @Test
+    @DisplayName("주간 요약 조회가 정상이면 200과 기간·합계·일별 내역을 돌려준다")
+    void getWeekSummary_200() throws Exception {
+        when(service.getWeekSummary(anyLong(), any())).thenReturn(new ExpenseSummaryResponse(
+                LocalDate.of(2026, 6, 7), LocalDate.of(2026, 6, 13), 30000, 4285,
+                List.of(new ExpenseSummaryResponse.DailyAmount(LocalDate.of(2026, 6, 8), 10000))));
+
+        mvc.perform(get("/api/expenses/summary/week").param("stDate", "2026-06-10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.periodStart").value("2026-06-07"))
+                .andExpect(jsonPath("$.data.periodEnd").value("2026-06-13"))
+                .andExpect(jsonPath("$.data.totalAmount").value(30000))
+                .andExpect(jsonPath("$.data.dailyAverage").value(4285))
+                .andExpect(jsonPath("$.data.dailyBreakdown[0].date").value("2026-06-08"))
+                .andExpect(jsonPath("$.data.dailyBreakdown[0].totalAmount").value(10000));
+    }
+
+    @Test
+    @DisplayName("월간 요약 조회가 정상이면 200과 기간·합계·일별 내역을 돌려준다")
+    void getMonthSummary_200() throws Exception {
+        when(service.getMonthSummary(anyLong(), any())).thenReturn(new ExpenseSummaryResponse(
+                LocalDate.of(2026, 6, 1), LocalDate.of(2026, 6, 30), 60000, 2000,
+                List.of(new ExpenseSummaryResponse.DailyAmount(LocalDate.of(2026, 6, 15), 60000))));
+
+        mvc.perform(get("/api/expenses/summary/month").param("stMonth", "2026-06"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.periodStart").value("2026-06-01"))
+                .andExpect(jsonPath("$.data.periodEnd").value("2026-06-30"))
+                .andExpect(jsonPath("$.data.totalAmount").value(60000))
+                .andExpect(jsonPath("$.data.dailyAverage").value(2000));
     }
 }

--- a/src/test/java/Hampouch/server/domain/expense/controller/ExpenseControllerTest.java
+++ b/src/test/java/Hampouch/server/domain/expense/controller/ExpenseControllerTest.java
@@ -14,6 +14,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.MediaType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import Hampouch.server.global.jwt.JwtProvider;
@@ -41,7 +47,27 @@ class ExpenseControllerTest {
     ExpenseService service;
 
     @MockitoBean
-    JwtProvider jwtProvider; //임시 추가
+    JwtProvider jwtProvider; // SecurityConfig가 요구하는 빈 — addFilters=false라 실제 토큰 검증엔 안 쓰임
+
+    private static final Long OWNER = 1L;
+
+    /**
+     * @LoginUserId가 읽어갈 인증 정보를 테스트 스레드의 SecurityContextHolder에 직접 심는다.
+     * addFilters=false라 SecurityContextPersistenceFilter류가 아예 안 돌기 때문에,
+     * .with(authentication(...))처럼 세션에 저장하고 필터가 복원해주길 기대하는 방식은 동작하지 않는다.
+     */
+    @BeforeEach
+    void setUpSecurityContext() {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(new UsernamePasswordAuthenticationToken(
+                OWNER, null, List.of(new SimpleGrantedAuthority("ROLE_USER"))));
+        SecurityContextHolder.setContext(context);
+    }
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
 
     @Test
     @DisplayName("생성 요청이 정상이면 201 Created와 Location 헤더, 생성 결과 본문을 돌려준다")
@@ -53,7 +79,8 @@ class ExpenseControllerTest {
                         .content("""
                                 { "name": "스타벅스", "price": 5000, "category": "CAFE", "emotion": "STRESS",
                                   "date": "2026-06-05" }
-                                """))
+                                """)
+                        )
                 .andExpect(status().isCreated())
                 .andExpect(header().string("Location", "/api/expenses/1"))
                 .andExpect(jsonPath("$.code").value("SUCCESS"))
@@ -68,7 +95,8 @@ class ExpenseControllerTest {
                         .content("""
                                 { "name": "스타벅스", "price": 0, "category": "CAFE", "emotion": "STRESS",
                                   "date": "2026-06-05" }
-                                """))
+                                """)
+                        )
                 .andExpect(status().isBadRequest());
     }
 
@@ -80,7 +108,8 @@ class ExpenseControllerTest {
                         .content("""
                                 { "name": "스터디카페 이용권", "price": 8000, "category": "ETC", "emotion": "STRESS",
                                   "date": "2026-06-05" }
-                                """))
+                                """)
+                        )
                 .andExpect(status().isBadRequest());
     }
 
@@ -92,7 +121,8 @@ class ExpenseControllerTest {
                         .content("""
                                 { "name": "스타벅스", "price": 5000, "category": "CAFE", "emotion": "STRESS",
                                   "date": "2099-01-01" }
-                                """))
+                                """)
+                        )
                 .andExpect(status().isBadRequest());
     }
 
@@ -107,7 +137,8 @@ class ExpenseControllerTest {
                         .content("""
                                 { "name": "아이스아메리카노", "price": 4500, "category": "ETC", "customCategory": "카페",
                                   "emotion": "STRESS", "date": "2026-06-05" }
-                                """))
+                                """)
+                        )
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.code").value("EXPENSE_CUSTOM_CATEGORY_NAME_DUPLICATED"))
                 .andExpect(jsonPath("$.status").value(409));
@@ -124,7 +155,8 @@ class ExpenseControllerTest {
                         .content("""
                                 { "name": "스타벅스", "price": 5000, "category": "CAFE",
                                   "emotion": "ETC", "customEmotion": "스트레스", "date": "2026-06-05" }
-                                """))
+                                """)
+                        )
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.code").value("EXPENSE_CUSTOM_EMOTION_NAME_DUPLICATED"))
                 .andExpect(jsonPath("$.status").value(409));
@@ -174,7 +206,8 @@ class ExpenseControllerTest {
                         .content("""
                                 { "name": "스타벅스", "price": 6000, "category": "CAFE", "emotion": "STRESS",
                                   "date": "2026-06-05" }
-                                """))
+                                """)
+                        )
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.expenseId").value(1));
     }

--- a/src/test/java/Hampouch/server/domain/expense/controller/ExpenseControllerTest.java
+++ b/src/test/java/Hampouch/server/domain/expense/controller/ExpenseControllerTest.java
@@ -26,7 +26,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import Hampouch.server.global.jwt.JwtProvider;
 
 import java.time.LocalDate;
-import java.time.YearMonth;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;

--- a/src/test/java/Hampouch/server/domain/expense/repository/ExpenseRepositoryTest.java
+++ b/src/test/java/Hampouch/server/domain/expense/repository/ExpenseRepositoryTest.java
@@ -18,6 +18,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
 
 /**
  * ExpenseRepository/CustomCategoryRepository/CustomEmotionRepository 파생 쿼리 + 유니크 제약을
@@ -109,5 +110,31 @@ class ExpenseRepositoryTest {
 
         assertThatThrownBy(() -> customEmotionRepository.saveAndFlush(CustomEmotion.of(user, "억울해서")))
                 .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    @DisplayName("sumGroupedByDate는 기간 내 ACTIVE 지출만 날짜별로 SUM하고, 기간 밖·DELETED·다른 유저 지출은 제외한다")
+    void sumGroupedByDate_groupsActiveExpensesWithinPeriodByDate() {
+        LocalDate d1 = LocalDate.of(2026, 6, 8);
+        LocalDate d2 = LocalDate.of(2026, 6, 10);
+        LocalDate outOfRange = LocalDate.of(2026, 6, 20);
+
+        expenseRepository.save(Expense.of("스타벅스", 5000, ExpenseCategory.CAFE, ExpenseEmotion.STRESS, d1, user));
+        expenseRepository.save(Expense.of("편의점", 3000, ExpenseCategory.CAFE, ExpenseEmotion.STRESS, d1, user));
+        expenseRepository.save(Expense.of("배달의민족", 15000, ExpenseCategory.DELIVERY, ExpenseEmotion.COMPENSATION, d2, user));
+        Expense deletedOnD2 = expenseRepository.save(
+                Expense.of("삭제된 지출", 9999, ExpenseCategory.CAFE, ExpenseEmotion.STRESS, d2, user));
+        deletedOnD2.delete();
+        expenseRepository.save(Expense.of("기간 밖 지출", 7000, ExpenseCategory.CAFE, ExpenseEmotion.STRESS, outOfRange, user));
+
+        User other = userRepository.save(User.createLocalUser("other@hampouch.com", "encoded", "other"));
+        expenseRepository.save(Expense.of("남의 지출", 4000, ExpenseCategory.CAFE, ExpenseEmotion.STRESS, d1, other));
+        expenseRepository.flush();
+
+        List<ExpenseDailyTotal> result = expenseRepository.sumGroupedByDate(
+                user.getId(), ExpenseStatus.ACTIVE, LocalDate.of(2026, 6, 7), LocalDate.of(2026, 6, 13));
+
+        assertThat(result).extracting(ExpenseDailyTotal::date, ExpenseDailyTotal::totalAmount)
+                .containsExactly(tuple(d1, 8000L), tuple(d2, 15000L));
     }
 }

--- a/src/test/java/Hampouch/server/domain/expense/repository/ExpenseRepositoryTest.java
+++ b/src/test/java/Hampouch/server/domain/expense/repository/ExpenseRepositoryTest.java
@@ -137,4 +137,30 @@ class ExpenseRepositoryTest {
         assertThat(result).extracting(ExpenseDailyTotal::date, ExpenseDailyTotal::totalAmount)
                 .containsExactly(tuple(d1, 8000L), tuple(d2, 15000L));
     }
+
+    @Test
+    @DisplayName("findAllByUser_IdOrderByCreatedAtAsc는 그 유저의 커스텀 카테고리/감정 태그를 등록 순서로, 다른 유저 것은 제외하고 돌려준다")
+    void findAllByUser_returnsOwnTagsInRegistrationOrder() {
+        customCategoryRepository.save(CustomCategory.of(user, "스터디카페"));
+        customCategoryRepository.save(CustomCategory.of(user, "자판기"));
+        customEmotionRepository.save(CustomEmotion.of(user, "번아웃"));
+        customEmotionRepository.save(CustomEmotion.of(user, "루틴"));
+
+        User other = userRepository.save(User.createLocalUser("other2@hampouch.com", "encoded", "other2"));
+        customCategoryRepository.save(CustomCategory.of(other, "남의 카테고리"));
+        customEmotionRepository.save(CustomEmotion.of(other, "남의 감정"));
+
+        List<CustomCategory> categories = customCategoryRepository.findAllByUser_IdOrderByCreatedAtAsc(user.getId());
+        List<CustomEmotion> emotions = customEmotionRepository.findAllByUser_IdOrderByCreatedAtAsc(user.getId());
+
+        assertThat(categories).extracting(CustomCategory::getName).containsExactly("스터디카페", "자판기");
+        assertThat(emotions).extracting(CustomEmotion::getName).containsExactly("번아웃", "루틴");
+    }
+
+    @Test
+    @DisplayName("커스텀 태그를 하나도 등록하지 않은 유저는 빈 리스트를 받는다")
+    void findAllByUser_returnsEmptyWhenNoTagsRegistered() {
+        assertThat(customCategoryRepository.findAllByUser_IdOrderByCreatedAtAsc(user.getId())).isEmpty();
+        assertThat(customEmotionRepository.findAllByUser_IdOrderByCreatedAtAsc(user.getId())).isEmpty();
+    }
 }

--- a/src/test/java/Hampouch/server/domain/expense/service/ExpenseServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/expense/service/ExpenseServiceTest.java
@@ -24,7 +24,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.Clock;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 
@@ -39,6 +41,7 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class ExpenseServiceTest {
 
+    private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
     private static final Long OWNER = 1L;
     private static final Long OTHER = 2L;
 
@@ -53,9 +56,17 @@ class ExpenseServiceTest {
     @Mock
     UserRepository userRepository;
 
+    // "오늘" = 2026-06-06 고정 — 대부분의 테스트가 쓰는 요청 날짜(2026-06-05)가 "어제"로 잡혀
+    // 챌린지 없음 + 오늘/어제 제한(validateWithinChallengePeriod)에 그대로 걸리지 않게 함.
     private ExpenseService service() {
+        return serviceAt(LocalDate.of(2026, 6, 6));
+    }
+
+    /** "오늘"을 직접 고정해야 하는 케이스(챌린지 없을 때의 오늘/어제 검증)용 — ChallengeServiceTest와 동일 패턴. */
+    private ExpenseService serviceAt(LocalDate today) {
+        Clock clock = Clock.fixed(today.atTime(12, 0).atZone(SEOUL).toInstant(), SEOUL);
         return new ExpenseService(expenseRepository, customCategoryRepository, customEmotionRepository,
-                challengeRepository, userRepository);
+                challengeRepository, userRepository, clock);
     }
 
     // ---------- create ----------
@@ -101,16 +112,31 @@ class ExpenseServiceTest {
     }
 
     @Test
-    @DisplayName("진행 중인 챌린지가 아예 없으면 날짜 범위 검증 없이 자유롭게 생성된다 (요구사항 빈틈 해소)")
-    void create_allowsAnyDateWhenNoActiveChallenge() {
+    @DisplayName("진행 중인 챌린지가 없어도 오늘/어제 날짜면 생성된다")
+    void create_allowsTodayOrYesterdayWhenNoActiveChallenge() {
         when(challengeRepository.findByUserIdAndStatus(OWNER, ChallengeStatus.IN_PROGRESS)).thenReturn(Optional.empty());
         when(userRepository.getReferenceById(OWNER)).thenReturn(user(OWNER));
         when(expenseRepository.save(any(Expense.class))).thenAnswer(inv -> inv.getArgument(0));
 
+        LocalDate today = LocalDate.of(2026, 6, 6);
         var req = new ExpenseCreateRequest("스타벅스", 5000, ExpenseCategory.CAFE, null,
-                ExpenseEmotion.STRESS, null, LocalDate.of(2020, 1, 1)); // 챌린지가 있었다면 당연히 밖일 날짜
+                ExpenseEmotion.STRESS, null, today.minusDays(1)); // 어제
 
-        assertThat(service().create(OWNER, req)).isNotNull();
+        assertThat(serviceAt(today).create(OWNER, req)).isNotNull();
+    }
+
+    @Test
+    @DisplayName("진행 중인 챌린지가 없는데 오늘/어제보다 이전 날짜로 생성하면 400(EXPENSE_DATE_OUT_OF_RECENT_RANGE)을 던진다 (회귀 방지)")
+    void create_rejectsDateOutsideRecentRangeWhenNoActiveChallenge() {
+        when(challengeRepository.findByUserIdAndStatus(OWNER, ChallengeStatus.IN_PROGRESS)).thenReturn(Optional.empty());
+
+        LocalDate today = LocalDate.of(2026, 6, 6);
+        var req = new ExpenseCreateRequest("스타벅스", 5000, ExpenseCategory.CAFE, null,
+                ExpenseEmotion.STRESS, null, LocalDate.of(2020, 1, 1)); // 챌린지가 있었다면 당연히 밖일 날짜, 없어도 이제 막혀야 함
+
+        assertThatThrownBy(() -> serviceAt(today).create(OWNER, req))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ExpenseErrorCode.EXPENSE_DATE_OUT_OF_RECENT_RANGE);
     }
 
     @Test
@@ -328,6 +354,22 @@ class ExpenseServiceTest {
         assertThatThrownBy(() -> service().update(OWNER, 1L, req))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ExpenseErrorCode.EXPENSE_DATE_OUT_OF_CHALLENGE_PERIOD);
+    }
+
+    @Test
+    @DisplayName("진행 중인 챌린지가 없는데 오늘/어제보다 이전 날짜로 수정하면 400(EXPENSE_DATE_OUT_OF_RECENT_RANGE)을 던진다 — create와 대칭 케이스")
+    void update_rejectsDateOutsideRecentRangeWhenNoActiveChallenge() {
+        Expense expense = expenseOf(OWNER, ExpenseCategory.CAFE, null, ExpenseEmotion.STRESS, null);
+        when(expenseRepository.findByIdAndStatus(1L, ExpenseStatus.ACTIVE)).thenReturn(Optional.of(expense));
+        when(challengeRepository.findByUserIdAndStatus(OWNER, ChallengeStatus.IN_PROGRESS)).thenReturn(Optional.empty());
+
+        LocalDate today = LocalDate.of(2026, 6, 6);
+        var req = new ExpenseCreateRequest("스타벅스", 5000, ExpenseCategory.CAFE, null,
+                ExpenseEmotion.STRESS, null, LocalDate.of(2020, 1, 1));
+
+        assertThatThrownBy(() -> serviceAt(today).update(OWNER, 1L, req))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ExpenseErrorCode.EXPENSE_DATE_OUT_OF_RECENT_RANGE);
     }
 
     @Test

--- a/src/test/java/Hampouch/server/domain/expense/service/ExpenseServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/expense/service/ExpenseServiceTest.java
@@ -5,6 +5,7 @@ import Hampouch.server.domain.challenge.entity.ChallengeStatus;
 import Hampouch.server.domain.challenge.repository.ChallengeRepository;
 import Hampouch.server.domain.expense.dto.ExpenseCreateRequest;
 import Hampouch.server.domain.expense.dto.ExpenseCreateResponse;
+import Hampouch.server.domain.expense.dto.ExpenseCustomTagsResponse;
 import Hampouch.server.domain.expense.dto.ExpenseDayListResponse;
 import Hampouch.server.domain.expense.dto.ExpenseDetailResponse;
 import Hampouch.server.domain.expense.dto.ExpenseSummaryResponse;
@@ -35,6 +36,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -501,6 +503,40 @@ class ExpenseServiceTest {
         assertThat(res.periodEnd()).isEqualTo(periodEnd);
         assertThat(res.totalAmount()).isEqualTo(60000);
         assertThat(res.dailyAverage()).isEqualTo(60000 / 30);
+    }
+
+    // ---------- getCustomTags ----------
+
+    @Test
+    @DisplayName("등록된 커스텀 카테고리/감정 태그를 하나의 응답으로 묶어 돌려준다")
+    void getCustomTags_combinesCategoriesAndEmotions() {
+        CustomCategory category = CustomCategory.of(user(OWNER), "자판기");
+        ReflectionTestUtils.setField(category, "id", 45L);
+        CustomEmotion emotion1 = CustomEmotion.of(user(OWNER), "번아웃");
+        ReflectionTestUtils.setField(emotion1, "id", 12L);
+        CustomEmotion emotion2 = CustomEmotion.of(user(OWNER), "루틴");
+        ReflectionTestUtils.setField(emotion2, "id", 15L);
+        when(customEmotionRepository.findAllByUser_IdOrderByCreatedAtAsc(OWNER)).thenReturn(List.of(emotion1, emotion2));
+        when(customCategoryRepository.findAllByUser_IdOrderByCreatedAtAsc(OWNER)).thenReturn(List.of(category));
+
+        ExpenseCustomTagsResponse res = service().getCustomTags(OWNER);
+
+        assertThat(res.emotions()).extracting(ExpenseCustomTagsResponse.Tag::id, ExpenseCustomTagsResponse.Tag::name)
+                .containsExactly(tuple(12L, "번아웃"), tuple(15L, "루틴"));
+        assertThat(res.categories()).extracting(ExpenseCustomTagsResponse.Tag::id, ExpenseCustomTagsResponse.Tag::name)
+                .containsExactly(tuple(45L, "자판기"));
+    }
+
+    @Test
+    @DisplayName("등록한 커스텀 태그가 하나도 없으면 emotions/categories 모두 빈 배열로 응답한다")
+    void getCustomTags_returnsEmptyListsWhenNoTagsRegistered() {
+        when(customEmotionRepository.findAllByUser_IdOrderByCreatedAtAsc(OWNER)).thenReturn(List.of());
+        when(customCategoryRepository.findAllByUser_IdOrderByCreatedAtAsc(OWNER)).thenReturn(List.of());
+
+        ExpenseCustomTagsResponse res = service().getCustomTags(OWNER);
+
+        assertThat(res.emotions()).isEmpty();
+        assertThat(res.categories()).isEmpty();
     }
 
     // ---------- fixtures ----------

--- a/src/test/java/Hampouch/server/domain/expense/service/ExpenseServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/expense/service/ExpenseServiceTest.java
@@ -7,9 +7,11 @@ import Hampouch.server.domain.expense.dto.ExpenseCreateRequest;
 import Hampouch.server.domain.expense.dto.ExpenseCreateResponse;
 import Hampouch.server.domain.expense.dto.ExpenseDayListResponse;
 import Hampouch.server.domain.expense.dto.ExpenseDetailResponse;
+import Hampouch.server.domain.expense.dto.ExpenseSummaryResponse;
 import Hampouch.server.domain.expense.entity.*;
 import Hampouch.server.domain.expense.repository.CustomCategoryRepository;
 import Hampouch.server.domain.expense.repository.CustomEmotionRepository;
+import Hampouch.server.domain.expense.repository.ExpenseDailyTotal;
 import Hampouch.server.domain.expense.repository.ExpenseRepository;
 import Hampouch.server.domain.user.entity.User;
 import Hampouch.server.domain.user.repository.UserRepository;
@@ -26,6 +28,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.Clock;
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
@@ -426,6 +429,78 @@ class ExpenseServiceTest {
 
         assertThat(res.expenses()).hasSize(2);
         assertThat(res.totalAmount()).isEqualTo(e1.getPrice() + e2.getPrice());
+    }
+
+    // ---------- getWeekSummary / getMonthSummary ----------
+
+    @Test
+    @DisplayName("주간 조회는 stDate가 속한 일~토를 기간으로 잡고, 이미 끝난 주면 경과일수를 7일로 평균을 낸다")
+    void getWeekSummary_completedPeriodAveragesOverFullWeek() {
+        LocalDate periodStart = LocalDate.of(2026, 6, 7); // 일
+        LocalDate periodEnd = LocalDate.of(2026, 6, 13); // 토
+        when(expenseRepository.sumGroupedByDate(OWNER, ExpenseStatus.ACTIVE, periodStart, periodEnd))
+                .thenReturn(List.of(
+                        new ExpenseDailyTotal(LocalDate.of(2026, 6, 8), 10000L),
+                        new ExpenseDailyTotal(LocalDate.of(2026, 6, 10), 20000L)));
+
+        // stDate=수요일(06-10), "오늘"=06-20 — 조회 대상 주가 이미 완전히 지난 시점
+        ExpenseSummaryResponse res = serviceAt(LocalDate.of(2026, 6, 20))
+                .getWeekSummary(OWNER, LocalDate.of(2026, 6, 10));
+
+        assertThat(res.periodStart()).isEqualTo(periodStart);
+        assertThat(res.periodEnd()).isEqualTo(periodEnd);
+        assertThat(res.totalAmount()).isEqualTo(30000);
+        assertThat(res.dailyAverage()).isEqualTo(30000 / 7); // 이미 끝난 주 → 경과일수=기간 전체(7일)
+        assertThat(res.dailyBreakdown()).extracting(ExpenseSummaryResponse.DailyAmount::date)
+                .containsExactly(LocalDate.of(2026, 6, 8), LocalDate.of(2026, 6, 10));
+    }
+
+    @Test
+    @DisplayName("조회 대상 주가 아직 진행 중이면 경과일수를 '기간 시작~오늘'로만 계산한다")
+    void getWeekSummary_ongoingPeriodAveragesOverElapsedDaysOnly() {
+        LocalDate periodStart = LocalDate.of(2026, 6, 7);
+        LocalDate periodEnd = LocalDate.of(2026, 6, 13);
+        LocalDate today = LocalDate.of(2026, 6, 10); // 기간 안(수요일) — 06-07~06-10 = 4일 경과
+        when(expenseRepository.sumGroupedByDate(OWNER, ExpenseStatus.ACTIVE, periodStart, periodEnd))
+                .thenReturn(List.of(new ExpenseDailyTotal(LocalDate.of(2026, 6, 8), 8000L)));
+
+        ExpenseSummaryResponse res = serviceAt(today).getWeekSummary(OWNER, today);
+
+        assertThat(res.totalAmount()).isEqualTo(8000);
+        assertThat(res.dailyAverage()).isEqualTo(8000 / 4);
+    }
+
+    @Test
+    @DisplayName("기간 내 지출이 하나도 없으면 totalAmount/dailyAverage 모두 0이다")
+    void getWeekSummary_returnsZeroWhenNoExpensesInPeriod() {
+        LocalDate periodStart = LocalDate.of(2026, 6, 7);
+        LocalDate periodEnd = LocalDate.of(2026, 6, 13);
+        when(expenseRepository.sumGroupedByDate(OWNER, ExpenseStatus.ACTIVE, periodStart, periodEnd))
+                .thenReturn(List.of());
+
+        ExpenseSummaryResponse res = serviceAt(LocalDate.of(2026, 6, 20)).getWeekSummary(OWNER, LocalDate.of(2026, 6, 10));
+
+        assertThat(res.totalAmount()).isEqualTo(0);
+        assertThat(res.dailyAverage()).isEqualTo(0);
+        assertThat(res.dailyBreakdown()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("월간 조회는 stMonth 해당 월 전체(1일~말일)를 기간으로 잡는다")
+    void getMonthSummary_returnsFirstDayToLastDayOfMonth() {
+        LocalDate periodStart = LocalDate.of(2026, 6, 1);
+        LocalDate periodEnd = LocalDate.of(2026, 6, 30); // 6월은 30일까지
+        when(expenseRepository.sumGroupedByDate(OWNER, ExpenseStatus.ACTIVE, periodStart, periodEnd))
+                .thenReturn(List.of(new ExpenseDailyTotal(LocalDate.of(2026, 6, 15), 60000L)));
+
+        // "오늘"=07-05 — 조회 대상 월이 이미 끝난 시점 → 경과일수=30일
+        ExpenseSummaryResponse res = serviceAt(LocalDate.of(2026, 7, 5))
+                .getMonthSummary(OWNER, YearMonth.of(2026, 6));
+
+        assertThat(res.periodStart()).isEqualTo(periodStart);
+        assertThat(res.periodEnd()).isEqualTo(periodEnd);
+        assertThat(res.totalAmount()).isEqualTo(60000);
+        assertThat(res.dailyAverage()).isEqualTo(60000 / 30);
     }
 
     // ---------- fixtures ----------


### PR DESCRIPTION
## 📎연관된 이슈
- close: #37

## 📄 작업 내용 요약
- GET /expenses/custom-tags — 유저가 등록한 커스텀 카테고리/감정 태그 전체를 등록(생성) 순서로 조회하는 API 구현
- 응답은 emotions/categories 두 리스트로 구성된 ExpenseCustomTagsResponse 하나로 통합 (각 항목은 {id, name})
- CustomCategoryRepository/CustomEmotionRepository에 findAllByUser_IdOrderByCreatedAtAsc 파생 쿼리 추가
- 등록된 태그가 하나도 없어도 에러가 아니라 200 + 빈 배열로 응답

##  👀 중요 변경 사항
- 추후 커스텀 태그 수정/삭제 API 생성 시 프론트가 이 id로 대상을 지정해야 하기 때문에 응답 DTO에 미리 포함
고정 enum 값(기본 제공 카테고리/감정)은 이 API의 책임이 아닙니다 — 프론트가 하드코딩해서 갖고 있다는 전제 하에, 이 API는 유저가 직접 등록한 커스텀 태그만 내려줍니다.

## 🔖 Uncompleted Tasks
- 이 브랜치는 feat/36-expense-summary 위에 쌓여 있습니다. #36 의 PR이 먼저 머지되어야 이 PR의 diff도 깨끗해집니다.
- 추후 프론트에서 "직접입력 확인 시점에 즉시 태그를 생성"하는 방향으로 UX가 바뀐다면, 그때는 POST /expenses/custom-tags 분리와 ExpenseCreateRequest의 문자열 기반(customCategory/customEmotion) 구조 자체를 재검토해야 합니다. 지금은 그럴 필요가 없다고 판단해 보류했습니다.

## 📢 To Reviewers
- 커스텀 태그 생성 로직을 분리하지 않고 조회 API만 추가하기로 한 판단(위 "중요 변경 사항" 참고)이 타당한지 한 번 봐주세요.