### PR TITLE
[Chore]: s3 세팅 및 관련 업로드 코드

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,8 @@ MAIL_PASSWORD=앱 비밀번호(카톡 참고)
 
 GOOGLE_CLIENT_ID=구글 ID(카톡 참고)
 KAKAO_REST_API_KEY=카카오 ID(카톡 참고)
+
+AWS_S3_BUCKET=hampouch-images
+AWS_S3_REGION=ap-northeast-2
+AWS_ACCESS_KEY=access-key(카톡참고)
+AWS_SECRET_KEY=secret-key(카톡참고)

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,10 @@ dependencies {
 
 	//google ID 토큰 검증
 	implementation 'com.google.api-client:google-api-client:2.7.0'
+
+	//s3
+	implementation platform('software.amazon.awssdk:bom:2.28.11')
+	implementation 'software.amazon.awssdk:s3'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,10 @@ services:
       MAIL_PASSWORD: ${MAIL_PASSWORD}
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
       KAKAO_REST_API_KEY: ${KAKAO_REST_API_KEY}
+      AWS_S3_BUCKET: ${AWS_S3_BUCKET}
+      AWS_S3_REGION: ${AWS_S3_REGION}
+      AWS_ACCESS_KEY: ${AWS_ACCESS_KEY}
+      AWS_SECRET_KEY: ${AWS_SECRET_KEY}
 
 #docker compose down을 해도 DB 데이터가 남아있도록 볼륨 정의
 #DB 데이터까지 지우고 싶다면 docker compose down -v

--- a/src/main/java/Hampouch/server/domain/community/controller/ImagePresignController.java
+++ b/src/main/java/Hampouch/server/domain/community/controller/ImagePresignController.java
@@ -1,0 +1,32 @@
+package Hampouch.server.domain.community.controller;
+
+import Hampouch.server.domain.community.dto.request.PresignRequest;
+import Hampouch.server.domain.community.dto.response.PresignResponse;
+import Hampouch.server.domain.community.service.ImagePresignService;
+import Hampouch.server.global.common.response.ApiResponse;
+import Hampouch.server.global.security.LoginUserId;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/community/images")
+@RequiredArgsConstructor
+public class ImagePresignController {
+
+    private final ImagePresignService imagePresignService;
+
+    // 커뮤니티용 이미지 presigned url 일괄 발급
+    @PostMapping("/presign")
+    public ResponseEntity<ApiResponse<PresignResponse>> presign(
+            @LoginUserId Long userId,
+            @RequestBody @Valid PresignRequest request
+    ) {
+        PresignResponse response = imagePresignService.presign(request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/Hampouch/server/domain/community/dto/request/PresignRequest.java
+++ b/src/main/java/Hampouch/server/domain/community/dto/request/PresignRequest.java
@@ -1,0 +1,34 @@
+package Hampouch.server.domain.community.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record PresignRequest(
+
+        @NotEmpty(message = "이미지는 최소 1장 이상 등록해야 합니다.")
+        @Size(max = 5, message = "이미지는 최대 5장까지 등록할 수 있습니다.")
+        @Valid
+        List<FileInfo> files
+) {
+    public record FileInfo(
+
+            @NotBlank(message = "파일 형식은 필수입니다.")
+            @Pattern(
+                    regexp = "image/(jpeg|png|jpg|webp)",
+                    message = "지원하지 않는 이미지 형식입니다."
+            )
+            String contentType,
+
+            @NotNull(message = "파일 크기는 필수입니다.")
+            @Positive(message = "파일 크기는 0보다 커야 합니다.")
+            Long size
+    ) {
+    }
+}

--- a/src/main/java/Hampouch/server/domain/community/dto/response/PresignResponse.java
+++ b/src/main/java/Hampouch/server/domain/community/dto/response/PresignResponse.java
@@ -1,0 +1,21 @@
+package Hampouch.server.domain.community.dto.response;
+
+import java.util.List;
+
+public record PresignResponse(
+        List<FileResult> files
+) {
+    public static PresignResponse of(List<FileResult> files) {
+        return new PresignResponse(files);
+    }
+
+    public record FileResult(
+            String uploadUrl,
+            String imageKey,
+            String imageUrl
+    ) {
+        public static FileResult of(String uploadUrl, String imageKey, String imageUrl) {
+            return new FileResult(uploadUrl, imageKey, imageUrl);
+        }
+    }
+}

--- a/src/main/java/Hampouch/server/domain/community/service/ImagePresignService.java
+++ b/src/main/java/Hampouch/server/domain/community/service/ImagePresignService.java
@@ -29,6 +29,9 @@ public class ImagePresignService {
     private static final String KEY_PREFIX = "community/posts/";
     private static final Duration UPLOAD_URL_EXPIRATION = Duration.ofMinutes(10);
 
+    //임시 상한 - 10MB
+    private static final long MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10MB
+
     private final S3Presigner s3Presigner;
 
     @Value("${aws.s3.bucket}")
@@ -46,6 +49,8 @@ public class ImagePresignService {
     }
 
     private PresignResponse.FileResult presignSingleFile(PresignRequest.FileInfo fileInfo) {
+        validateFileSize(fileInfo.size());
+
         String extension = resolveExtension(fileInfo.contentType());
         String imageKey = KEY_PREFIX + UUID.randomUUID() + extension;
 
@@ -54,6 +59,7 @@ public class ImagePresignService {
                     .bucket(bucket)
                     .key(imageKey)
                     .contentType(fileInfo.contentType())
+                    .contentLength(fileInfo.size())
                     .build();
 
             PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
@@ -68,8 +74,18 @@ public class ImagePresignService {
 
             return PresignResponse.FileResult.of(uploadUrl, imageKey, imageUrl);
         } catch (Exception e) {
-            log.error("presigned URL 발급 실패: contentType={}", fileInfo.contentType(), e);
+            log.error("presigned URL 발급 실패: contentType={}, size={}", fileInfo.contentType(), fileInfo.size(), e);
             throw new CustomException(CommunityErrorCode.COMMUNITY_IMAGE_UPLOAD_FAILED);
+        }
+    }
+
+    /**
+     * 실제 업로드 시 S3가 이 크기와 정확히 일치하는지 검증
+     * 애초에 너무 큰 파일에 대한 URL 발급 자체를 막는다
+     */
+    private void validateFileSize(Long size) {
+        if (size > MAX_FILE_SIZE_BYTES) {
+            throw new CustomException(CommunityErrorCode.COMMUNITY_IMAGE_SIZE_EXCEEDED);
         }
     }
 

--- a/src/main/java/Hampouch/server/domain/community/service/ImagePresignService.java
+++ b/src/main/java/Hampouch/server/domain/community/service/ImagePresignService.java
@@ -1,0 +1,89 @@
+package Hampouch.server.domain.community.service;
+
+import Hampouch.server.domain.community.dto.request.PresignRequest;
+import Hampouch.server.domain.community.dto.response.PresignResponse;
+import Hampouch.server.global.common.exception.CustomException;
+import Hampouch.server.global.common.exception.domain.CommunityErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 커뮤니티 게시글용 이미지 presigned URL 발급
+ * 프론트에서 이 URL로 S3에 직접 PUT 업로드하고, 서버는 URL 발급만 담당한다
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ImagePresignService {
+
+    private static final String KEY_PREFIX = "community/posts/";
+    private static final Duration UPLOAD_URL_EXPIRATION = Duration.ofMinutes(10);
+
+    private final S3Presigner s3Presigner;
+
+    @Value("${aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${aws.s3.region}")
+    private String region;
+
+    public PresignResponse presign(PresignRequest request) {
+        List<PresignResponse.FileResult> results = request.files().stream()
+                .map(this::presignSingleFile)
+                .toList();
+
+        return PresignResponse.of(results);
+    }
+
+    private PresignResponse.FileResult presignSingleFile(PresignRequest.FileInfo fileInfo) {
+        String extension = resolveExtension(fileInfo.contentType());
+        String imageKey = KEY_PREFIX + UUID.randomUUID() + extension;
+
+        try {
+            PutObjectRequest objectRequest = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(imageKey)
+                    .contentType(fileInfo.contentType())
+                    .build();
+
+            PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+                    .signatureDuration(UPLOAD_URL_EXPIRATION)
+                    .putObjectRequest(objectRequest)
+                    .build();
+
+            PresignedPutObjectRequest presignedRequest = s3Presigner.presignPutObject(presignRequest);
+
+            String uploadUrl = presignedRequest.url().toString();
+            String imageUrl = buildPublicUrl(imageKey);
+
+            return PresignResponse.FileResult.of(uploadUrl, imageKey, imageUrl);
+        } catch (Exception e) {
+            log.error("presigned URL 발급 실패: contentType={}", fileInfo.contentType(), e);
+            throw new CustomException(CommunityErrorCode.COMMUNITY_IMAGE_UPLOAD_FAILED);
+        }
+    }
+
+    /** 버킷이 퍼블릭 읽기를 허용하므로, 업로드 후 그대로 접근 가능한 조회용 URL을 S3의 표준 URL 형식으로 직접 조합 (서명 불필요, 만료 없음) */
+    private String buildPublicUrl(String imageKey) {
+        return "https://" + bucket + ".s3." + region + ".amazonaws.com/" + imageKey;
+    }
+
+    private String resolveExtension(String contentType) {
+        return switch (contentType) {
+            case "image/jpeg", "image/jpg" -> ".jpg";
+            case "image/png" -> ".png";
+            case "image/webp" -> ".webp";
+            default -> throw new CustomException(CommunityErrorCode.COMMUNITY_IMAGE_UPLOAD_FAILED);
+        };
+    }
+}

--- a/src/main/java/Hampouch/server/global/common/exception/domain/CommunityErrorCode.java
+++ b/src/main/java/Hampouch/server/global/common/exception/domain/CommunityErrorCode.java
@@ -1,4 +1,17 @@
 package Hampouch.server.global.common.exception.domain;
 
-public class CommunityErrorCode {
+import Hampouch.server.global.common.exception.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommunityErrorCode implements BaseErrorCode {
+
+    COMMUNITY_IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "COMMUNITY_IMAGE_UPLOAD_FAILED", "이미지 업로드 처리 중 오류가 발생했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
 }

--- a/src/main/java/Hampouch/server/global/common/exception/domain/CommunityErrorCode.java
+++ b/src/main/java/Hampouch/server/global/common/exception/domain/CommunityErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum CommunityErrorCode implements BaseErrorCode {
 
-    COMMUNITY_IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "COMMUNITY_IMAGE_UPLOAD_FAILED", "이미지 업로드 처리 중 오류가 발생했습니다.");
+    COMMUNITY_IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "COMMUNITY_IMAGE_UPLOAD_FAILED", "이미지 업로드 처리 중 오류가 발생했습니다."),
+    COMMUNITY_IMAGE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "COMMUNITY_IMAGE_SIZE_EXCEEDED", "이미지 크기는 최대 10MB까지 등록할 수 있습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/Hampouch/server/global/config/S3Config.java
+++ b/src/main/java/Hampouch/server/global/config/S3Config.java
@@ -1,0 +1,36 @@
+package Hampouch.server.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+/**
+ * S3 presigned URL 발급을 위한 클라이언트 설정.
+ * 실제 업로드/다운로드는 프론트에서 presigned URL로 S3에 직접 수행하고, 서버는 그 URL을 만들어주는 역할만 한다
+ */
+@Configuration
+public class S3Config {
+
+    @Value("${aws.s3.region}")
+    private String region;
+
+    @Value("${aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
+
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,3 +45,11 @@ oauth:
     client-id: ${GOOGLE_CLIENT_ID}
   kakao:
     rest-api-key: ${KAKAO_REST_API_KEY}
+
+aws:
+  s3:
+    bucket: ${AWS_S3_BUCKET}
+    region: ${AWS_S3_REGION}
+  credentials:
+    access-key: ${AWS_ACCESS_KEY}
+    secret-key: ${AWS_SECRET_KEY}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -41,3 +41,11 @@ oauth:
     client-id: test-client-id.apps.googleusercontent.com
   kakao:
     rest-api-key: test-rest-api-key
+
+aws:
+  s3:
+    bucket: test-bucket
+    region: ap-northeast-2
+  credentials:
+    access-key: test-access-key
+    secret-key: test-secret-key


### PR DESCRIPTION
## 📎연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) closes #[issue number]

- close: #54

## 📄 작업 내용 요약
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
- aws S3 설정
- S3Presigner 빈 설정 (S3Config)
- S3 presigned URL 발급 API 구현

## 👀 중요 변경 사항
> API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요
- S3 버킷은 커뮤니티/지출 도메인 공용으로 사용합니다. prefix로 도메인을 구분하니 다른 도메인에서 사용 시 다른 prefix를 사용해주세요. (커뮤니티는 community/posts/{uuid}.{ext} 형태)
- 버킷은 퍼블릭 읽기를 허용하는 상태입니다. presign으로 발급하는 `uploadUrl`(PUT)과 달리, `imageUrl`(조회용)은 만료 없는 일반 URL이며 인증 없이 누구나 접근 가능합니다.
- presigned URL로 S3에 업로드할 때는 Authorization 헤더를 포함하면 안 됩니다. (인증 방식 중복)

## 🔖 Uncompleted Tasks
> 후속 작업 예정인 사항이 있다면 작성해주세요.
- 이미지 파일 크기 상한 검증 -> 논의 필요

## 📢 To Reviewers
> Reviewer가 주로 확인해주었으면 하는 부분을 적어주세요.
- S3 presigned URL 발급 흐름(POST /images/presign → 클라이언트가 uploadUrl로 S3에 직접 PUT)
  - 이미지 업로드가 필요하면 이 방식과 ImagePresignService 구조를 참고해서 접두어만 다르게 재사용하면 될 것 같습니다.