### PR TITLE
fix: 지원하지 않는 메서드·없는 경로 요청을 405/404로 응답하도록 공통 예외 처리 추가

### DIFF
--- a/src/main/java/Hampouch/server/global/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/Hampouch/server/global/common/exception/GlobalExceptionHandler.java
@@ -5,17 +5,21 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 
 @Slf4j
 @RestControllerAdvice
@@ -155,6 +159,44 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(CommonErrorCode.VALIDATION_ERROR.getHttpStatus())
                 .body(ErrorResponse.validation());
+    }
+
+    // 경로는 맞는데 메서드가 지원 밖인 요청 — 스프링 기본 처리가 붙여 주던 Allow 헤더는 advice가 먼저 잡으면
+    // 사라지므로(RFC 9110이 405에 Allow를 요구), 예외가 들고 있는 지원 메서드 목록으로 직접 붙인다.
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(
+            HttpRequestMethodNotSupportedException e,
+            HttpServletRequest request
+    ) {
+        log.warn(
+                "[HttpRequestMethodNotSupportedException] {} {} | supported={}",
+                request.getMethod(), request.getRequestURI(), e.getSupportedHttpMethods()
+        );
+
+        ResponseEntity.BodyBuilder response = ResponseEntity
+                .status(CommonErrorCode.METHOD_NOT_ALLOWED.getHttpStatus());
+        Set<HttpMethod> supportedMethods = e.getSupportedHttpMethods();
+        if (supportedMethods != null && !supportedMethods.isEmpty()) {
+            response.allow(supportedMethods.toArray(HttpMethod[]::new));
+        }
+        return response.body(ErrorResponse.from(CommonErrorCode.METHOD_NOT_ALLOWED));
+    }
+
+    // 어느 매핑에도 안 걸린 경로는 NoHandlerFound가 아니라 정적 리소스 폴백의 이 예외로 온다 —
+    // 없으면 아래 Exception 핸들러가 잡아 클라이언트의 경로 오타가 500으로 나간다.
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNoResourceFoundException(
+            NoResourceFoundException e,
+            HttpServletRequest request
+    ) {
+        log.warn(
+                "[NoResourceFoundException] {} {}",
+                request.getMethod(), request.getRequestURI()
+        );
+
+        return ResponseEntity
+                .status(CommonErrorCode.NOT_FOUND.getHttpStatus())
+                .body(ErrorResponse.from(CommonErrorCode.NOT_FOUND));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/Hampouch/server/global/common/exception/domain/CommonErrorCode.java
+++ b/src/main/java/Hampouch/server/global/common/exception/domain/CommonErrorCode.java
@@ -14,6 +14,7 @@ public enum CommonErrorCode implements BaseErrorCode {
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "인증이 필요합니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "FORBIDDEN", "접근 권한이 없습니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "NOT_FOUND", "요청한 리소스를 찾을 수 없습니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "METHOD_NOT_ALLOWED", "지원하지 않는 HTTP 메서드입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/test/java/Hampouch/server/global/common/exception/GlobalExceptionHandlerIntegrationTest.java
+++ b/src/test/java/Hampouch/server/global/common/exception/GlobalExceptionHandlerIntegrationTest.java
@@ -1,0 +1,57 @@
+package Hampouch.server.global.common.exception;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * 메서드 불일치·미매핑 경로 예외는 컨트롤러에 못 닿고 MVC 단계에서 나므로,
+ * 슬라이스가 아니라 실제 매핑·시큐리티 필터를 다 태운 통합으로 검증한다.
+ * 요청 경로는 전부 permitAll 목록에 있는 것만 쓴다 — 아니면 401이 먼저 나가 재현이 안 된다.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+class GlobalExceptionHandlerIntegrationTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    @Test
+    @DisplayName("등록된 경로에 지원하지 않는 메서드로 요청하면 405 상태와 지원 메서드가 담긴 Allow 헤더로 응답한다")
+    void unsupportedMethod_returns405WithAllowHeader() throws Exception {
+        mvc.perform(get("/api/auth/login"))
+                .andExpect(status().isMethodNotAllowed())
+                .andExpect(header().string("Allow", "POST"))
+                .andExpect(jsonPath("$.code").value("METHOD_NOT_ALLOWED"))
+                .andExpect(jsonPath("$.message").value("지원하지 않는 HTTP 메서드입니다."))
+                .andExpect(jsonPath("$.status").value(405));
+    }
+
+    @Test
+    @DisplayName("지원 메서드가 여러 개인 경로에서도 405 응답의 Allow 헤더에 그 메서드들이 전부 담긴다")
+    void unsupportedMethod_allowHeaderListsEveryMethod() throws Exception {
+        mvc.perform(patch("/api/mini-challenges"))
+                .andExpect(status().isMethodNotAllowed())
+                .andExpect(header().string("Allow", containsString("GET")))
+                .andExpect(header().string("Allow", containsString("POST")))
+                .andExpect(jsonPath("$.code").value("METHOD_NOT_ALLOWED"));
+    }
+
+    @Test
+    @DisplayName("어느 매핑에도 없는 경로로 요청하면 404 상태와 리소스 없음 응답을 준다")
+    void unmappedPath_returns404() throws Exception {
+        mvc.perform(get("/api/challenges/zzz/zzz"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("NOT_FOUND"))
+                .andExpect(jsonPath("$.message").value("요청한 리소스를 찾을 수 없습니다."))
+                .andExpect(jsonPath("$.status").value(404));
+    }
+}


### PR DESCRIPTION
## 📎연관된 이슈

- close: #58

## 📄 작업 내용 요약

- `GlobalExceptionHandler`에 핸들러 2개를 추가했습니다. 지원하지 않는 메서드 요청은 405로, 어느 매핑에도 없는 경로 요청은 404로 응답합니다. 지금은 둘 다 `Exception` 폴백까지 내려가 500(`INTERNAL_SERVER_ERROR`)으로 나갑니다.
- `CommonErrorCode`에 `METHOD_NOT_ALLOWED`(405)를 추가했습니다. 404는 기존 `NOT_FOUND`를 재사용합니다 — 이슈 본문의 "두 코드가 없다"는 절반만 맞았고, `NOT_FOUND`는 처음부터 있었습니다.
- 405 응답에 RFC 9110 §15.5.6이 요구하는 `Allow` 헤더를 붙입니다. 스프링 기본 처리가 붙여 주던 헤더인데 advice가 예외를 먼저 잡으면 사라져서, 예외가 들고 있는 지원 메서드 목록으로 직접 세팅합니다.
- 통합 테스트 3건을 추가했습니다(`@SpringBootTest` + MockMvc, 보안 필터 켠 상태 — 이슈 실측과 같은 조건). 전체 396건 통과, 핸들러를 빼면 신규 3건이 전부 실패하는 것까지 확인했습니다.

## 👀 중요 변경 사항

- 특정 도메인이 아니라 전 엔드포인트 공통 변경입니다. 메서드나 경로를 틀린 요청의 응답이 500 → 405/404로 바뀝니다. 본문 형태는 기존 `ErrorResponse` 그대로이고 `code` 값만 `METHOD_NOT_ALLOWED` / `NOT_FOUND`로 갈립니다.
- 405 응답의 `Allow` 헤더는 메서드 나열 순서가 보장되지 않습니다(예: `Allow: GET,POST`). 클라이언트가 파싱해 쓴다면 순서에 기대면 안 됩니다.
- `global/common/exception`은 나연 님 관할이라 사전 허락받고 진행한 건입니다(이슈 #58 Note 참조).

## 🔖 Uncompleted Tasks

- 없습니다.

## 📢 To Reviewers

- 새 에러 코드의 메시지 문구("지원하지 않는 HTTP 메서드입니다.")는 기존 `CommonErrorCode` 문체를 따라 정한 것이라, 더 나은 문구가 있으면 의견 부탁드립니다.
