### PR TITLE
feat: 미니 챌린지 제목 길이 상한을 컬럼 선언에 명시하고 검증과 일원화

### DIFF
--- a/src/main/java/Hampouch/server/domain/minichallenge/entity/MiniChallenge.java
+++ b/src/main/java/Hampouch/server/domain/minichallenge/entity/MiniChallenge.java
@@ -11,25 +11,17 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 /**
- * 미니 챌린지 1건 — 유저 소유, 본 챌린지와 독립(0707 서버회의: 정의+참여 합침, challenge_id 없음).
- *
- * 추천에서 왔든 커스텀이든 같은 행(origin 컬럼 없음 — 추천/커스텀 통일, 0707).
- * 내용 수정 불가(0630 확정: 삭제 후 새로 생성) — 그래서 수정 메서드가 없다.
- * endDate는 startDate + durationDays - 1 스냅샷 — 나중에 규칙이 바뀌어도 기존 행의 기간이 흔들리지 않게.
+ * 미니 챌린지 1건 — 유저 소유, 본 챌린지와 독립(challenge_id 없음).
+ * 추천에서 왔든 커스텀이든 같은 행(origin 구분 컬럼 없음).
+ * 내용 수정 불가(확정 사양: 삭제 후 새로 생성) — 그래서 수정 메서드가 없다.
+ * endDate는 startDate + durationDays - 1 스냅샷 — 규칙이 바뀌어도 기존 행의 기간이 흔들리지 않게.
  */
-@Getter // 필드별 getter 자동 생성(나연 common과 동일한 팀 스타일)
-// JPA 필수 빈 생성자(Hibernate가 행→객체 복원·프록시 생성에 사용) — 스펙이 public 또는 protected를
-// 요구한다. 지연 로딩 프록시가 이 엔티티를 상속한 자식 클래스라서 private면 안 된다.
-// protected의 호출 가능 범위 = 같은 패키지 전부 + 다른 패키지의 자식 클래스(생성자는 super() 경유만).
-// 즉 서비스 등 패키지 밖 일반 코드의 반쪽짜리 new는 막힌다. 정식 생성은 create()
+@Getter
+// JPA 스펙상 기본 생성자는 protected 이상 — 정식 생성 통로는 create()
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "mini_challenge")
-// @EntityListeners: 엔티티 생명주기 이벤트(저장 직전 등)의 콜백을 엔티티 밖 클래스에 위임하는 JPA 표준.
-// AuditingEntityListener는 스프링이 제공하는 그 콜백 구현체로, 저장 직전에 끼어들어 @CreatedDate(createdAt)를 채운다.
-// 셋이 한 세트다 — 기능 켜기는 JpaAuditingConfig(@EnableJpaAuditing), 이 줄은 이 엔티티에 리스너 붙이기,
-// @CreatedDate는 채울 필드 지목. 이 줄이 빠지면 아무도 채우지 않아 createdAt이 null → nullable=false 위반.
-// 채우는 시각은 공용 Clock(Asia/Seoul) — 엔티티가 직접 now()를 부르지 않게 해서 테스트에서 시각을 고정할 수 있다.
+// 이 줄이 빠지면 @CreatedDate가 안 채워져 createdAt의 nullable=false 위반으로 저장이 터진다
 @EntityListeners(AuditingEntityListener.class)
 public class MiniChallenge {
 
@@ -40,11 +32,6 @@ public class MiniChallenge {
     public static final int TITLE_MAX_LENGTH = 255;
 
     @Id
-    // @GeneratedValue는 "이 값은 내가 안 넣을 테니 알아서 채워라"는 위임일 뿐, 누가 채우는지는 strategy가 정한다.
-    // UUID를 골랐으면 자바가 만들지만 IDENTITY는 DB의 auto_increment 몫 — 그래서 create()로 갓 만든 객체의 id는
-    // null이고, save()가 INSERT를 날려 DB가 매긴 번호를 돌려받아야 채워진다. MySQL엔 시퀀스가 없어 사실상 이게 정답
-    // (AUTO였다면 채번 테이블로 떨어져 더 무겁다). 대신 롤백에 소모된 번호는 재사용되지 않아 중간에 구멍이 뚫리니,
-    // 순서나 개수를 세는 용도로 쓰면 안 되고 고유 식별자로만 쓴다.
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
@@ -52,15 +39,14 @@ public class MiniChallenge {
     @Column(nullable = false)
     private Long userId;
 
-    /** 제목 — 추천에서 복사됐든 커스텀이든 동일(ERD MINI_CHALLENGE.title). */
     @Column(nullable = false, length = TITLE_MAX_LENGTH)
     private String title;
 
-    /** 기간(일). 화이트리스트 {1, 3, 7, 14, 31} 검증은 서비스가 담당(규칙 단일 출처는 MiniChallengeService.ALLOWED_DURATIONS). */
+    /** 기간(일) — 화이트리스트 검증의 단일 출처는 MiniChallengeService.ALLOWED_DURATIONS. */
     @Column(nullable = false)
     private int durationDays;
 
-    /** 시작일 = 추가한 날(명세 §3 자체 결정: start_date = 오늘). */
+    /** 시작일 = 추가한 날(오늘). */
     @Column(nullable = false)
     private LocalDate startDate;
 
@@ -68,14 +54,7 @@ public class MiniChallenge {
     @Column(nullable = false)
     private LocalDate endDate;
 
-    /**
-     * 생성 시각. @CreatedDate는 JPA 표준이 아니라 스프링 것(org.springframework.data.annotation)이라
-     * Spring Data를 쓰면 JPA 밖에서도 통한다. 값을 채우는 게 아니라 "이 필드가 생성 시각"이라고 표시만 하고,
-     * 실제로 채우는 건 클래스에 붙인 AuditingEntityListener다.
-     * 최초 INSERT 때 한 번만 채워지므로 updatable = false로 UPDATE 문에서 아예 빼 실수로도 덮이지 않게 한다.
-     * 형제인 @LastModifiedDate를 안 쓰는 건 미니 챌린지가 수정 불가(0630 확정, 삭제 후 재생성)라 마지막 수정 시각이
-     * 있을 수 없어서다.
-     */
+    /** updatable = false — UPDATE 문에서 아예 빼 실수로도 안 덮이게. 수정 불가 엔티티라 @LastModifiedDate는 없다. */
     @CreatedDate
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
@@ -88,10 +67,7 @@ public class MiniChallenge {
         this.endDate = startDate.plusDays(durationDays - 1L);
     }
 
-    /**
-     * 미니 챌린지 생성 — Challenge.create와 같은 관례로, 생성자를 private으로 잠그고
-     * 이름 있는 정적 팩토리를 유일한 생성 통로로 둔다(endDate 스냅샷 계산을 우회한 객체가 못 생기게).
-     */
+    /** 유일한 생성 통로 — endDate 스냅샷 계산을 우회한 객체가 못 생기게 생성자는 private. */
     public static MiniChallenge create(Long userId, String title, int durationDays, LocalDate startDate) {
         return new MiniChallenge(userId, title, durationDays, startDate);
     }
@@ -100,7 +76,6 @@ public class MiniChallenge {
         return this.userId.equals(userId);
     }
 
-    /** 그 날짜에 활성(기간에 걸쳐 있는)인지 — start ≤ date ≤ end. */
     public boolean isActiveOn(LocalDate date) {
         return !date.isBefore(startDate) && !date.isAfter(endDate);
     }

--- a/src/main/java/Hampouch/server/domain/minichallenge/entity/MiniChallenge.java
+++ b/src/main/java/Hampouch/server/domain/minichallenge/entity/MiniChallenge.java
@@ -33,6 +33,12 @@ import java.time.LocalDateTime;
 @EntityListeners(AuditingEntityListener.class)
 public class MiniChallenge {
 
+    /**
+     * 제목 길이 상한 — 명세·ERD에 없어 서버가 정한 저장 방어값이다(화면 입력 제한은 안드 몫).
+     * 커스텀 생성 검증(MiniChallengeService)과 추천 카탈로그 컬럼이 이 상수를 같이 쓴다 — 값을 바꾸면 셋이 함께 움직인다.
+     */
+    public static final int TITLE_MAX_LENGTH = 255;
+
     @Id
     // @GeneratedValue는 "이 값은 내가 안 넣을 테니 알아서 채워라"는 위임일 뿐, 누가 채우는지는 strategy가 정한다.
     // UUID를 골랐으면 자바가 만들지만 IDENTITY는 DB의 auto_increment 몫 — 그래서 create()로 갓 만든 객체의 id는
@@ -47,7 +53,7 @@ public class MiniChallenge {
     private Long userId;
 
     /** 제목 — 추천에서 복사됐든 커스텀이든 동일(ERD MINI_CHALLENGE.title). */
-    @Column(nullable = false)
+    @Column(nullable = false, length = TITLE_MAX_LENGTH)
     private String title;
 
     /** 기간(일). 화이트리스트 {1, 3, 7, 14, 31} 검증은 서비스가 담당(규칙 단일 출처는 MiniChallengeService.ALLOWED_DURATIONS). */

--- a/src/main/java/Hampouch/server/domain/minichallenge/entity/RecommendedMiniChallenge.java
+++ b/src/main/java/Hampouch/server/domain/minichallenge/entity/RecommendedMiniChallenge.java
@@ -32,8 +32,12 @@ public class RecommendedMiniChallenge {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    /** 추천 문구. 예: 편의점 디저트 안 먹기 */
-    @Column(nullable = false)
+    /**
+     * 추천 문구. 예: 편의점 디저트 안 먹기
+     * 길이 상한을 mini_challenge.title과 같은 값으로 묶는다 — 추가할 때 이 값이 그대로 복사되므로,
+     * 여기가 더 길면 복사되는 쪽 컬럼에서 저장이 터진다.
+     */
+    @Column(nullable = false, length = MiniChallenge.TITLE_MAX_LENGTH)
     private String title;
 
     /** 기간(일). 기간 탭 화이트리스트 = 오늘만 1 / 3 / 7 / 14 / 31 (명세 §2 확정) */

--- a/src/main/java/Hampouch/server/domain/minichallenge/entity/RecommendedMiniChallenge.java
+++ b/src/main/java/Hampouch/server/domain/minichallenge/entity/RecommendedMiniChallenge.java
@@ -6,28 +6,17 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /**
- * 추천 미니 챌린지 프리셋 카탈로그 1건 (ERD RECOMMENDED_MINI_CHALLENGE).
- *
- * 기획이 심어 두는 고정 목록(읽기 전용) — 유저가 "추가하기" 하면 이 행의 값(title·durationDays)만
- * 유저의 mini_challenge 행으로 복사되고(API명세_미니챌린지.md §3), 이 테이블과의 FK 관계는 두지 않는다(0707 본챌 독립화).
- * created_at 없음 — ERD대로. 운영 중 유저가 만드는 데이터가 아니라 생성 시각 추적이 불필요해
- * JPA Auditing도 안 쓴다.
+ * 추천 미니 챌린지 프리셋 카탈로그 1건 — 기획이 심어 두는 고정 목록(읽기 전용).
+ * 유저가 추가하면 이 행의 title·durationDays 값만 유저의 mini_challenge 행으로 복사되고 FK 관계는 두지 않는다.
+ * 유저가 만드는 데이터가 아니라 created_at·Auditing이 없다.
  */
-@Getter // 필드별 getter 자동 생성(팀 스타일)
-// JPA 필수 빈 생성자 — 스펙(Jakarta Persistence)이 public 또는 protected를 요구한다.
-// Hibernate가 지연 로딩 프록시를 "이 엔티티를 상속한 자식 클래스"로 만들기 때문에 private는 안 된다.
-// protected의 호출 가능 범위 = 같은 패키지 전부 + 다른 패키지의 자식 클래스(생성자는 super() 경유만).
-// 즉 서비스 등 패키지 밖 일반 코드의 반쪽짜리 new는 막힌다. 정식 생성은 of()
+@Getter
+// JPA 스펙상 기본 생성자는 protected 이상 — 정식 생성 통로는 of()
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "recommended_mini_challenge")
 public class RecommendedMiniChallenge {
 
-    // IDENTITY = 번호를 앱(자바 코드)이 정하지 않고 DB에 맡긴다는 뜻. INSERT문에 id 컬럼을 아예
-    // 빼고 보내면 MySQL의 auto_increment(테스트는 H2)가 다음 번호를 매기고, Hibernate가 그 번호를
-    // 읽어와 이 필드에 채워 준다. 앱이 직접 매기면(예: 조회한 최댓값+1) 동시 요청·다중 인스턴스에서
-    // 같은 번호가 겹칠 수 있는데, DB는 발급 지점이 하나뿐이라 겹치지 않는다.
-    // 그래서 저장 전에는 id가 없다 — 필드가 원시형 long이 아니라 null을 담는 Long인 이유.
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -40,7 +29,7 @@ public class RecommendedMiniChallenge {
     @Column(nullable = false, length = MiniChallenge.TITLE_MAX_LENGTH)
     private String title;
 
-    /** 기간(일). 기간 탭 화이트리스트 = 오늘만 1 / 3 / 7 / 14 / 31 (명세 §2 확정) */
+    /** 기간(일). */
     @Column(nullable = false)
     private int durationDays;
 

--- a/src/main/java/Hampouch/server/domain/minichallenge/service/MiniChallengeService.java
+++ b/src/main/java/Hampouch/server/domain/minichallenge/service/MiniChallengeService.java
@@ -33,13 +33,6 @@ public class MiniChallengeService {
      */
     private static final Set<Integer> ALLOWED_DURATIONS = Set.of(1, 3, 7, 14, 31);
 
-    /**
-     * 제목 길이 잠정 상한 — 명세·ERD에 최대 길이가 없어 자체 결정(PM 확인 대상, 확정되면 조정).
-     * title 컬럼이 Hibernate 기본 varchar(255)로 생성되므로, 여기서 안 끊으면 255자 초과 입력이
-     * INSERT의 컬럼 제약에서 터져 클라이언트 입력 오류가 500으로 나간다 — 서버 검증으로 400 컷.
-     */
-    private static final int MAX_TITLE_LENGTH = 255;
-
     private final MiniChallengeRepository miniChallengeRepository;
     private final MiniChallengeDayRepository miniChallengeDayRepository;
     // 추천 카탈로그(#10) 조회용 — "추천에서 추가"(§3)가 여기서 title·durationDays를 복사해 온다(#19 배선)
@@ -132,10 +125,12 @@ public class MiniChallengeService {
         }
 
         CreateMiniChallengeRequest.Custom custom = req.custom();
-        // title 필수·비공백·길이 상한(잠정), durationDays 필수 — 위반은 형태 위반(MINI_INVALID_BODY)으로 자체 결정
+        // title 필수·비공백·길이 상한(상한값은 저장 컬럼 선언과 같은 MiniChallenge.TITLE_MAX_LENGTH —
+        // 여기서 안 끊으면 초과 입력이 INSERT에서 터져 클라이언트 입력 오류가 500으로 나간다),
+        // durationDays 필수 — 위반은 형태 위반(MINI_INVALID_BODY)으로 자체 결정
         // (기간 "값이 이상함"과 "필드 자체가 빠짐"을 구분: 후자는 화이트리스트 이전의 폼 문제)
         if (custom.title() == null || custom.title().isBlank()
-                || custom.title().length() > MAX_TITLE_LENGTH || custom.durationDays() == null) {
+                || custom.title().length() > MiniChallenge.TITLE_MAX_LENGTH || custom.durationDays() == null) {
             throw new CustomException(MiniChallengeErrorCode.MINI_INVALID_BODY);
         }
         if (!ALLOWED_DURATIONS.contains(custom.durationDays())) {

--- a/src/main/java/Hampouch/server/domain/minichallenge/service/MiniChallengeService.java
+++ b/src/main/java/Hampouch/server/domain/minichallenge/service/MiniChallengeService.java
@@ -20,42 +20,33 @@ import java.time.format.DateTimeParseException;
 import java.util.*;
 
 @Service
-@RequiredArgsConstructor // final 필드들을 받는 생성자 자동 생성 — 스프링이 그 생성자로 의존성 주입(팀 스타일)
-@Transactional(readOnly = true) // 기본 = 조회 전용, 쓰기 메서드(create·delete·check)만 개별 @Transactional로 덮어씀(#1과 동일)
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MiniChallengeService {
 
     /**
-     * 기간 화이트리스트 — 오늘만(1)/3/7/14/31일, 명세 §3 확정.
-     * 설정(yml·DB)이 아니라 상수로 두는 게 맞다: 운영 중에 서버만 조정할 값이 아니라 명세가 확정한 도메인 규칙이고,
-     * 안드가 같은 목록을 기간 탭으로 들고 있어(§2) 서버만 바꾸면 화면과 어긋난다. 설정으로 빼면 "서버만 고치면 되는
-     * 척"하게 만들어 오히려 위험하다 — 목록이 바뀌면 서버·안드가 각자 PR을 내는 게 정상이다.
-     * 규칙의 단일 출처라 다른 곳에 같은 목록을 복사하지 말 것(엔티티 durationDays 주석이 여기를 가리킨다).
+     * 기간 화이트리스트 — 1(오늘만)·3·7·14·31일.
+     * 안드가 같은 목록을 기간 탭으로 들고 있어 설정이 아니라 상수다 — 서버만 바꾸면 화면과 어긋난다.
+     * 규칙의 단일 출처 — 다른 곳에 같은 목록을 복사하지 말 것.
      */
     private static final Set<Integer> ALLOWED_DURATIONS = Set.of(1, 3, 7, 14, 31);
 
     private final MiniChallengeRepository miniChallengeRepository;
     private final MiniChallengeDayRepository miniChallengeDayRepository;
-    // 추천 카탈로그(#10) 조회용 — "추천에서 추가"(§3)가 여기서 title·durationDays를 복사해 온다(#19 배선)
     private final RecommendedMiniChallengeRepository recommendedMiniChallengeRepository;
-    // "지금"의 단일 출처(ClockConfig, Asia/Seoul) — 인자 없는 now()는 서버 OS 시간대를 타고 테스트 고정도 불가(#1과 동일 이유)
+    // "지금"의 단일 출처 — 인자 없는 now()는 서버 OS 시간대를 타고 테스트에서 시각 고정도 안 된다
     private final Clock clock;
 
     /**
-     * 그날 나의 미니 챌린지(§1) — 요청 date(생략 시 오늘) 기준 as-of 집계. 저장 없이 계산.
-     * 집계 = 저장된 원재료(미니 행·체크 행)를 모아 세어 만드는 응답 숫자들(checkedCount·totalCount·
-     * streakDays·progressDays·itemStreak). DB 어디에도 이 숫자들은 저장돼 있지 않다 — 저장해 두면
-     * 체크/해제 때마다 같이 고쳐야 해 어긋날 수 있고, 매번 다시 세면 어긋날 방법이 없다(ERD 확정).
-     *
-     * date를 LocalDate가 아닌 String으로 받는 이유: 타입 바인딩 실패는 나연 공통 핸들러의
-     * Exception 폴백에 걸려 500이 되므로, 원시값으로 받아 서버가 직접 파싱·검증해 400으로 컷 —
-     * #1 캘린더가 year·month를 서비스에서 검증해 BAD_REQUEST로 끊는 것과 같은 "서버가 최종 방어선" 패턴.
+     * 그날 나의 미니 챌린지 — 요청 date(생략 시 오늘) 기준 as-of 집계.
+     * 집계값은 저장하지 않고 조회 때마다 계산한다 — 저장해 두면 체크/해제 때마다 같이 고쳐야 해 어긋날 수 있다.
+     * date를 String으로 받는 건 공통 핸들러에 바인딩 실패 처리가 없던 시절의 방어 — 지금은 공통 핸들러가
+     * 400으로 받아 주므로 LocalDate 직접 바인딩 전환 대상(TODO #27).
      */
     public DailyMiniChallengesResponse getDaily(Long userId, String dateParam) {
         LocalDate date = parseDateOrToday(dateParam);
-        // 미래 date는 400 차단(0716 자체 확정 — 초기 잠정은 허용이었으나 확정 둘의 준용으로 전환):
-        // ① 홈 날짜 스트립은 다음날(미래) 이동 불가(0711 PM 확정 — 미니 홈도 같은 스트립 컴포넌트),
-        // ② 미니의 미래 체크 400(0707 일혁 확정, "선체크 상황 없음")과 동일 논리로 미래 '조회'도 일어날 상황이 없다.
-        // 열어 두면 클라 날짜 계산 버그가 그럴싸한 빈 응답으로 조용히 넘어가는데, 400이면 바로 드러난다.
+        // 미래 date는 400 — 화면상 미래 조회가 일어날 상황이 없고, 열어 두면 클라의 날짜 계산 버그가
+        // 그럴싸한 빈 응답으로 조용히 넘어간다. 400이면 바로 드러난다.
         if (date.isAfter(LocalDate.now(clock))) {
             throw new CustomException(MiniChallengeErrorCode.MINI_FUTURE_DATE);
         }
@@ -73,9 +64,9 @@ public class MiniChallengeService {
                     checkedDatesByMiniId.getOrDefault(m.getId(), Set.of())));
         }
 
-        // 응답 순서는 명세에 없어 id 오름차순(생성순)으로 고정 — 자체 결정(호출마다 순서가 흔들리지 않게)
+        // 응답 순서는 명세에 없어 id 오름차순(생성순)으로 고정 — 호출마다 순서가 흔들리지 않게
         List<DailyMiniChallengesResponse.Item> items = minis.stream()
-                .filter(m -> m.isActiveOn(date)) // 목록·집계 대상 = 그날 활성 미니만(§1)
+                .filter(m -> m.isActiveOn(date))
                 .sorted(Comparator.comparing(MiniChallenge::getId))
                 .map(m -> {
                     MiniCheckHistory history = historyByMiniId.get(m.getId());
@@ -97,7 +88,6 @@ public class MiniChallengeService {
                 items);
     }
 
-    /** 미니 추가(§3) — 바디는 recommendedId/custom XOR. start = 오늘(Clock), end = start + duration - 1 스냅샷. */
     @Transactional
     public CreateMiniChallengeResponse create(Long userId, CreateMiniChallengeRequest req) {
         boolean byRecommended = req.recommendedId() != null;
@@ -107,15 +97,9 @@ public class MiniChallengeService {
         }
 
         if (byRecommended) {
-            // 추천에서 추가(#19 배선) — 카탈로그(recommended_mini_challenge, #10)에서 조회해 없으면 404(§3),
-            // 있으면 title·durationDays만 복사해 유저 소유 행을 새로 만든다. 참조(FK)가 아니라 값 복사인 이유(§2):
-            // 카탈로그는 기획이 관리하는 공용 목록이라, 문구 수정·항목 삭제가 이미 시작한 유저 미니를 흔들면 안 된다.
-            // 커스텀 경로의 값 검증(비공백·길이·화이트리스트)을 여기엔 안 거는 이유 — 카탈로그 값은 유저 입력이
-            // 아니라 서버가 시드로 관리하는 데이터라, 이상하면 그건 400이 아니라 시드 수정 사안이다.
-            // 잠정: §3의 409(같은 추천을 이미 진행 중 — 명세도 잠정 표기)는 미구현 — 추천/커스텀 통일로
-            // origin 컬럼이 ERD에 없어 "같은 추천에서 온 미니"를 식별할 수 없음. 확정되면 식별 수단부터 재설계(질문 10).
-            // findById는 Optional(값이 있을 수도, 없을 수도 있는 상자)을 반환 — orElseThrow는 값이 있으면
-            // 꺼내 주고, 비어 있으면(해당 id 없음) 람다가 만든 예외를 그때 생성해 던진다. null 검사 if문의 한 줄 대체.
+            // 커스텀 경로의 값 검증(비공백·길이·화이트리스트)을 여기엔 안 건다 — 카탈로그 값은 유저 입력이
+            // 아니라 서버가 시드로 관리하는 데이터라, 이상하면 400이 아니라 시드 수정 사안이다.
+            // "같은 추천 중복 추가 409"는 미구현 — origin 컬럼이 없어 같은 추천에서 온 미니를 식별할 수 없다.
             RecommendedMiniChallenge rec = recommendedMiniChallengeRepository.findById(req.recommendedId())
                     .orElseThrow(() -> new CustomException(MiniChallengeErrorCode.MINI_RECOMMENDED_NOT_FOUND));
             MiniChallenge mini = MiniChallenge.create(
@@ -143,7 +127,6 @@ public class MiniChallengeService {
         return CreateMiniChallengeResponse.from(mini);
     }
 
-    /** 미니 삭제(§4) — 미니 행 + 그 일별 체크 행 삭제(0630 확정: 수정 대신 삭제 후 새로 생성). */
     @Transactional
     public void delete(Long userId, Long miniChallengeId) {
         MiniChallenge mini = loadOwned(userId, miniChallengeId);
@@ -152,36 +135,32 @@ public class MiniChallengeService {
     }
 
     /**
-     * 일별 체크/해제(§5) — PUT + 목표 상태 = 멱등(같은 요청을 몇 번 보내도 최종 상태가 같음 — 재전송 안전).
-     * "토글해라"가 아니라 "이 상태로 만들어라"를 받는 이유다(토글은 두 번 가면 원위치라 멱등이 아님).
-     * checked=true는 upsert(이미 있으면 행 유지 → checkedAt 보존), false는 행 삭제(없어도 그대로 200).
+     * 일별 체크/해제 — "토글해라"가 아니라 "이 상태로 만들어라"를 받아 재전송에 안전하다(토글은 두 번 가면 원위치).
+     * checked=true는 이미 있으면 행 유지(최초 checkedAt 보존), false는 행이 없어도 그대로 200.
      */
     @Transactional
     public MiniCheckResponse check(Long userId, Long miniChallengeId, MiniCheckRequest req) {
-        MiniChallenge mini = loadOwned(userId, miniChallengeId); // 존재·소유 먼저(404/403) → 그 다음 날짜 검증(#1과 동일 순서)
+        MiniChallenge mini = loadOwned(userId, miniChallengeId); // 존재·소유 검사(404/403)가 날짜 검증보다 먼저
         LocalDate today = LocalDate.now(clock);
-        // 바디의 date도 GET의 쿼리 파라미터와 같은 방어 — 서버가 직접 파싱해 형식 오류는 400, 생략은 오늘
         LocalDate date = parseDateOrToday(req.date());
 
-        // 미래 검사를 기간 검사보다 먼저 — 미래 날짜는 기간 밖이기도 할 수 있는데(종료일 이후),
-        // 겹치면 MINI_FUTURE_CHECK 우선이 명세 §5 확정(0716)이라 검사 순서로 그 우선순위를 보장한다.
+        // 미래 검사를 기간 검사보다 먼저 — 종료일 이후의 미래처럼 둘 다 걸릴 때 MINI_FUTURE_CHECK가
+        // 우선이라는 확정을 검사 순서로 보장한다.
         if (date.isAfter(today)) {
             throw new CustomException(MiniChallengeErrorCode.MINI_FUTURE_CHECK);
         }
-        if (!mini.isActiveOn(date)) { // 과거는 기간 안이면 허용(0707 확정) — 기간 밖만 400
+        if (!mini.isActiveOn(date)) { // 과거는 기간 안이면 허용 — 기간 밖만 400
             throw new CustomException(MiniChallengeErrorCode.MINI_DATE_OUT_OF_RANGE);
         }
 
         if (req.checked()) {
-            // 알려진 한계: exists→save 사이에 같은 (미니, 날짜)의 요청이 동시에 끼면(모바일 더블탭 수준의
-            // 희귀 케이스) 한쪽 INSERT가 유니크 제약(uq_mini_challenge_day)에 걸려 500이 난다.
-            // 중복 행 자체는 제약이 막아 데이터는 정합. 여기서 try-catch로 삼키는 것만으론 해결이 안 된다 —
-            // 제약 위반이 나는 순간 JPA 규약상 트랜잭션이 rollback-only로 표시돼 커밋에서 다시 터지기 때문.
-            // 제대로 하려면 트랜잭션 분리나 잠금이 필요해서, #1의 동일 패턴(기록 upsert)과 함께 팀 차원 개선 항목으로 남긴다.
+            // 알려진 한계(TODO #57): exists→save 사이에 같은 (미니, 날짜) 요청이 동시에 끼면 한쪽 INSERT가
+            // 유니크 제약(uq_mini_challenge_day)에 걸려 500이 난다(중복 행 자체는 제약이 막아 데이터는 정합).
+            // 여기서 try-catch로 삼키는 것만으론 안 된다 — 제약 위반 순간 트랜잭션이 rollback-only로 표시돼
+            // 커밋에서 다시 터진다.
             if (!miniChallengeDayRepository.existsByMiniChallenge_IdAndCheckDate(miniChallengeId, date)) {
                 miniChallengeDayRepository.save(MiniChallengeDay.of(mini, date));
             }
-            // 이미 있으면 아무것도 안 함 — 기존 행 유지로 최초 checkedAt 보존(§5)
         } else {
             miniChallengeDayRepository.deleteByMiniChallenge_IdAndCheckDate(miniChallengeId, date); // 0건 삭제도 정상(멱등)
         }
@@ -197,10 +176,7 @@ public class MiniChallengeService {
         return mini;
     }
 
-    /**
-     * date 원시값 파싱 — GET의 쿼리 파라미터와 PUT 체크 바디가 공용.
-     * 생략(null·공백)이면 오늘(Clock), ISO(yyyy-MM-dd) 파싱 실패면 400(§1 "date 형식" · §0 요청 형식 오류).
-     */
+    /** date 원시값 파싱(GET 쿼리·PUT 바디 공용) — 생략(null·공백)이면 오늘, ISO(yyyy-MM-dd) 파싱 실패면 400. */
     private LocalDate parseDateOrToday(String dateParam) {
         if (dateParam == null || dateParam.isBlank()) {
             return LocalDate.now(clock);
@@ -208,20 +184,13 @@ public class MiniChallengeService {
         try {
             return LocalDate.parse(dateParam);
         } catch (DateTimeParseException e) {
-            throw new CustomException(CommonErrorCode.BAD_REQUEST, e); // 코드명 미지정 400이라 공통 BAD_REQUEST(#1 캘린더와 동일)
+            throw new CustomException(CommonErrorCode.BAD_REQUEST, e); // 전용 코드명이 없는 형식 오류라 공통 BAD_REQUEST
         }
     }
 
     /**
-     * 유저 미니들의 체크 이력을 in 절 한 번에 조회해 미니 id별 날짜 집합으로 그룹핑.
-     * N+1 방지 — 미니마다 낱개 조회하면 목록 1번 + 미니 N개에 N번 = 총 N+1번의 쿼리가 나가고,
-     * 데이터가 늘수록 쿼리 수가 같이 는다. in 절이면 미니가 몇 개든 이 조회는 1번으로 고정.
-     * asOf는 가져올 대상이 아니라 상한선이다 — "그날까지 체크된 날들"을 달라는 뜻(쿼리의 CheckDateLessThanEqual).
-     * date를 유저가 고를 수 있어(과거 조회) 선을 안 그으면 그 이후 체크가 과거 화면에 새어 든다.
-     * in 절에 넣는 id가 호출 직전에 이미 읽어둔 minis에서 나오므로, row.getMiniChallenge()는 지연 로딩 프록시가
-     * 아니라 1차 캐시에 있는 그 엔티티 그대로다 — 그래서 추가 쿼리가 없다.
-     * 설령 프록시로 오더라도 id만 읽는 건 초기화 없이 가능해 결과는 같다(두 경로 다 쿼리 0). 다만 이건 Hibernate가
-     * 보장하는 동작이지 JPA 표준 보장은 아니다 — 표준은 LAZY를 힌트로만 규정한다.
+     * 미니 id별 "asOf까지 체크된 날짜" 집합 — in 절 한 번으로 조회(미니마다 낱개로 부르면 N+1).
+     * asOf 상한을 안 그으면 과거 날짜 조회 화면에 그 이후의 체크가 새어 든다.
      */
     private Map<Long, Set<LocalDate>> loadCheckedDatesAsOf(List<MiniChallenge> minis, LocalDate asOf) {
         List<Long> ids = minis.stream().map(MiniChallenge::getId).toList();

--- a/src/test/java/Hampouch/server/domain/minichallenge/MiniChallengeFlowIntegrationTest.java
+++ b/src/test/java/Hampouch/server/domain/minichallenge/MiniChallengeFlowIntegrationTest.java
@@ -1,5 +1,6 @@
 package Hampouch.server.domain.minichallenge;
 
+import Hampouch.server.domain.minichallenge.entity.MiniChallenge;
 import Hampouch.server.domain.minichallenge.entity.RecommendedMiniChallenge;
 import Hampouch.server.domain.minichallenge.repository.RecommendedMiniChallengeRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -150,5 +151,42 @@ class MiniChallengeFlowIntegrationTest {
                         .content("{\"recommendedId\":999999}"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value("MINI_RECOMMENDED_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("제목이 공백만 있거나 저장 컬럼 상한인 255자를 넘으면 실제 스택에서도 400으로 끊기고, 딱 255자짜리 제목은 저장돼 그날 미니 목록 조회에 잘리지 않고 그대로 나온다")
+    void titleLengthBoundaryFlow() throws Exception {
+        // 앞 시나리오들(유저 9·19)의 집계 단언과 데이터가 섞이지 않게 전용 유저를 따로 쓴다
+        String user = "29";
+        String atLimit = "가".repeat(MiniChallenge.TITLE_MAX_LENGTH);
+
+        // 1) 공백만 있는 제목 — 저장 전에 400
+        mvc.perform(post("/api/mini-challenges")
+                        .header("X-User-Id", user)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"custom\":{\"title\":\"   \",\"durationDays\":7}}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("MINI_INVALID_BODY"));
+
+        // 2) 상한을 한 글자 넘긴 제목 — INSERT까지 가지 않고 400
+        mvc.perform(post("/api/mini-challenges")
+                        .header("X-User-Id", user)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"custom\":{\"title\":\"" + atLimit + "가\",\"durationDays\":7}}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("MINI_INVALID_BODY"));
+
+        // 3) 경계값(딱 상한) — 검증 상한과 컬럼 길이가 어긋나면 여기서 저장이 터진다
+        mvc.perform(post("/api/mini-challenges")
+                        .header("X-User-Id", user)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"custom\":{\"title\":\"" + atLimit + "\",\"durationDays\":7}}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.title").value(atLimit));
+
+        // 4) 저장된 값이 잘렸는지는 DB에서 다시 읽어야 드러난다 — 응답 본문은 방금 만든 객체를 그대로 실어 보내기 때문
+        mvc.perform(get("/api/mini-challenges").header("X-User-Id", user))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.items[0].title").value(atLimit));
     }
 }


### PR DESCRIPTION
## 📎연관된 이슈

- close: #46

## 📄 작업 내용 요약

- `MiniChallenge`에 `TITLE_MAX_LENGTH = 255` 상수를 만들고, `MiniChallenge.title`·`RecommendedMiniChallenge.title` 두 컬럼에 `length = TITLE_MAX_LENGTH`를 명시했습니다. 서비스에 따로 있던 사설 상한(`MAX_TITLE_LENGTH`)은 지우고 같은 상수를 쓰게 해서, 검증 상한과 저장 컬럼 길이가 한 곳에서만 정의됩니다.
- 경계값 통합 테스트를 추가했습니다: 공백만 있는 제목 400 / 상한을 한 글자 넘긴 제목 400 / 딱 255자 제목은 저장되고 목록 재조회에서 잘리지 않고 그대로 나오는지. 검증 상한과 컬럼 길이가 어긋나면 이 테스트가 잡습니다.
- 두 번째 커밋(b796cc8)은 코드 변경 없이 미니 도메인 3파일의 주석 정리입니다(동작 원리 설명 제거, 제약·의도만 유지).

## 👀 중요 변경 사항

- API 요청·응답·에러 코드 변경 없음. 상한 값도 기존과 같은 255라 동작이 바뀌는 입력이 없습니다.
- DDL 영향 없음 — 255는 length 미지정 시 Hibernate 기본값과 같아서 `ddl-auto=update`가 기존 개발 DB에 ALTER를 내보내지 않습니다.
- `RecommendedMiniChallenge.title`이 `MiniChallenge.TITLE_MAX_LENGTH`를 참조합니다. 추천 카탈로그 값이 유저 미니로 그대로 복사되는 구조라, 두 컬럼과 서비스 검증이 항상 같은 값으로 움직이게 한 의도적 결합입니다.

## 🔖 Uncompleted Tasks

- 상한은 저장이 터지지 않게 하는 서버 방어값으로 255를 유지합니다. 제품 차원의 제목 길이 제한(더 좁은 값)이 화면에서 확정되면 그때 별도로 다룹니다 — 값을 좁히면 기존 DB에 ALTER가 나가므로 그 영향 확인도 그때 함께.

## 📢 To Reviewers

- 커밋 단위로 보시면 빠릅니다: 87d3afe가 실제 변경(4파일), b796cc8은 주석만 정리한 커밋입니다.