### PR TITLE
feat: 햄배틀 생성 및 목록 조회 API 구현

### DIFF
--- a/src/main/java/Hampouch/server/domain/battle/controller/BattleController.java
+++ b/src/main/java/Hampouch/server/domain/battle/controller/BattleController.java
@@ -1,0 +1,47 @@
+package Hampouch.server.domain.battle.controller;
+
+import Hampouch.server.domain.battle.dto.BattleListResponse;
+import Hampouch.server.domain.battle.dto.CreateBattleRequest;
+import Hampouch.server.domain.battle.dto.CreateBattleResponse;
+import Hampouch.server.domain.battle.entity.BattleStatus;
+import Hampouch.server.domain.battle.service.BattleService;
+import Hampouch.server.global.common.response.ApiResponse;
+import Hampouch.server.global.security.LoginUserId;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+
+/**
+ * 햄배틀 생성/목록 조회 API. 참가·상세조회는 이후 이슈.
+ */
+@RestController
+@RequestMapping(BattleController.BASE_PATH)
+@RequiredArgsConstructor
+public class BattleController {
+
+    static final String BASE_PATH = "/api/battles";
+
+    private final BattleService battleService;
+
+    /** POST /api/battles — 201 + Location 헤더. */
+    @PostMapping
+    public ResponseEntity<ApiResponse<CreateBattleResponse>> create(
+            @LoginUserId Long userId,
+            @Valid @RequestBody CreateBattleRequest request) {
+        CreateBattleResponse res = battleService.create(userId, request);
+        return ResponseEntity
+                .created(URI.create(BASE_PATH + "/" + res.battleId()))
+                .body(ApiResponse.success(res));
+    }
+
+    /** GET /api/battles — status 미지정 시 전체 상태 조회. */
+    @GetMapping
+    public ApiResponse<BattleListResponse> getMyBattles(
+            @LoginUserId Long userId,
+            @RequestParam(required = false) BattleStatus status) {
+        return ApiResponse.success(battleService.getMyBattles(userId, status));
+    }
+}

--- a/src/main/java/Hampouch/server/domain/battle/dto/BattleListResponse.java
+++ b/src/main/java/Hampouch/server/domain/battle/dto/BattleListResponse.java
@@ -1,0 +1,9 @@
+package Hampouch.server.domain.battle.dto;
+
+import java.util.List;
+
+/** GET /battles 응답 — 정렬 기준 startDate DESC, battleId DESC 고정 */
+public record BattleListResponse(
+        List<BattleSummary> battles
+) {
+}

--- a/src/main/java/Hampouch/server/domain/battle/dto/BattleSummary.java
+++ b/src/main/java/Hampouch/server/domain/battle/dto/BattleSummary.java
@@ -1,0 +1,48 @@
+package Hampouch.server.domain.battle.dto;
+
+import Hampouch.server.domain.battle.entity.BattleStatus;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * GET /battles 목록 항목 — READY(정원/참가인원)·ONGOING(참가자별 today/total)·TERMINATED(승자 요약)
+ * 3가지가 shape 자체가 달라, 공통 필드+널러블 옵션필드 하나 대신 sealed interface로 나눔
+ * (status별 필드 누락·오조합을 컴파일 타임에 막음, Java 21).
+ */
+public sealed interface BattleSummary
+        permits BattleSummary.Ready, BattleSummary.Ongoing, BattleSummary.Terminated {
+
+    Long battleId();
+    String battleCode();
+    String title();
+    String penalty();
+    LocalDate startDate();
+    LocalDate endDate();
+    BattleStatus status();
+
+    record Ready(
+            Long battleId, String battleCode, String title, String penalty,
+            LocalDate startDate, LocalDate endDate, BattleStatus status,
+            int capacity, int joinedCount
+    ) implements BattleSummary {
+    }
+
+    record Ongoing(
+            Long battleId, String battleCode, String title, String penalty,
+            LocalDate startDate, LocalDate endDate, BattleStatus status,
+            List<ParticipantAmount> participants
+    ) implements BattleSummary {
+        public record ParticipantAmount(
+                Long userId, String nickname, String avatarUrl, int todayAmount, int totalAmount
+        ) {
+        }
+    }
+
+    record Terminated(
+            Long battleId, String battleCode, String title, String penalty,
+            LocalDate startDate, LocalDate endDate, BattleStatus status,
+            String winnerNickname
+    ) implements BattleSummary {
+    }
+}

--- a/src/main/java/Hampouch/server/domain/battle/dto/CreateBattleRequest.java
+++ b/src/main/java/Hampouch/server/domain/battle/dto/CreateBattleRequest.java
@@ -1,0 +1,30 @@
+package Hampouch.server.domain.battle.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+
+/**
+ * POST /battles 요청 — capacity/durationDays/startDate 검증은 서비스 계층에서 한다
+ * (INVALID_CAPACITY_RANGE/INVALID_START_DATE 전용 BattleErrorCode를 내야 하므로
+ * @Min / @Max는 GlobalExceptionHandler가 전부 VALIDATION_ERROR로 검증
+ */
+public record CreateBattleRequest(
+        @NotBlank @Size(max = 100)
+        String title,
+
+        @NotNull
+        Integer capacity,
+
+        @NotNull
+        Integer durationDays,
+
+        @NotNull
+        LocalDate startDate,
+
+        @NotBlank @Size(max = 100)
+        String penalty
+) {
+}

--- a/src/main/java/Hampouch/server/domain/battle/dto/CreateBattleResponse.java
+++ b/src/main/java/Hampouch/server/domain/battle/dto/CreateBattleResponse.java
@@ -1,0 +1,33 @@
+package Hampouch.server.domain.battle.dto;
+
+import Hampouch.server.domain.battle.entity.Battle;
+import Hampouch.server.domain.battle.entity.BattleStatus;
+
+import java.time.LocalDate;
+
+/** POST /battles 응답 — creatorId/creatorNickname은 화면에 불필요해서 제외 */
+public record CreateBattleResponse(
+        Long battleId,
+        String battleCode,
+        String title,
+        int capacity,
+        int durationDays,
+        LocalDate startDate,
+        LocalDate endDate,
+        String penalty,
+        BattleStatus status
+) {
+    public static CreateBattleResponse from(Battle battle) {
+        return new CreateBattleResponse(
+                battle.getId(),
+                battle.getBattleCode(),
+                battle.getTitle(),
+                battle.getCapacity(),
+                battle.getDurationDays(),
+                battle.getStartDate(),
+                battle.getEndDate(),
+                battle.getPenalty(),
+                battle.getStatus()
+        );
+    }
+}

--- a/src/main/java/Hampouch/server/domain/battle/entity/Battle.java
+++ b/src/main/java/Hampouch/server/domain/battle/entity/Battle.java
@@ -1,0 +1,129 @@
+package Hampouch.server.domain.battle.entity;
+
+import Hampouch.server.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * 햄배틀 (소비 절약 대결). capacity 미달 자동취소·시작 전환·종료 스냅샷은 전부 배치가
+ * 명시적으로 호출하는 상태 전이 메서드(start/cancel/terminate)를 통해서만 일어난다
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "battle",
+        uniqueConstraints = @UniqueConstraint(name = "uq_battle_code", columnNames = "battle_code"))
+@EntityListeners(AuditingEntityListener.class)
+public class Battle {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "battle_id")
+    private Long id;
+
+    @Column(name = "battle_code", nullable = false, length = 30)
+    private String battleCode; // 재발급 없는 영구 코드
+
+    @Column(nullable = false, length = 100)
+    private String title;
+
+    @Column(name = "party_capacity", nullable = false)
+    private int capacity;
+
+    @Column(name = "duration", nullable = false)
+    private int durationDays;
+
+    @Column(nullable = false)
+    private LocalDate startDate;
+
+    /** startDate + durationDays - 1, 생성 시점 스냅샷(Challenge.endDate와 동일 — 매 조회마다 재계산 안 함) */
+    @Column(nullable = false)
+    private LocalDate endDate;
+
+    @Column(nullable = false, length = 100)
+    private String penalty;
+
+    @Enumerated(EnumType.STRING) // ORDINAL 금지 — enum 순서가 바뀌면 저장된 데이터가 조용히 깨짐(팀 공통 컨벤션)
+    @Column(nullable = false, length = 10)
+    private BattleStatus status;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    /** 생성자 — API 응답엔 노출 안 하지만(화면에 불필요) ERD상 NOT NULL 컬럼이라 엔티티엔 유지. */
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "creator_id", nullable = false)
+    private User creator;
+
+    /** 꼴찌(벌칙 대상) — TERMINATED 전엔 항상 null, terminate()가 유일한 세팅 통로.
+     * participant.rank/totalAmount와 동일한 스냅샷 성격(ERD 확인: nullable). */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "penalty_user_id")
+    private User penaltyUser;
+
+    private Battle(String battleCode, String title, int capacity, int durationDays,
+                    LocalDate startDate, String penalty, User creator) {
+        this.battleCode = battleCode;
+        this.title = title;
+        this.capacity = capacity;
+        this.durationDays = durationDays;
+        this.startDate = startDate;
+        this.endDate = startDate.plusDays(durationDays - 1L);
+        this.penalty = penalty;
+        this.creator = creator;
+        this.status = BattleStatus.READY;
+    }
+
+    /**
+     * 정적 팩토리 — private 생성자 대신 노출한 이유: status 기본값(READY) 강제, penaltyUser는
+     * startDate을 검증하는 이유는 startDate와 durationDays를 기반으로 endDate를 계산하는데,
+     * startDate가 null이면 NullPointerException으로 죽어 원인 파악이 어렵다
+     */
+    public static Battle of(String battleCode, String title, int capacity, int durationDays,
+                             LocalDate startDate, String penalty, User creator) {
+        if (startDate == null) {
+            throw new IllegalArgumentException("startDate는 필수입니다.");
+        }
+        return new Battle(battleCode, title, capacity, durationDays, startDate, penalty, creator);
+    }
+
+    /** 시작일 배치 전용 — 정원 충족 확인 후 호출. READY가 아니면 배치 로직 버그라 즉시 터뜨림. */
+    public void start() {
+        if (status != BattleStatus.READY) {
+            throw new IllegalStateException("READY 상태만 시작할 수 있습니다: " + status);
+        }
+        this.status = BattleStatus.ONGOING;
+    }
+
+    /** 시작일 배치 전용 — 정원 미달 확인 후 호출. 수동 취소 API는 없음 */
+    public void cancel() {
+        if (status != BattleStatus.READY) {
+            throw new IllegalStateException("READY 상태만 취소할 수 있습니다: " + status);
+        }
+        this.status = BattleStatus.CANCELLED;
+    }
+
+    /**
+     * 종료일 배치 전용. penaltyUser는 여기서만 세팅되는 확정 스냅샷(참가자별 rank/totalAmount는
+     * BattleParticipant.finalizeResult()가 각자 책임).
+     */
+    public void terminate(User penaltyUser) {
+        if (status != BattleStatus.ONGOING) {
+            throw new IllegalStateException("ONGOING 상태만 종료할 수 있습니다: " + status);
+        }
+        this.status = BattleStatus.TERMINATED;
+        this.penaltyUser = penaltyUser;
+    }
+
+    public boolean isOwnedBy(Long userId) {
+        return this.creator.getId().equals(userId);
+    }
+}

--- a/src/main/java/Hampouch/server/domain/battle/entity/BattleParticipant.java
+++ b/src/main/java/Hampouch/server/domain/battle/entity/BattleParticipant.java
@@ -1,0 +1,80 @@
+package Hampouch.server.domain.battle.entity;
+
+import Hampouch.server.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+/**
+ * 배틀 참가자 — 배틀 생성 시 생성자도 이 테이블에 함께 등록된다(Battle.creator와 별개로,
+ * 참가자 명단 자체는 여기가 유일한 출처 — joinedCount/participants 목록이 전부 이 테이블 기준).
+ * rank/totalAmount는 TERMINATED 스냅샷 전엔 항상 null(Battle.penaltyUser와 동일한 성격).
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "battle_participant",
+        uniqueConstraints = @UniqueConstraint(name = "uq_battle_participant", columnNames = {"battle_id", "user_id"}))
+// 동시 참가 요청 경쟁의 최종 방어선 — 서비스 계층의 사전 체크(ALREADY_JOINED)를 뚫고 들어와도 DB가 막음
+@EntityListeners(AuditingEntityListener.class)
+public class BattleParticipant {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "participant_id")
+    private Long id;
+
+    @CreatedDate
+    @Column(name = "joined_at", nullable = false, updatable = false)
+    private LocalDateTime joinedAt;
+
+    @Column(name = "is_valid", nullable = false)
+    private boolean isValid;
+
+    /** 배틀 종료 시점 순위 — TERMINATED 스냅샷 전엔 null(Battle.penaltyUser와 동일 원칙) */
+    private Integer rank;
+
+    /** 배틀 기간 동안 사용한 금액 — 위와 동일하게 스냅샷 전엔 null */
+    @Column(name = "total_amount")
+    private Integer totalAmount;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "battle_id", nullable = false)
+    private Battle battle;
+
+    private BattleParticipant(User user, Battle battle) {
+        this.user = user;
+        this.battle = battle;
+        this.isValid = true; // ERD 기본값 true — 무효화는 배치가 3일 연속 미기록 확인 후 invalidate()로만
+    }
+
+    public static BattleParticipant of(User user, Battle battle) {
+        return new BattleParticipant(user, battle);
+    }
+
+    /**
+     * 3일 연속 미기록 시 무효화
+     */
+    public void invalidate() {
+        this.isValid = false;
+    }
+
+    /** 종료일 배치 전용 스냅샷 — Battle.terminate()와 같은 트랜잭션에서 참가자별로 호출. */
+    public void finalizeResult(int rank, int totalAmount) {
+        this.rank = rank;
+        this.totalAmount = totalAmount;
+    }
+
+    public boolean isOwnedBy(Long userId) {
+        return this.user.getId().equals(userId);
+    }
+}

--- a/src/main/java/Hampouch/server/domain/battle/entity/BattleStatus.java
+++ b/src/main/java/Hampouch/server/domain/battle/entity/BattleStatus.java
@@ -1,0 +1,12 @@
+package Hampouch.server.domain.battle.entity;
+
+/**
+ * READY: 생성 직후, 시작일 전까지 참가자 모집 중 / ONGOING: 시작일 배치가 정원 충족 확인 후 전환
+ * TERMINATED: 종료일 배치가 결과 스냅샷 확정 / CANCELLED: 시작일 배치가 정원 미달 확인 후 자동 취소
+ */
+public enum BattleStatus {
+    READY,
+    ONGOING,
+    TERMINATED,
+    CANCELLED
+}

--- a/src/main/java/Hampouch/server/domain/battle/repository/BattleParticipantRepository.java
+++ b/src/main/java/Hampouch/server/domain/battle/repository/BattleParticipantRepository.java
@@ -1,0 +1,26 @@
+package Hampouch.server.domain.battle.repository;
+
+import Hampouch.server.domain.battle.entity.BattleParticipant;
+import Hampouch.server.domain.battle.entity.BattleStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface BattleParticipantRepository extends JpaRepository<BattleParticipant, Long> {
+
+    boolean existsByBattle_IdAndUser_Id(Long battleId, Long userId); // ALREADY_JOINED 판단
+
+    int countByBattle_Id(Long battleId); // joinedCount 응답 필드 + 시작일 배치의 정원 충족 체크
+
+    /**
+     * GET /battles — 내가 참가 중인 배틀은 BattleParticipant를 통해 확인할 수 있는 정보.
+     * BattleRepository가 아니라 여기서 조회를 시작한다. status는 선택 필터(null이면 전체).
+     * JOIN FETCH로 Battle을 함께 가져와 N+1 방지, 정렬은 startDate와 등록 순의 DESC로 고정
+     */
+    @Query("SELECT p FROM BattleParticipant p JOIN FETCH p.battle b " +
+            "WHERE p.user.id = :userId AND (:status IS NULL OR b.status = :status) " +
+            "ORDER BY b.startDate DESC, b.id DESC")
+    List<BattleParticipant> findMyParticipations(@Param("userId") Long userId, @Param("status") BattleStatus status);
+}

--- a/src/main/java/Hampouch/server/domain/battle/repository/BattleRepository.java
+++ b/src/main/java/Hampouch/server/domain/battle/repository/BattleRepository.java
@@ -1,0 +1,9 @@
+package Hampouch.server.domain.battle.repository;
+
+import Hampouch.server.domain.battle.entity.Battle;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BattleRepository extends JpaRepository<Battle, Long> {
+
+    boolean existsByBattleCode(String battleCode);
+}

--- a/src/main/java/Hampouch/server/domain/battle/service/BattleCodeGenerator.java
+++ b/src/main/java/Hampouch/server/domain/battle/service/BattleCodeGenerator.java
@@ -1,0 +1,41 @@
+package Hampouch.server.domain.battle.service;
+
+import Hampouch.server.domain.battle.repository.BattleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.security.SecureRandom;
+
+/**
+ * battleCode 발급 — 초대 링크에 그대로 노출되는 추측 불가능한 토큰이라, SecureRandom을 활용
+ * 충돌은 DB unique(uq_battle_code)가 최종 방어선이고, 여기 재시도는 흔한 경우를 미리 걸러내는 선제 조치일 뿐.
+ */
+@Component
+@RequiredArgsConstructor
+public class BattleCodeGenerator {
+
+    private static final String ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    private static final int LENGTH = 8; // VARCHAR(30) 여유 있게 남기고, 초대 링크에 넣기 적당한 길이로 8
+    private static final int MAX_ATTEMPTS = 5; // 62^8 공간에서 5연속 충돌은 사실상 불가능 — 넘으면 버그로 간주하고 즉시 터뜨림
+
+    private final SecureRandom random = new SecureRandom();
+    private final BattleRepository battleRepository;
+
+    public String generate() {
+        for (int i = 0; i < MAX_ATTEMPTS; i++) {
+            String code = randomCode();
+            if (!battleRepository.existsByBattleCode(code)) {
+                return code;
+            }
+        }
+        throw new IllegalStateException("battleCode 생성 재시도 한도 초과 — 충돌률이 비정상적으로 높습니다.");
+    }
+
+    private String randomCode() {
+        StringBuilder sb = new StringBuilder(LENGTH);
+        for (int i = 0; i < LENGTH; i++) {
+            sb.append(ALPHABET.charAt(random.nextInt(ALPHABET.length())));
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/Hampouch/server/domain/battle/service/BattleService.java
+++ b/src/main/java/Hampouch/server/domain/battle/service/BattleService.java
@@ -1,0 +1,123 @@
+package Hampouch.server.domain.battle.service;
+
+import Hampouch.server.domain.battle.dto.BattleListResponse;
+import Hampouch.server.domain.battle.dto.BattleSummary;
+import Hampouch.server.domain.battle.dto.CreateBattleRequest;
+import Hampouch.server.domain.battle.dto.CreateBattleResponse;
+import Hampouch.server.domain.battle.entity.Battle;
+import Hampouch.server.domain.battle.entity.BattleParticipant;
+import Hampouch.server.domain.battle.entity.BattleStatus;
+import Hampouch.server.domain.battle.repository.BattleParticipantRepository;
+import Hampouch.server.domain.battle.repository.BattleRepository;
+import Hampouch.server.domain.user.entity.User;
+import Hampouch.server.domain.user.repository.UserRepository;
+import Hampouch.server.global.common.exception.CustomException;
+import Hampouch.server.global.common.exception.domain.BattleErrorCode;
+import Hampouch.server.global.common.exception.domain.CommonErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * 배틀 생성 + 목록 조회의 서비스 계층. 참가/랭킹/배치는 이후 구현 예정.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BattleService {
+
+    private static final Set<Integer> ALLOWED_DURATIONS = Set.of(3, 7, 14, 31);
+
+    private final BattleRepository battleRepository;
+    private final BattleParticipantRepository battleParticipantRepository;
+    private final UserRepository userRepository;
+    private final BattleCodeGenerator battleCodeGenerator;
+    private final Clock clock;
+
+    /**
+     * POST /battles. userRepository.getReferenceById()로 실제 SELECT 없이 프록시만 받는다 —
+     * userId는 @LoginUserId(JWT 인증)를 통과한 값이라 재검증 필요 X
+     */
+    @Transactional
+    public CreateBattleResponse create(Long userId, CreateBattleRequest request) {
+        validateCapacity(request.capacity());
+        validateDuration(request.durationDays());
+        validateStartDate(request.startDate());
+
+        User creator = userRepository.getReferenceById(userId);
+        String battleCode = battleCodeGenerator.generate();
+        Battle battle = Battle.of(battleCode, request.title(), request.capacity(), request.durationDays(),
+                request.startDate(), request.penalty(), creator);
+        battleRepository.save(battle);
+
+        // 생성자 자동 첫 참가자 등록 — 참가자 명단의 유일한 출처는 BattleParticipant
+        battleParticipantRepository.save(BattleParticipant.of(creator, battle));
+
+        return CreateBattleResponse.from(battle);
+    }
+
+    /**
+     * GET /battles. 내가 참가 중인 배틀이 BattleParticipant를 거쳐야만 나오는 정보라
+     * BattleParticipantRepository에서 조회를 시작
+     */
+    public BattleListResponse getMyBattles(Long userId, BattleStatus statusFilter) {
+        List<BattleParticipant> participation = battleParticipantRepository.findMyParticipations(userId, statusFilter);
+
+        List<BattleSummary> summaries = participation.stream()
+                .map(p -> toSummary(p.getBattle()))
+                .toList();
+
+        return new BattleListResponse(summaries);
+    }
+
+    private void validateCapacity(int capacity) {
+        if (capacity < 2 || capacity > 10) {
+            throw new CustomException(BattleErrorCode.INVALID_CAPACITY_RANGE);
+        }
+    }
+
+    /** durationDays는 전용 BattleErrorCode가 없어 공통 VALIDATION_ERROR + 구체 메시지로 처리 */
+    private void validateDuration(int durationDays) {
+        if (!ALLOWED_DURATIONS.contains(durationDays)) {
+            throw new CustomException(CommonErrorCode.VALIDATION_ERROR, "durationDays는 3/7/14/31만 가능합니다.");
+        }
+    }
+
+    private void validateStartDate(LocalDate startDate) {
+        if (startDate.isBefore(LocalDate.now(clock))) {
+            throw new CustomException(BattleErrorCode.INVALID_START_DATE);
+        }
+    }
+
+    /**
+     * status별 카드 shape 분기. ONGOING의 todayAmount/totalAmount, TERMINATED의 winnerNickname은
+     * 실시간 집계/랭킹 쿼리가 아직 없어 빈 값으로 스텁 — 시작일·종료일 배치가 없는 지금은
+     * 어떤 배틀도 실제로 이 상태에 도달하지 않아 당장 잘못된 값이 나갈 일은 없음.
+     */
+    private BattleSummary toSummary(Battle battle) {
+        return switch (battle.getStatus()) {
+            case READY -> new BattleSummary.Ready(
+                    battle.getId(), battle.getBattleCode(), battle.getTitle(), battle.getPenalty(),
+                    battle.getStartDate(), battle.getEndDate(), battle.getStatus(),
+                    battle.getCapacity(), battleParticipantRepository.countByBattle_Id(battle.getId())
+            );
+            case ONGOING -> new BattleSummary.Ongoing(
+                    battle.getId(), battle.getBattleCode(), battle.getTitle(), battle.getPenalty(),
+                    battle.getStartDate(), battle.getEndDate(), battle.getStatus(),
+                    List.of() // TODO(③): 참가자별 today/total 실시간 집계로 교체
+            );
+            case TERMINATED -> new BattleSummary.Terminated(
+                    battle.getId(), battle.getBattleCode(), battle.getTitle(), battle.getPenalty(),
+                    battle.getStartDate(), battle.getEndDate(), battle.getStatus(),
+                    null // TODO(③): rank=1 참가자 닉네임으로 교체
+            );
+            case CANCELLED -> throw new IllegalStateException(
+                    "CANCELLED 배틀의 목록 카드 shape가 아직 정의되지 않음");
+        };
+    }
+}

--- a/src/main/java/Hampouch/server/global/common/exception/domain/BattleErrorCode.java
+++ b/src/main/java/Hampouch/server/global/common/exception/domain/BattleErrorCode.java
@@ -1,0 +1,34 @@
+package Hampouch.server.global.common.exception.domain;
+
+import Hampouch.server.global.common.exception.BaseErrorCode;
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum BattleErrorCode implements BaseErrorCode {
+
+    INVALID_CAPACITY_RANGE(HttpStatus.BAD_REQUEST, "INVALID_CAPACITY_RANGE", "참가 정원은 2명 이상 10명 이하로 설정해야 합니다."),
+
+    INVALID_START_DATE(HttpStatus.BAD_REQUEST, "INVALID_START_DATE", "시작일은 오늘 이후 날짜여야 합니다."),
+
+    BATTLE_NOT_FOUND(HttpStatus.NOT_FOUND, "BATTLE_NOT_FOUND", "요청한 햄배틀을 찾을 수 없습니다"),
+    
+    BATTLE_CODE_NOT_FOUND(HttpStatus.NOT_FOUND, "BATTLE_CODE_NOT_FOUND", "요청한 초대 코드를 찾을 수 없습니다"),
+
+    BATTLE_FULL(HttpStatus.CONFLICT, "BATTLE_FULL", "정원이 마감된 햄배틀입니다."),
+
+    BATTLE_ALREADY_STARTED(HttpStatus.CONFLICT, "BATTLE_ALREADY_STARTED", "이미 시작된 햄배틀입니다."),
+
+    ALREADY_JOINED(HttpStatus.CONFLICT, "ALREADY_JOINED", "이미 참가한 햄배틀입니다."),
+
+    BATTLE_CANCELLED(HttpStatus.BAD_REQUEST, "BATTLE_CANCELLED", "이미 취소된 햄배틀입니다."),
+
+    FORBIDDEN_NOT_PARTICIPANT(HttpStatus.FORBIDDEN, "FORBIDDEN_NOT_PARTICIPANT", "햄배틀 정보는 참가자만 조회할 수 있습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/test/java/Hampouch/server/domain/battle/entity/BattleParticipantTest.java
+++ b/src/test/java/Hampouch/server/domain/battle/entity/BattleParticipantTest.java
@@ -1,0 +1,68 @@
+package Hampouch.server.domain.battle.entity;
+
+import Hampouch.server.domain.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * BattleParticipant 생성 시 기본 상태와 무효화·결과 확정 동작 검증.
+ * of()는 user/battle을 계산 없이 그대로 대입만 하므로(Battle.of()의 startDate처럼 계산 전제조건이
+ * 아님) null 가드를 두지 않는다 — Expense.of()와 동일한 "포지셔널 팩토리는 값 검증 안 함" 원칙.
+ */
+class BattleParticipantTest {
+
+    private static User user(Long id) {
+        User user = User.createLocalUser("p" + id + "@hampouch.com", "encoded", "p" + id);
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    private static Battle battle() {
+        return Battle.of("ABCD1234", "짠테크 배틀", 4, 7, LocalDate.of(2026, 8, 1), "치킨 사주기", user(99L));
+    }
+
+    @Test
+    @DisplayName("생성하면 isValid는 true로 시작하고 rank/totalAmount는 아직 비어있다")
+    void of_startsValidWithoutResult() {
+        BattleParticipant participant = BattleParticipant.of(user(1L), battle());
+
+        assertThat(participant.isValid()).isTrue();
+        assertThat(participant.getRank()).isNull();
+        assertThat(participant.getTotalAmount()).isNull();
+    }
+
+    @Test
+    @DisplayName("invalidate()를 호출하면 isValid가 false로 바뀐다")
+    void invalidate_setsFalse() {
+        BattleParticipant participant = BattleParticipant.of(user(1L), battle());
+
+        participant.invalidate();
+
+        assertThat(participant.isValid()).isFalse();
+    }
+
+    @Test
+    @DisplayName("finalizeResult()를 호출하면 rank/totalAmount가 세팅된다")
+    void finalizeResult_setsRankAndTotalAmount() {
+        BattleParticipant participant = BattleParticipant.of(user(1L), battle());
+
+        participant.finalizeResult(2, 15000);
+
+        assertThat(participant.getRank()).isEqualTo(2);
+        assertThat(participant.getTotalAmount()).isEqualTo(15000);
+    }
+
+    @Test
+    @DisplayName("isOwnedBy는 참가자 본인의 id와 같을 때만 true를 반환한다")
+    void isOwnedBy_matchesUserIdOnly() {
+        BattleParticipant participant = BattleParticipant.of(user(1L), battle());
+
+        assertThat(participant.isOwnedBy(1L)).isTrue();
+        assertThat(participant.isOwnedBy(2L)).isFalse();
+    }
+}

--- a/src/test/java/Hampouch/server/domain/battle/entity/BattleTest.java
+++ b/src/test/java/Hampouch/server/domain/battle/entity/BattleTest.java
@@ -1,0 +1,114 @@
+package Hampouch.server.domain.battle.entity;
+
+import Hampouch.server.domain.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Battle 엔티티의 생성 규칙과 상태 전이(READY→ONGOING→TERMINATED, READY→CANCELLED) 검증.
+ * capacity/durationDays 범위 등 값 검증은 서비스 계층 책임이라(0727 결정, Battle.of() 참조) 여기선
+ * startDate null 가드와 상태 전이 규칙만 확인한다 — of()는 포지셔널이라 필드 누락 자체가 불가능하다.
+ */
+class BattleTest {
+
+    private static User creator(Long id) {
+        User user = User.createLocalUser("creator" + id + "@hampouch.com", "encoded", "creator" + id);
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    private static Battle validBattle() {
+        return Battle.of("ABCD1234", "짠테크 배틀", 4, 7, LocalDate.of(2026, 8, 1), "치킨 사주기", creator(1L));
+    }
+
+    @Test
+    @DisplayName("생성하면 종료일(시작일 포함 기간의 마지막 날)이 계산되고 상태는 READY로 시작한다")
+    void of_computesEndDateAndStartsReady() {
+        Battle battle = validBattle();
+
+        assertThat(battle.getEndDate()).isEqualTo(LocalDate.of(2026, 8, 7)); // 8/1 + (7일 - 1)
+        assertThat(battle.getStatus()).isEqualTo(BattleStatus.READY);
+        assertThat(battle.getPenaltyUser()).isNull(); // terminate() 전엔 항상 null
+    }
+
+    @Test
+    @DisplayName("시작일이 null이면 종료일 계산 전에 IllegalArgumentException으로 막는다 — endDate 계산의 전제조건")
+    void of_rejectsNullStartDate() {
+        assertThatThrownBy(() -> Battle.of("ABCD1234", "짠테크 배틀", 4, 7, null, "치킨 사주기", creator(1L)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("READY 상태에서 start()를 호출하면 ONGOING으로 바뀐다")
+    void start_transitionsReadyToOngoing() {
+        Battle battle = validBattle();
+
+        battle.start();
+
+        assertThat(battle.getStatus()).isEqualTo(BattleStatus.ONGOING);
+    }
+
+    @Test
+    @DisplayName("이미 시작된(ONGOING) 배틀은 다시 start()할 수 없다 — IllegalStateException")
+    void start_rejectsWhenNotReady() {
+        Battle battle = validBattle();
+        battle.start();
+
+        assertThatThrownBy(battle::start).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    @DisplayName("READY 상태에서 cancel()을 호출하면 CANCELLED로 바뀐다")
+    void cancel_transitionsReadyToCancelled() {
+        Battle battle = validBattle();
+
+        battle.cancel();
+
+        assertThat(battle.getStatus()).isEqualTo(BattleStatus.CANCELLED);
+    }
+
+    @Test
+    @DisplayName("이미 시작된(ONGOING) 배틀은 cancel()할 수 없다 — 자동취소는 시작 전(READY)에만 가능")
+    void cancel_rejectsWhenNotReady() {
+        Battle battle = validBattle();
+        battle.start();
+
+        assertThatThrownBy(battle::cancel).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    @DisplayName("ONGOING 상태에서 terminate()를 호출하면 TERMINATED로 바뀌고 penaltyUser가 세팅된다")
+    void terminate_transitionsOngoingToTerminatedAndSetsPenaltyUser() {
+        Battle battle = validBattle();
+        battle.start();
+        User penaltyUser = creator(2L);
+
+        battle.terminate(penaltyUser);
+
+        assertThat(battle.getStatus()).isEqualTo(BattleStatus.TERMINATED);
+        assertThat(battle.getPenaltyUser()).isSameAs(penaltyUser);
+    }
+
+    @Test
+    @DisplayName("시작 전(READY) 배틀은 terminate()할 수 없다 — 종료는 진행 중(ONGOING)에서만 가능")
+    void terminate_rejectsWhenNotOngoing() {
+        Battle battle = validBattle();
+
+        assertThatThrownBy(() -> battle.terminate(creator(2L))).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    @DisplayName("isOwnedBy는 creator의 id와 같을 때만 true를 반환한다")
+    void isOwnedBy_matchesCreatorIdOnly() {
+        Battle battle = validBattle();
+
+        assertThat(battle.isOwnedBy(1L)).isTrue();
+        assertThat(battle.isOwnedBy(2L)).isFalse();
+    }
+}

--- a/src/test/java/Hampouch/server/domain/battle/repository/BattleParticipantRepositoryTest.java
+++ b/src/test/java/Hampouch/server/domain/battle/repository/BattleParticipantRepositoryTest.java
@@ -1,0 +1,113 @@
+package Hampouch.server.domain.battle.repository;
+
+import Hampouch.server.domain.battle.entity.Battle;
+import Hampouch.server.domain.battle.entity.BattleParticipant;
+import Hampouch.server.domain.battle.entity.BattleStatus;
+import Hampouch.server.domain.user.entity.User;
+import Hampouch.server.domain.user.repository.UserRepository;
+import Hampouch.server.global.config.ClockConfig;
+import Hampouch.server.global.config.JpaAuditingConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * ALREADY_JOINED 판단(existsByBattle_IdAndUser_Id)·정원 카운트(countByBattle_Id)·
+ * 내 참가 목록 조회(findMyParticipations)를 H2에 실제 적용해 검증 (ExpenseRepositoryTest와 동일 스타일).
+ */
+@DataJpaTest
+@Import({ClockConfig.class, JpaAuditingConfig.class})
+class BattleParticipantRepositoryTest {
+
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    BattleRepository battleRepository;
+    @Autowired
+    BattleParticipantRepository battleParticipantRepository;
+
+    private User me;
+    private User other;
+
+    @BeforeEach
+    void setUp() {
+        me = userRepository.save(User.createLocalUser("me@hampouch.com", "encoded", "me"));
+        other = userRepository.save(User.createLocalUser("other@hampouch.com", "encoded", "other"));
+    }
+
+    private Battle battle(String code, LocalDate startDate) {
+        return battleRepository.save(Battle.of(code, "짠테크 배틀", 4, 7, startDate, "치킨 사주기", other));
+    }
+
+    @Test
+    @DisplayName("existsByBattle_IdAndUser_Id는 그 배틀에 그 유저가 참가한 행이 있을 때만 true다")
+    void existsByBattleAndUser_reflectsParticipation() {
+        Battle battle = battle("ABCD1234", LocalDate.of(2026, 8, 1));
+        battleParticipantRepository.save(BattleParticipant.of(me, battle));
+
+        assertThat(battleParticipantRepository.existsByBattle_IdAndUser_Id(battle.getId(), me.getId())).isTrue();
+        assertThat(battleParticipantRepository.existsByBattle_IdAndUser_Id(battle.getId(), other.getId())).isFalse();
+    }
+
+    @Test
+    @DisplayName("countByBattle_Id는 그 배틀의 참가자 수만 센다 — 다른 배틀 참가자는 섞이지 않는다")
+    void countByBattle_countsOnlyThatBattle() {
+        Battle battle = battle("ABCD1234", LocalDate.of(2026, 8, 1));
+        Battle otherBattle = battle("ZZZZ9999", LocalDate.of(2026, 8, 1));
+        battleParticipantRepository.save(BattleParticipant.of(me, battle));
+        battleParticipantRepository.save(BattleParticipant.of(other, battle));
+        battleParticipantRepository.save(BattleParticipant.of(me, otherBattle));
+
+        assertThat(battleParticipantRepository.countByBattle_Id(battle.getId())).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("같은 배틀에 같은 유저가 두 번 참가하면 유니크 제약(uq_battle_participant)이 거절한다")
+    void uniqueConstraint_rejectsDuplicateJoin() {
+        Battle battle = battle("ABCD1234", LocalDate.of(2026, 8, 1));
+        battleParticipantRepository.saveAndFlush(BattleParticipant.of(me, battle));
+
+        assertThatThrownBy(() -> battleParticipantRepository.saveAndFlush(BattleParticipant.of(me, battle)))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    @DisplayName("findMyParticipations는 status 필터가 없으면 내 참가 전체를 startDate DESC, battleId DESC로 준다")
+    void findMyParticipations_returnsAllOrderedWhenNoFilter() {
+        Battle older = battle("AAAA0001", LocalDate.of(2026, 8, 1));
+        Battle newer = battle("AAAA0002", LocalDate.of(2026, 9, 1));
+        battleParticipantRepository.save(BattleParticipant.of(me, older));
+        battleParticipantRepository.save(BattleParticipant.of(me, newer));
+        battleParticipantRepository.save(BattleParticipant.of(other, older)); // 남의 참가 — 제외돼야 함
+
+        List<BattleParticipant> result = battleParticipantRepository.findMyParticipations(me.getId(), null);
+
+        assertThat(result).extracting(p -> p.getBattle().getId())
+                .containsExactly(newer.getId(), older.getId()); // startDate가 늦은(9/1) 쪽이 먼저
+    }
+
+    @Test
+    @DisplayName("findMyParticipations는 status를 지정하면 그 상태의 배틀 참가만 걸러낸다")
+    void findMyParticipations_filtersByStatus() {
+        Battle ready = battle("AAAA0001", LocalDate.of(2026, 8, 1));
+        Battle ongoing = battle("AAAA0002", LocalDate.of(2026, 8, 2));
+        ongoing.start();
+        battleRepository.saveAndFlush(ongoing);
+        battleParticipantRepository.save(BattleParticipant.of(me, ready));
+        battleParticipantRepository.save(BattleParticipant.of(me, ongoing));
+
+        List<BattleParticipant> result = battleParticipantRepository.findMyParticipations(me.getId(), BattleStatus.READY);
+
+        assertThat(result).extracting(p -> p.getBattle().getId()).containsExactly(ready.getId());
+    }
+}

--- a/src/test/java/Hampouch/server/domain/battle/repository/BattleRepositoryTest.java
+++ b/src/test/java/Hampouch/server/domain/battle/repository/BattleRepositoryTest.java
@@ -1,0 +1,61 @@
+package Hampouch.server.domain.battle.repository;
+
+import Hampouch.server.domain.battle.entity.Battle;
+import Hampouch.server.domain.user.entity.User;
+import Hampouch.server.domain.user.repository.UserRepository;
+import Hampouch.server.global.config.ClockConfig;
+import Hampouch.server.global.config.JpaAuditingConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * battleCode 존재 여부 조회와 uq_battle_code 유니크 제약을 H2에 실제 적용해 검증 —
+ * BattleCodeGenerator의 충돌 재시도 판단이 여기 의존한다.
+ */
+@DataJpaTest
+@Import({ClockConfig.class, JpaAuditingConfig.class})
+class BattleRepositoryTest {
+
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    BattleRepository battleRepository;
+
+    private User creator;
+
+    @BeforeEach
+    void setUp() {
+        creator = userRepository.save(User.createLocalUser("creator@hampouch.com", "encoded", "creator"));
+    }
+
+    @Test
+    @DisplayName("existsByBattleCode는 저장된 코드는 true, 그 외는 false를 반환한다")
+    void existsByBattleCode_reflectsSavedCode() {
+        battleRepository.save(Battle.of("ABCD1234", "짠테크 배틀", 4, 7,
+                LocalDate.of(2026, 8, 1), "치킨 사주기", creator));
+
+        assertThat(battleRepository.existsByBattleCode("ABCD1234")).isTrue();
+        assertThat(battleRepository.existsByBattleCode("ZZZZ9999")).isFalse();
+    }
+
+    @Test
+    @DisplayName("battle_code 유니크 제약이 걸려 있어 같은 코드로 두 번째 배틀을 저장하면 데이터베이스가 거절한다")
+    void battleCode_uniqueConstraintRejectsDuplicate() {
+        battleRepository.saveAndFlush(Battle.of("ABCD1234", "짠테크 배틀", 4, 7,
+                LocalDate.of(2026, 8, 1), "치킨 사주기", creator));
+
+        assertThatThrownBy(() -> battleRepository.saveAndFlush(Battle.of("ABCD1234", "다른 배틀", 3, 3,
+                LocalDate.of(2026, 8, 2), "커피 사주기", creator)))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+}

--- a/src/test/java/Hampouch/server/domain/battle/service/BattleCodeGeneratorTest.java
+++ b/src/test/java/Hampouch/server/domain/battle/service/BattleCodeGeneratorTest.java
@@ -1,0 +1,57 @@
+package Hampouch.server.domain.battle.service;
+
+import Hampouch.server.domain.battle.repository.BattleRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * battleCode 충돌 재시도/한도 초과 처리 검증. SecureRandom이 실제로 뽑는 값 자체는 검증 대상이
+ * 아니라 existsByBattleCode 응답에 따른 재시도 분기만 목으로 확인한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class BattleCodeGeneratorTest {
+
+    @Mock
+    BattleRepository battleRepository;
+
+    @Test
+    @DisplayName("충돌이 없으면 첫 시도에서 8자리 코드를 바로 반환한다")
+    void generate_returnsOnFirstTryWhenNoCollision() {
+        when(battleRepository.existsByBattleCode(anyString())).thenReturn(false);
+
+        String code = new BattleCodeGenerator(battleRepository).generate();
+
+        assertThat(code).hasSize(8);
+        verify(battleRepository, times(1)).existsByBattleCode(anyString());
+    }
+
+    @Test
+    @DisplayName("충돌이 나면 재시도해서 충돌하지 않는 코드가 나올 때까지 계속한다")
+    void generate_retriesUntilNoCollision() {
+        when(battleRepository.existsByBattleCode(anyString()))
+                .thenReturn(true, true, false); // 두 번 충돌 후 세 번째에 성공
+
+        String code = new BattleCodeGenerator(battleRepository).generate();
+
+        assertThat(code).hasSize(8);
+        verify(battleRepository, times(3)).existsByBattleCode(anyString());
+    }
+
+    @Test
+    @DisplayName("MAX_ATTEMPTS(5회) 내내 충돌하면 재시도를 포기하고 IllegalStateException을 던진다")
+    void generate_throwsWhenAttemptsExhausted() {
+        when(battleRepository.existsByBattleCode(anyString())).thenReturn(true);
+
+        assertThatThrownBy(() -> new BattleCodeGenerator(battleRepository).generate())
+                .isInstanceOf(IllegalStateException.class);
+        verify(battleRepository, times(5)).existsByBattleCode(anyString());
+    }
+}

--- a/src/test/java/Hampouch/server/domain/battle/service/BattleServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/battle/service/BattleServiceTest.java
@@ -1,0 +1,192 @@
+package Hampouch.server.domain.battle.service;
+
+import Hampouch.server.domain.battle.dto.BattleListResponse;
+import Hampouch.server.domain.battle.dto.BattleSummary;
+import Hampouch.server.domain.battle.dto.CreateBattleRequest;
+import Hampouch.server.domain.battle.dto.CreateBattleResponse;
+import Hampouch.server.domain.battle.entity.Battle;
+import Hampouch.server.domain.battle.entity.BattleParticipant;
+import Hampouch.server.domain.battle.entity.BattleStatus;
+import Hampouch.server.domain.battle.repository.BattleParticipantRepository;
+import Hampouch.server.domain.battle.repository.BattleRepository;
+import Hampouch.server.domain.user.entity.User;
+import Hampouch.server.domain.user.repository.UserRepository;
+import Hampouch.server.global.common.exception.CustomException;
+import Hampouch.server.global.common.exception.domain.BattleErrorCode;
+import Hampouch.server.global.common.exception.domain.CommonErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * 생성 검증 로직 + 상태별 카드 매핑 검증. 리포지토리는 Mockito 목 — DB 불필요(ExpenseServiceTest와 동일 스타일).
+ */
+@ExtendWith(MockitoExtension.class)
+class BattleServiceTest {
+
+    private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
+    private static final Long OWNER = 1L;
+
+    @Mock
+    BattleRepository battleRepository;
+    @Mock
+    BattleParticipantRepository battleParticipantRepository;
+    @Mock
+    UserRepository userRepository;
+    @Mock
+    BattleCodeGenerator battleCodeGenerator;
+
+    private BattleService serviceAt(LocalDate today) {
+        Clock clock = Clock.fixed(today.atTime(12, 0).atZone(SEOUL).toInstant(), SEOUL);
+        return new BattleService(battleRepository, battleParticipantRepository, userRepository, battleCodeGenerator, clock);
+    }
+
+    private static User user(Long id) {
+        User user = User.createLocalUser("user" + id + "@hampouch.com", "encoded", "user" + id);
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    private static CreateBattleRequest request(int capacity, int durationDays, LocalDate startDate) {
+        return new CreateBattleRequest("짠테크 배틀", capacity, durationDays, startDate, "치킨 사주기");
+    }
+
+    // ---------- create ----------
+
+    @Test
+    @DisplayName("capacity가 2 미만이면 400(INVALID_CAPACITY_RANGE)을 던진다")
+    void create_rejectsCapacityBelowMin() {
+        assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 7, 1)).create(OWNER, request(1, 7, LocalDate.of(2026, 8, 1))))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", BattleErrorCode.INVALID_CAPACITY_RANGE);
+        verifyNoInteractions(battleRepository, battleCodeGenerator);
+    }
+
+    @Test
+    @DisplayName("capacity가 10 초과면 400(INVALID_CAPACITY_RANGE)을 던진다")
+    void create_rejectsCapacityAboveMax() {
+        assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 7, 1)).create(OWNER, request(11, 7, LocalDate.of(2026, 8, 1))))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", BattleErrorCode.INVALID_CAPACITY_RANGE);
+    }
+
+    @Test
+    @DisplayName("durationDays가 3/7/14/31이 아니면 400(VALIDATION_ERROR)을 던진다")
+    void create_rejectsInvalidDuration() {
+        assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 7, 1)).create(OWNER, request(4, 10, LocalDate.of(2026, 8, 1))))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", CommonErrorCode.VALIDATION_ERROR);
+    }
+
+    @Test
+    @DisplayName("startDate가 오늘보다 이전이면 400(INVALID_START_DATE)을 던진다")
+    void create_rejectsPastStartDate() {
+        assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 7, 10)).create(OWNER, request(4, 7, LocalDate.of(2026, 7, 9))))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", BattleErrorCode.INVALID_START_DATE);
+    }
+
+    @Test
+    @DisplayName("startDate가 오늘이면 통과한다 — 과거만 막고 오늘은 막지 않는다")
+    void create_allowsStartDateToday() {
+        when(userRepository.getReferenceById(OWNER)).thenReturn(user(OWNER));
+        when(battleCodeGenerator.generate()).thenReturn("ABCD1234");
+        when(battleRepository.save(any(Battle.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        CreateBattleResponse res = serviceAt(LocalDate.of(2026, 7, 10))
+                .create(OWNER, request(4, 7, LocalDate.of(2026, 7, 10)));
+
+        assertThat(res.startDate()).isEqualTo(LocalDate.of(2026, 7, 10));
+    }
+
+    @Test
+    @DisplayName("생성에 성공하면 battleCode를 발급받아 저장하고, 생성자를 첫 참가자로 자동 등록한다")
+    void create_generatesCodeAndRegistersCreatorAsParticipant() {
+        when(userRepository.getReferenceById(OWNER)).thenReturn(user(OWNER));
+        when(battleCodeGenerator.generate()).thenReturn("ABCD1234");
+        ArgumentCaptor<Battle> battleCaptor = ArgumentCaptor.forClass(Battle.class);
+        when(battleRepository.save(battleCaptor.capture())).thenAnswer(inv -> inv.getArgument(0));
+        ArgumentCaptor<BattleParticipant> participantCaptor = ArgumentCaptor.forClass(BattleParticipant.class);
+        when(battleParticipantRepository.save(participantCaptor.capture())).thenAnswer(inv -> inv.getArgument(0));
+
+        CreateBattleResponse res = serviceAt(LocalDate.of(2026, 7, 1))
+                .create(OWNER, request(4, 7, LocalDate.of(2026, 8, 1)));
+
+        assertThat(battleCaptor.getValue().getBattleCode()).isEqualTo("ABCD1234");
+        assertThat(participantCaptor.getValue().getBattle()).isSameAs(battleCaptor.getValue());
+        assertThat(participantCaptor.getValue().getUser().getId()).isEqualTo(OWNER);
+        assertThat(res.battleCode()).isEqualTo("ABCD1234");
+        assertThat(res.status()).isEqualTo(BattleStatus.READY);
+        assertThat(res.endDate()).isEqualTo(LocalDate.of(2026, 8, 7)); // 8/1 + (7일 - 1)
+    }
+
+    // ---------- getMyBattles ----------
+
+    @Test
+    @DisplayName("status 필터를 그대로 리포지토리에 전달한다")
+    void getMyBattles_passesStatusFilterThrough() {
+        when(battleParticipantRepository.findMyParticipations(OWNER, BattleStatus.READY)).thenReturn(List.of());
+
+        serviceAt(LocalDate.of(2026, 7, 1)).getMyBattles(OWNER, BattleStatus.READY);
+
+        verify(battleParticipantRepository).findMyParticipations(OWNER, BattleStatus.READY);
+    }
+
+    @Test
+    @DisplayName("READY 배틀은 capacity와 joinedCount(참가자 수)가 함께 담긴 카드로 매핑된다")
+    void getMyBattles_mapsReadyWithJoinedCount() {
+        Battle battle = Battle.of("ABCD1234", "짠테크 배틀", 4, 7, LocalDate.of(2026, 8, 1), "치킨 사주기", user(OWNER));
+        ReflectionTestUtils.setField(battle, "id", 10L);
+        BattleParticipant participation = BattleParticipant.of(user(OWNER), battle);
+        when(battleParticipantRepository.findMyParticipations(OWNER, null)).thenReturn(List.of(participation));
+        when(battleParticipantRepository.countByBattle_Id(10L)).thenReturn(3);
+
+        BattleListResponse res = serviceAt(LocalDate.of(2026, 7, 1)).getMyBattles(OWNER, null);
+
+        BattleSummary.Ready summary = (BattleSummary.Ready) res.battles().get(0);
+        assertThat(summary.capacity()).isEqualTo(4);
+        assertThat(summary.joinedCount()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("ONGOING 배틀은 현재 today/total 실시간 집계가 없어 참가자 목록이 빈 리스트로 나간다 (③에서 구현 예정)")
+    void getMyBattles_mapsOngoingWithEmptyParticipants() {
+        Battle battle = Battle.of("ABCD1234", "짠테크 배틀", 4, 7, LocalDate.of(2026, 8, 1), "치킨 사주기", user(OWNER));
+        battle.start();
+        BattleParticipant participation = BattleParticipant.of(user(OWNER), battle);
+        when(battleParticipantRepository.findMyParticipations(OWNER, null)).thenReturn(List.of(participation));
+
+        BattleListResponse res = serviceAt(LocalDate.of(2026, 7, 1)).getMyBattles(OWNER, null);
+
+        BattleSummary.Ongoing summary = (BattleSummary.Ongoing) res.battles().get(0);
+        assertThat(summary.participants()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("TERMINATED 배틀은 승자 요약 카드로 매핑된다 (winnerNickname은 현재 스텁 null)")
+    void getMyBattles_mapsTerminated() {
+        Battle battle = Battle.of("ABCD1234", "짠테크 배틀", 4, 7, LocalDate.of(2026, 8, 1), "치킨 사주기", user(OWNER));
+        battle.start();
+        battle.terminate(user(2L));
+        BattleParticipant participation = BattleParticipant.of(user(OWNER), battle);
+        when(battleParticipantRepository.findMyParticipations(OWNER, null)).thenReturn(List.of(participation));
+
+        BattleListResponse res = serviceAt(LocalDate.of(2026, 7, 1)).getMyBattles(OWNER, null);
+
+        assertThat(res.battles().get(0)).isInstanceOf(BattleSummary.Terminated.class);
+    }
+}


### PR DESCRIPTION
## 📎연관된 이슈

- close: #43

## 📄 작업 내용 요약

- `Battle/BattleParticipant` 엔티티 정의 및 상태 전이(`READY→ONGOING→TERMINATED`, `READY→CANCELLED`), 정의만, 변경 condition은 차후 issue
- battleCode 발급 로직(`BattleCodeGenerator`, `SecureRandom` 충돌 시 재시도 후 `IllegalStateException`)
- `POST /api/battles` — `capacity/durationDays/startDate` 검증, `endDate` 계산, 햄배틀 생성자 자동 첫 참가자 등록
- `GET /api/battles` — `@LoginUserId` 기준 내 배틀만, `status` 필터, `READY/ONGOING/TERMINATED` 카드 shape 분기
- 정렬 `startDate DESC, battleId DESC` 고정
- 단위 테스트 6개 파일 추가(엔티티 2, 서비스 2, 리포지토리 2) — 로컬에서 291개 전체 통과 확인

## 👀 중요 변경 사항

- `ONGOING` 카드의 참가자별 `today/total` 집계는 아직 미구현 — 빈 리스트로 응답(상세조회/랭킹 이슈에서 실제 집계 예정). 이 상태로는 어떤 배틀도 구조적으로 `ONGOING`에 도달할 수 없어 잘못된 값이 나갈 위험은 없음
- `durationDays` 검증은 전용 `BattleErrorCode` 없이 `CommonErrorCode.VALIDATION_ERROR` + 커스텀 메시지로 처리 — 필요하면 전용 코드로 승격 예정
- `BattleSummary`는 `sealed interface(Ready/Ongoing/Terminated)`로 `CANCELLED` variant는 아직 없음 — 배치 전엔 도달 불가능한 상태라 `toSummary()`에서 `IllegalStateException`으로 명시적으로 막아둠

## 🔖 Uncompleted Tasks

- 참가 링크 조회/참가 API
- 상세 조회 및 랭킹 API(ONGOING 실시간 집계 포함)
- 자동 취소·무효화·종료 스냅샷 배치
- `BattleSummary.CANCELLED` 카드 shape 정의

## 📢 To Reviewers

- `Battle.of()`는 `startDate` null 가드만 남기고 `capacity/durationDays/creator` 검증은 서비스 계층으로 위임했습니다 — 이 경계가 맞는지 봐주세요
- `BattleParticipant.of()`는 계산에 쓰이는 값이 없어 null 가드 자체가 없습니다