### PR TITLE
fix: 챌린지 성패 판정을 초과일 유무에서 기간 총액 기준으로 전환

### DIFF
--- a/src/main/java/Hampouch/server/domain/challenge/entity/ChallengeStatus.java
+++ b/src/main/java/Hampouch/server/domain/challenge/entity/ChallengeStatus.java
@@ -3,8 +3,8 @@ package Hampouch.server.domain.challenge.entity;
 /**
  * 챌린지 전체 상태.
  * - IN_PROGRESS: 생성 직후, 진행 중
- * - SUCCESS: 종료(end_date 경과) 후 모든 날 성공
- * - FAIL: 종료 후 초과한 날 1일 이상
+ * - SUCCESS: 종료(end_date 경과) 후 기간 총지출 ≤ 목표(budgetTotal) — 하루 한도를 넘긴 날이 있어도 무관(0727 PM 확정)
+ * - FAIL: 종료 후 총지출 > 목표, 또는 중도 포기(EndReason.GIVEN_UP — 이쪽은 계산이 아니라 유저 선언)
  */
 public enum ChallengeStatus {
     IN_PROGRESS,

--- a/src/main/java/Hampouch/server/domain/challenge/entity/DayStatus.java
+++ b/src/main/java/Hampouch/server/domain/challenge/entity/DayStatus.java
@@ -3,7 +3,8 @@ package Hampouch.server.domain.challenge.entity;
 /**
  * 하루 단위 판정 결과: 그날 지출 합계 ≤ 하루 한도 이면 SUCCESS, 아니면 OVER.
  * FAIL이 아니라 OVER인 이유: "실패"는 챌린지 전체의 결말(ChallengeStatus.FAIL)에만 쓰는 말 —
- * 하루는 "한도를 넘었다"는 사실만 기록하고, OVER 1일 이상이면 챌린지가 FAIL로 판정된다.
+ * 하루는 "한도를 넘었다"는 사실만 기록한다. 챌린지 성패는 기간 총지출로만 정해지므로(0727 PM 확정)
+ * OVER는 달력 표시·overDays 집계에만 쓰이고 성패를 가르지 않는다.
  */
 public enum DayStatus {
     SUCCESS,

--- a/src/main/java/Hampouch/server/domain/challenge/service/ChallengeCalculator.java
+++ b/src/main/java/Hampouch/server/domain/challenge/service/ChallengeCalculator.java
@@ -18,7 +18,7 @@ import java.util.Map;
  * 일별 판정  = spent ≤ dailyLimit ? SUCCESS : OVER
  * savedAmount = Σ max(0, dailyLimit − spent)
  * overAmount  = Σ max(0, spent − dailyLimit)
- * 결과 status = OVER 1일+ 이면 FAIL, 아니면 SUCCESS
+ * 결과 status = 기간 총지출(actualSpent) ≤ budgetTotal 이면 SUCCESS, 넘으면 FAIL (0727 PM 확정 — 일별 OVER는 성패와 무관)
  * GOAL_TOO_TIGHT = 판정 완료 구간 마지막 3일 연속 초과
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE) // 엔티티의 PROTECTED와 반대 용도 — 아무도 호출하지 않는 자물쇠. 자동 public 생성자를 차단해 정적 유틸의 인스턴스화 방지
@@ -138,10 +138,13 @@ public final class ChallengeCalculator {
         return streak;
     }
 
-    /** 종료 결과 status: 초과한 날 1일 이상이면 FAIL, 전부 성공이면 SUCCESS. */
-    public static ChallengeStatus resultStatus(List<ChallengeDay> days) {
-        boolean anyOver = days.stream().anyMatch(d -> d.getStatus() == DayStatus.OVER);
-        return anyOver ? ChallengeStatus.FAIL : ChallengeStatus.SUCCESS;
+    /**
+     * 종료 결과 status: 기간 총지출이 목표를 넘으면 FAIL, 이하면 SUCCESS(같으면 SUCCESS — 0727 PM 확정).
+     * 일별 초과(OVER)는 달력 표시·overDays 집계로만 남고 성패를 가르지 않는다.
+     * actualSpent는 summarizeForResult가 만든 값을 넘길 것 — 판정 근거와 응답의 총액이 같은 계산이어야 한다.
+     */
+    public static ChallengeStatus resultStatus(int actualSpent, int budgetTotal) {
+        return actualSpent > budgetTotal ? ChallengeStatus.FAIL : ChallengeStatus.SUCCESS;
     }
 
 }

--- a/src/main/java/Hampouch/server/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/Hampouch/server/domain/challenge/service/ChallengeService.java
@@ -188,18 +188,19 @@ public class ChallengeService {
         Challenge c = loadOwned(userId, challengeId);
         List<ChallengeDay> days = challengeDayRepository.findByChallenge_Id(challengeId);
 
+        // 결과는 기간 전체 기준 — 미입력일 = 0원 SUCCESS 간주(0630 확정, 명세 §4).
+        // 확정보다 먼저 계산하는 이유: 총액 판정의 입력이 이 집계의 actualSpent다(판정 근거 = 응답 값).
+        ChallengeSummary s = ChallengeCalculator.summarizeForResult(
+                days, c.getDailyLimit(), c.getStartDate(), c.getEndDate());
+
         if (c.isInProgress()) {
             LocalDate today = LocalDate.now(clock);
             if (!today.isAfter(c.getEndDate())) {
                 throw new CustomException(ChallengeErrorCode.CHALLENGE_NOT_ENDED);
             }
-            // 기록 0건이어도 그대로 확정(0714 PM: 성공 처리) — 미입력일=0원=성공 규칙이라 전일 미입력이면 SUCCESS.
-            c.applyResult(ChallengeCalculator.resultStatus(days)); // end_date 경과 → 최초 계산 시 저장(배치 없음)
+            // 기록 0건이어도 그대로 확정(0714 PM: 성공 처리) — 총지출 0원 ≤ 목표라 SUCCESS.
+            c.applyResult(ChallengeCalculator.resultStatus(s.actualSpent(), c.getBudgetTotal())); // end_date 경과 → 최초 계산 시 저장(배치 없음)
         }
-
-        // 결과는 기간 전체 기준 — 미입력일 = 0원 SUCCESS 간주(0630 확정, 명세 §4)
-        ChallengeSummary s = ChallengeCalculator.summarizeForResult(
-                days, c.getDailyLimit(), c.getStartDate(), c.getEndDate());
         var period = ResultResponse.Period.from(c);
         var summary = new ResultResponse.Summary(
                 s.successDays(), s.overDays(), s.savedAmount(), s.overAmount(),
@@ -227,9 +228,13 @@ public class ChallengeService {
                         ChallengeDay.of(c, req.date(), req.spentAmount(), status)));
 
         // 종료 확정 후 기간 내 지출을 고치면 결과도 다시 계산한다. 단 중도 포기의 FAIL은 유저 선언이라 제외 —
-        // 빼지 않으면 "포기했는데 지출을 고쳤더니 기록상 전부 성공이라 SUCCESS로 부활"한다. 기록 수정 자체는 포기 챌린지도 허용이고, 막는 건 재계산뿐.
+        // 빼지 않으면 "포기했는데 지출을 고쳤더니 총지출이 예산 이하라 SUCCESS로 부활"한다(총액 규칙에선 중도 포기가
+        // 거의 항상 예산 이하라 이 가드가 사실상 유일한 방어선). 기록 수정 자체는 포기 챌린지도 허용이고, 막는 건 재계산뿐.
         if (!c.isInProgress() && c.getEndReason() != EndReason.GIVEN_UP) {
-            c.applyResult(ChallengeCalculator.resultStatus(challengeDayRepository.findByChallenge_Id(challengeId)));
+            ChallengeSummary s = ChallengeCalculator.summarizeForResult(
+                    challengeDayRepository.findByChallenge_Id(challengeId),
+                    c.getDailyLimit(), c.getStartDate(), c.getEndDate());
+            c.applyResult(ChallengeCalculator.resultStatus(s.actualSpent(), c.getBudgetTotal()));
         }
 
         return new DayUpsertResponse(day.getDayDate(), day.getSpentAmount(), dailyLimit, day.getStatus());
@@ -328,8 +333,10 @@ public class ChallengeService {
      */
     private void finalizeIfExpired(Challenge c) {
         if (c.isInProgress() && isExpired(c)) {
-            c.applyResult(ChallengeCalculator.resultStatus(
-                    challengeDayRepository.findByChallenge_Id(c.getId())));
+            ChallengeSummary s = ChallengeCalculator.summarizeForResult(
+                    challengeDayRepository.findByChallenge_Id(c.getId()),
+                    c.getDailyLimit(), c.getStartDate(), c.getEndDate());
+            c.applyResult(ChallengeCalculator.resultStatus(s.actualSpent(), c.getBudgetTotal()));
         }
     }
 

--- a/src/test/java/Hampouch/server/domain/challenge/service/ChallengeCalculatorTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/service/ChallengeCalculatorTest.java
@@ -16,7 +16,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * 판정·집계 공식 검증 (테스트시나리오_본챌린지.md S1~S4). 순수 로직 — Spring·DB 불필요.
+ * 판정·집계 공식 검증 (테스트시나리오_본챌린지.md). 순수 로직 — Spring·DB 불필요.
  */
 class ChallengeCalculatorTest {
 
@@ -42,12 +42,12 @@ class ChallengeCalculatorTest {
         assertThat(s.overAmount()).isZero();
         assertThat(s.maxStreak()).isEqualTo(14);
         assertThat(s.actualSpent()).isEqualTo(211800);
-        assertThat(ChallengeCalculator.resultStatus(days)).isEqualTo(ChallengeStatus.SUCCESS);
+        assertThat(ChallengeCalculator.resultStatus(s.actualSpent(), ch.getBudgetTotal())).isEqualTo(ChallengeStatus.SUCCESS);
     }
 
     @Test
-    @DisplayName("초과한 날이 하루라도 있으면 실패로 확정된다 — 초과액 24,100원은 (지출−한도)의 합, 최장 연속 성공은 초과 전 9일 (S2)")
-    void s2_fail() {
+    @DisplayName("하루 한도를 넘긴 날이 5일 있어도 총지출 259,100원이 목표 280,000원 이하라 성공이다 — 일별 초과는 overDays·초과액 집계로만 남는다")
+    void s2_totalWithinBudget_success() {
         int dailyLimit = 20000;
         List<ChallengeDay> days = new ArrayList<>();
         Challenge ch = challenge(dailyLimit);
@@ -64,7 +64,39 @@ class ChallengeCalculatorTest {
         assertThat(s.overDays()).isEqualTo(5);
         assertThat(s.overAmount()).isEqualTo(24100);
         assertThat(s.maxStreak()).isEqualTo(9);
-        assertThat(ChallengeCalculator.resultStatus(days)).isEqualTo(ChallengeStatus.FAIL);
+        assertThat(s.savedAmount()).isEqualTo(45000);   // 성공 9일 × (20,000−15,000) — 초과일은 0으로 클램프
+        assertThat(s.actualSpent()).isEqualTo(259100);  // 판정을 가르는 값 — PM이 확답에 든 예시 숫자 그대로
+        assertThat(ChallengeCalculator.resultStatus(s.actualSpent(), ch.getBudgetTotal())).isEqualTo(ChallengeStatus.SUCCESS);
+    }
+
+    @Test
+    @DisplayName("총지출 320,000원이 목표 280,000원을 넘으면 실패다 — 성공한 날이 10일로 더 많아도 성패는 총액만 본다")
+    void totalOverBudget_fail() {
+        int dailyLimit = 20000;
+        List<ChallengeDay> days = new ArrayList<>();
+        Challenge ch = challenge(dailyLimit);
+        for (int i = 0; i < 10; i++) {
+            days.add(day(ch, START.plusDays(i), 20000, dailyLimit)); // 성공 10일(정확히 한도)
+        }
+        for (int i = 0; i < 4; i++) {
+            days.add(day(ch, START.plusDays(10 + i), 30000, dailyLimit)); // 초과 4일
+        }
+
+        ChallengeSummary s = ChallengeCalculator.summarizeForResult(days, dailyLimit, START, START.plusDays(13));
+        assertThat(s.successDays()).isEqualTo(10);
+        assertThat(s.overDays()).isEqualTo(4);
+        assertThat(s.overAmount()).isEqualTo(40000);
+        assertThat(s.savedAmount()).isZero();
+        assertThat(s.maxStreak()).isEqualTo(10);
+        assertThat(s.actualSpent()).isEqualTo(320000);
+        assertThat(ChallengeCalculator.resultStatus(s.actualSpent(), ch.getBudgetTotal())).isEqualTo(ChallengeStatus.FAIL);
+    }
+
+    @Test
+    @DisplayName("총지출이 목표와 정확히 같으면 성공이고, 1원이라도 넘으면 실패다")
+    void resultStatus_boundary() {
+        assertThat(ChallengeCalculator.resultStatus(280000, 280000)).isEqualTo(ChallengeStatus.SUCCESS);
+        assertThat(ChallengeCalculator.resultStatus(280001, 280000)).isEqualTo(ChallengeStatus.FAIL);
     }
 
     @Test

--- a/src/test/java/Hampouch/server/domain/challenge/service/ChallengeServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/service/ChallengeServiceTest.java
@@ -173,9 +173,9 @@ class ChallengeServiceTest {
     }
 
     @Test
-    @DisplayName("SUCCESS로 확정된 뒤라도 기간 내 지출을 초과로 수정하면 결과가 FAIL로 재계산된다 (0714 PM)")
+    @DisplayName("SUCCESS로 확정된 뒤라도 기간 내 지출을 목표 총액이 넘게 수정하면 결과가 FAIL로 재계산된다")
     void upsertDay_recomputesFinalizedStatus() {
-        Challenge ch = inProgress(LocalDate.of(2026, 6, 1)); // 06-01~06-14, dailyLimit 20000
+        Challenge ch = inProgress(LocalDate.of(2026, 6, 1)); // 06-01~06-14, dailyLimit 20000, budgetTotal 280000
         ch.applyResult(ChallengeStatus.SUCCESS); // 이미 SUCCESS로 확정된 챌린지
         LocalDate date = LocalDate.of(2026, 6, 3);
         ChallengeDay existing = ChallengeDay.of(ch, date, 1000, DayStatus.SUCCESS);
@@ -183,9 +183,25 @@ class ChallengeServiceTest {
         when(challengeDayRepository.findByChallenge_IdAndDayDate(10L, date)).thenReturn(Optional.of(existing));
         when(challengeDayRepository.findByChallenge_Id(10L)).thenReturn(List.of(existing));
 
-        serviceAt(LocalDate.of(2026, 6, 20)).upsertDay(USER, 10L, new DayUpsertRequest(date, 99999, null, null));
+        serviceAt(LocalDate.of(2026, 6, 20)).upsertDay(USER, 10L, new DayUpsertRequest(date, 300000, null, null));
 
-        assertThat(ch.getStatus()).isEqualTo(ChallengeStatus.FAIL); // 초과 1일 생김 → 재계산으로 뒤집힘
+        assertThat(ch.getStatus()).isEqualTo(ChallengeStatus.FAIL); // 총지출 300,000 > 280,000 → 재계산으로 뒤집힘
+    }
+
+    @Test
+    @DisplayName("총지출 초과로 FAIL이 확정된 챌린지는 지출을 낮춰 총지출이 목표 이하가 되면 SUCCESS로 재계산된다 — 포기의 FAIL과 달리 계산된 FAIL은 재계산 대상이다")
+    void upsertDay_recalculatesCalculatedFailBackToSuccess() {
+        Challenge ch = inProgress(LocalDate.of(2026, 6, 1)); // 06-01~06-14, budgetTotal 280000
+        ch.applyResult(ChallengeStatus.FAIL); // 계산으로 확정된 FAIL(endReason 없음) — 포기 아님
+        LocalDate date = LocalDate.of(2026, 6, 3);
+        ChallengeDay existing = ChallengeDay.of(ch, date, 300000, DayStatus.OVER);
+        when(challengeRepository.findById(10L)).thenReturn(Optional.of(ch));
+        when(challengeDayRepository.findByChallenge_IdAndDayDate(10L, date)).thenReturn(Optional.of(existing));
+        when(challengeDayRepository.findByChallenge_Id(10L)).thenReturn(List.of(existing));
+
+        serviceAt(LocalDate.of(2026, 6, 20)).upsertDay(USER, 10L, new DayUpsertRequest(date, 1000, null, null));
+
+        assertThat(ch.getStatus()).isEqualTo(ChallengeStatus.SUCCESS); // 총지출 1,000 ≤ 280,000
     }
 
     @Test
@@ -338,13 +354,13 @@ class ChallengeServiceTest {
     }
 
     @Test
-    @DisplayName("종료일이 지났고 초과일이 하루라도 있으면 결과가 FAIL로 확정 저장된다")
+    @DisplayName("종료일이 지났고 기간 총지출이 목표를 넘으면 결과가 FAIL로 확정 저장된다")
     void result_finalizesFailAfterEnd() {
-        Challenge ch = inProgress(LocalDate.of(2026, 6, 1)); // endDate 2026-06-14
+        Challenge ch = inProgress(LocalDate.of(2026, 6, 1)); // endDate 2026-06-14, budgetTotal 280000
         when(challengeRepository.findById(10L)).thenReturn(Optional.of(ch));
         when(challengeDayRepository.findByChallenge_Id(10L)).thenReturn(List.of(
                 ChallengeDay.of(ch, LocalDate.of(2026, 6, 1), 10000, DayStatus.SUCCESS),
-                ChallengeDay.of(ch, LocalDate.of(2026, 6, 2), 99999, DayStatus.OVER)));
+                ChallengeDay.of(ch, LocalDate.of(2026, 6, 2), 299999, DayStatus.OVER))); // 총 309,999 > 280,000
 
         ResultResponse res = serviceAt(LocalDate.of(2026, 6, 20)).getResult(USER, 10L);
 


### PR DESCRIPTION
## 📎연관된 이슈

- close: #49

## 📄 작업 내용 요약

- `ChallengeCalculator.resultStatus`를 초과일 유무 판정에서 **기간 총지출 ≤ 목표(budgetTotal) 판정**으로 교체. 시그니처가 `(List<ChallengeDay>)` → `(int actualSpent, int budgetTotal)`로 바뀌었고, 총지출이 목표와 같으면 성공입니다.
- 호출부 3곳(`getResult` 최초 확정 · `upsertDay` 재계산 · `finalizeIfExpired`)이 전부 `summarizeForResult`의 `actualSpent`를 넘기도록 통일 — 판정 근거와 응답의 총액이 같은 계산에서 나옵니다.
- `getResult`는 집계를 확정보다 먼저 계산하도록 순서 이동(총액이 판정 입력이라서). 409 검사와 응답의 `status` 시점은 그대로입니다.
- 판정 기준을 서술하던 주석 4곳(`ChallengeStatus`·`DayStatus`·계산기 Javadoc·`upsertDay` 가드) 갱신.
- 테스트: 신규 3(총액 초과 실패 / 경계값 / 계산된 FAIL의 SUCCESS 재계산) + 수정 3(총액 기준으로 픽스처·기대값 재작성). 전체 340건 통과, 판정을 되돌리는 변이에 4건이 빨간불로 잡히는 것까지 확인했습니다.

## 👀 중요 변경 사항

- **`status: "SUCCESS"`인데 `summary.overDays ≥ 1`·`overAmount > 0`인 응답이 정상이 됩니다.** 이전 규칙에선 나올 수 없던 조합이라 안드에 별도 공유 예정입니다.
- **이미 FAIL로 저장된 종료 챌린지는 자동 소급되지 않습니다.** 뒤집는 경로는 그 챌린지에 일별 지출을 다시 보내는 것(`upsertDay` 재계산)뿐이라, 저장된 `status`와 조회 시 계산되는 `summary`가 한 응답 안에서 어긋나 보일 수 있습니다. 아직 실데이터가 없어 실질 영향은 없습니다.
- **중도 포기 FAIL의 재계산 제외 가드는 그대로입니다.** 총액 규칙에선 중도 포기 챌린지의 총지출이 거의 항상 목표 이하라, 이 가드가 포기 FAIL을 지키는 사실상 유일한 방어선이 됐습니다(가드를 지키는 테스트 유지 + 신규 테스트로 경계 보강).

## 🔖 Uncompleted Tasks

- 옛 규칙으로 저장된 FAIL 행의 소급 처리 여부 — 최종 종료 잠금(#50)이 들어오면 지출 재전송 경로도 막혀 영구 동결되므로, 그전에 결정이 필요합니다.

## 📢 To Reviewers

- 새 실패 테스트의 숫자는 수용 기준 문서의 시나리오를 그대로 썼습니다. 이 숫자에선 일별 초과액 합(`overAmount`)과 총액 초과분(실지출−목표)이 우연히 같아서, 실패 화면의 '초과 금액'이 어느 값인지는 이 테스트로 갈리지 않습니다 — 화면이 어느 값을 쓰는지 확정되면 그때 가르는 숫자로 보강할 생각입니다.
- 총액 판정은 단위·서비스 테스트로만 보호됩니다. 통합 테스트는 시계를 돌릴 수 없어 종료 챌린지를 리포지토리로 직접 심는 구조라 최초 확정 경로를 실요청으로 태우지 못합니다(Clock 빈 교체가 필요한데 이 이슈 범위 밖으로 뒀습니다).
