### PR TITLE
feat: 햄배틀 초대 링크 조회 및 참가 API 구현

### DIFF
--- a/src/main/java/Hampouch/server/domain/battle/controller/BattleController.java
+++ b/src/main/java/Hampouch/server/domain/battle/controller/BattleController.java
@@ -1,5 +1,6 @@
 package Hampouch.server.domain.battle.controller;
 
+import Hampouch.server.domain.battle.dto.BattleInvitationResponse;
 import Hampouch.server.domain.battle.dto.BattleListResponse;
 import Hampouch.server.domain.battle.dto.CreateBattleRequest;
 import Hampouch.server.domain.battle.dto.CreateBattleResponse;
@@ -15,7 +16,7 @@ import org.springframework.web.bind.annotation.*;
 import java.net.URI;
 
 /**
- * 햄배틀 생성/목록 조회 API. 참가·상세조회는 이후 이슈.
+ * 햄배틀 생성/목록 조회/참가 링크 조회/참가 API. 상세조회+랭킹은 이후 이슈.
  */
 @RestController
 @RequestMapping(BattleController.BASE_PATH)
@@ -43,5 +44,30 @@ public class BattleController {
             @LoginUserId Long userId,
             @RequestParam(required = false) BattleStatus status) {
         return ApiResponse.success(battleService.getMyBattles(userId, status));
+    }
+
+    /**
+     * GET /api/battles/invitations/{battleCode} — 참가 전 미리보기(로그인 필수).
+     * 참가 가능 여부는 응답 필드가 아니라 에러(BATTLE_FULL 등)로 분기하므로 200이면 곧 참가 가능.
+     */
+    @GetMapping("/invitations/{battleCode}")
+    public ApiResponse<BattleInvitationResponse> getInvitation(
+            @LoginUserId Long userId,
+            @PathVariable String battleCode) {
+        return ApiResponse.success(battleService.getInvitation(userId, battleCode));
+    }
+
+    /**
+     * POST /api/battles/invitations/{battleCode} — 참가. 반환할 데이터가 없어(참가자 등록 자체가
+     * 목적) ApiResponse.success()의 no-arg 버전 사용, 위치는 Location 헤더로 충분히 전달됨.
+     */
+    @PostMapping("/invitations/{battleCode}")
+    public ResponseEntity<ApiResponse<Void>> join(
+            @LoginUserId Long userId,
+            @PathVariable String battleCode) {
+        Long battleId = battleService.join(userId, battleCode);
+        return ResponseEntity
+                .created(URI.create(BASE_PATH + "/" + battleId))
+                .body(ApiResponse.success());
     }
 }

--- a/src/main/java/Hampouch/server/domain/battle/dto/BattleInvitationResponse.java
+++ b/src/main/java/Hampouch/server/domain/battle/dto/BattleInvitationResponse.java
@@ -1,0 +1,30 @@
+package Hampouch.server.domain.battle.dto;
+
+import Hampouch.server.domain.battle.entity.Battle;
+
+import java.time.LocalDate;
+
+/**
+ * GET /battles/invitations/{battleCode} 응답
+ * 참가 가능 여부는 별도 필드가 아니라 에러(BATTLE_FULL/BATTLE_ALREADY_STARTED/ALREADY_JOINED/
+ * BATTLE_CANCELLED)로 분기하므로, 이 레코드가 만들어졌다는 사실 자체가 참가 가능을 의미
+ */
+public record BattleInvitationResponse(
+        String title,
+        String penalty,
+        int capacity,
+        int joinedCount,
+        LocalDate startDate,
+        LocalDate endDate
+) {
+    public static BattleInvitationResponse from(Battle battle, int joinedCount) {
+        return new BattleInvitationResponse(
+                battle.getTitle(),
+                battle.getPenalty(),
+                battle.getCapacity(),
+                joinedCount,
+                battle.getStartDate(),
+                battle.getEndDate()
+        );
+    }
+}

--- a/src/main/java/Hampouch/server/domain/battle/dto/BattleInvitationResponse.java
+++ b/src/main/java/Hampouch/server/domain/battle/dto/BattleInvitationResponse.java
@@ -5,9 +5,14 @@ import Hampouch.server.domain.battle.entity.Battle;
 import java.time.LocalDate;
 
 /**
- * GET /battles/invitations/{battleCode} 응답
- * 참가 가능 여부는 별도 필드가 아니라 에러(BATTLE_FULL/BATTLE_ALREADY_STARTED/ALREADY_JOINED/
- * BATTLE_CANCELLED)로 분기하므로, 이 레코드가 만들어졌다는 사실 자체가 참가 가능을 의미
+ * GET /battles/invitations/{battleCode} 응답 — battleId는 포함하지 않는다(참가 전 미리보기라
+ * battleId 리소스는 참가자 전용이라는 원칙, hampouch_battle_api_review 확정 사항). 참가 가능
+ * 여부는 별도 필드가 아니라 에러(BATTLE_FULL/BATTLE_ALREADY_STARTED/ALREADY_JOINED/
+ * BATTLE_CANCELLED)로 분기하므로, 이 레코드가 만들어졌다는 사실 자체가 "참가 가능"을 의미한다.
+ *
+ * endDate 대신 durationDays인 이유(2026-08-01, 초대 링크 진입 화면 Figma 확인): 화면이
+ * "종료일"을 따로 안 보여주고 "7일 · 5인"처럼 durationDays(3/7/14/31 프리셋)를 그대로 노출한다.
+ * startDate는 화면에 아직 없지만 디자이너에게 명시 요청 예정(반영 가능성 높음)이라 미리 유지한다.
  */
 public record BattleInvitationResponse(
         String title,
@@ -15,7 +20,7 @@ public record BattleInvitationResponse(
         int capacity,
         int joinedCount,
         LocalDate startDate,
-        LocalDate endDate
+        int durationDays
 ) {
     public static BattleInvitationResponse from(Battle battle, int joinedCount) {
         return new BattleInvitationResponse(
@@ -24,7 +29,7 @@ public record BattleInvitationResponse(
                 battle.getCapacity(),
                 joinedCount,
                 battle.getStartDate(),
-                battle.getEndDate()
+                battle.getDurationDays()
         );
     }
 }

--- a/src/main/java/Hampouch/server/domain/battle/repository/BattleRepository.java
+++ b/src/main/java/Hampouch/server/domain/battle/repository/BattleRepository.java
@@ -1,9 +1,28 @@
 package Hampouch.server.domain.battle.repository;
 
 import Hampouch.server.domain.battle.entity.Battle;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface BattleRepository extends JpaRepository<Battle, Long> {
 
     boolean existsByBattleCode(String battleCode);
+
+    /** 참가 링크 조회(GET /invitations/{battleCode})용 — 락 없는 단순 조회. 없으면 BATTLE_CODE_NOT_FOUND. */
+    Optional<Battle> findByBattleCode(String battleCode);
+
+    /**
+     * 참가(POST /invitations/{battleCode}) 전용 — Battle row를 PESSIMISTIC_WRITE로 잠근다.
+     * 중복 참가는 BattleParticipant의 uq_battle_participant 유니크 제약이 이미 막아주지만,
+     * 정원 초과 여부를 방지를 위해 락이 필요: 4/5명 상태에서 서로 다른 두 유저가 동시에 countByBattle_Id()를 읽으면
+     * 둘 다 자리 있음으로 통과해 6명이 될 수 있기 때문이다.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT b FROM Battle b WHERE b.battleCode = :battleCode")
+    Optional<Battle> findByBattleCodeForUpdate(@Param("battleCode") String battleCode);
 }

--- a/src/main/java/Hampouch/server/domain/battle/service/BattleService.java
+++ b/src/main/java/Hampouch/server/domain/battle/service/BattleService.java
@@ -1,5 +1,6 @@
 package Hampouch.server.domain.battle.service;
 
+import Hampouch.server.domain.battle.dto.BattleInvitationResponse;
 import Hampouch.server.domain.battle.dto.BattleListResponse;
 import Hampouch.server.domain.battle.dto.BattleSummary;
 import Hampouch.server.domain.battle.dto.CreateBattleRequest;
@@ -15,6 +16,7 @@ import Hampouch.server.global.common.exception.CustomException;
 import Hampouch.server.global.common.exception.domain.BattleErrorCode;
 import Hampouch.server.global.common.exception.domain.CommonErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,7 +26,7 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * 배틀 생성 + 목록 조회의 서비스 계층. 참가/랭킹/배치는 이후 구현 예정.
+ * 배틀 생성/목록/참가 링크 조회/참가의 서비스 계층. 상세조회·랭킹·배치는 이후 구현 예정.
  */
 @Service
 @RequiredArgsConstructor
@@ -75,6 +77,39 @@ public class BattleService {
         return new BattleListResponse(summaries);
     }
 
+    /**
+     * GET /battles/invitations/{battleCode}. 락 없는 단순 조회 — 참가와 달리 여기선 참가자를
+     * insert하지 않으므로 카운트 레이스가 응답 하나 잘못 보여주는 것 이상의 피해를 못 준다
+     */
+    public BattleInvitationResponse getInvitation(Long userId, String battleCode) {
+        Battle battle = battleRepository.findByBattleCode(battleCode)
+                .orElseThrow(() -> new CustomException(BattleErrorCode.BATTLE_CODE_NOT_FOUND));
+        validateJoinable(battle, userId);
+        int joinedCount = battleParticipantRepository.countByBattle_Id(battle.getId());
+        return BattleInvitationResponse.from(battle, joinedCount);
+    }
+
+    /**
+     * POST /battles/invitations/{battleCode}. findByBattleCodeForUpdate로 Battle row를 잠근 채
+     * validateJoinable을 통과해야 insert까지 간다.
+     * DataIntegrityViolationException은 검증 통과 직후 같은 유저의 동시 재요청이 uq_battle_participant에
+     * 걸린 극단적 타이밍 케이스 방어용
+     */
+    @Transactional
+    public Long join(Long userId, String battleCode) {
+        Battle battle = battleRepository.findByBattleCodeForUpdate(battleCode)
+                .orElseThrow(() -> new CustomException(BattleErrorCode.BATTLE_CODE_NOT_FOUND));
+        validateJoinable(battle, userId);
+
+        User user = userRepository.getReferenceById(userId);
+        try {
+            battleParticipantRepository.save(BattleParticipant.of(user, battle));
+        } catch (DataIntegrityViolationException e) {
+            throw new CustomException(BattleErrorCode.ALREADY_JOINED);
+        }
+        return battle.getId();
+    }
+
     private void validateCapacity(int capacity) {
         if (capacity < 2 || capacity > 10) {
             throw new CustomException(BattleErrorCode.INVALID_CAPACITY_RANGE);
@@ -91,6 +126,26 @@ public class BattleService {
     private void validateStartDate(LocalDate startDate) {
         if (startDate.isBefore(LocalDate.now(clock))) {
             throw new CustomException(BattleErrorCode.INVALID_START_DATE);
+        }
+    }
+
+    /**
+     * 참가 링크 조회/참가 공통 검증. CANCELLED된 Battle의 경우 400 Error를 반환하므로 다른 status보다 먼저 검증.
+     * 이후 햄배틀의 상태가 READY(참여 가능)인지 조회 후, ALREADY_JOINED와 BATTLE_FULL을 검증(인원이 찬 경우에도
+     * 이미 참여한 배틀의 경우 ALREADY_JOINED이므로)
+     */
+    private void validateJoinable(Battle battle, Long userId) {
+        if (battle.getStatus() == BattleStatus.CANCELLED) {
+            throw new CustomException(BattleErrorCode.BATTLE_CANCELLED);
+        }
+        if (battle.getStatus() != BattleStatus.READY) {
+            throw new CustomException(BattleErrorCode.BATTLE_ALREADY_STARTED);
+        }
+        if (battleParticipantRepository.existsByBattle_IdAndUser_Id(battle.getId(), userId)) {
+            throw new CustomException(BattleErrorCode.ALREADY_JOINED);
+        }
+        if (battleParticipantRepository.countByBattle_Id(battle.getId()) >= battle.getCapacity()) {
+            throw new CustomException(BattleErrorCode.BATTLE_FULL);
         }
     }
 

--- a/src/test/java/Hampouch/server/domain/battle/controller/BattleControllerTest.java
+++ b/src/test/java/Hampouch/server/domain/battle/controller/BattleControllerTest.java
@@ -1,0 +1,228 @@
+package Hampouch.server.domain.battle.controller;
+
+import Hampouch.server.domain.battle.dto.BattleInvitationResponse;
+import Hampouch.server.domain.battle.dto.BattleListResponse;
+import Hampouch.server.domain.battle.dto.BattleSummary;
+import Hampouch.server.domain.battle.dto.CreateBattleResponse;
+import Hampouch.server.domain.battle.entity.BattleStatus;
+import Hampouch.server.domain.battle.service.BattleService;
+import Hampouch.server.global.common.exception.CustomException;
+import Hampouch.server.global.common.exception.domain.BattleErrorCode;
+import Hampouch.server.global.jwt.JwtProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * 웹 계층(검증·상태코드·팀 공통 에러 응답 매핑) 검증. 서비스는 목 — DB 불필요
+ * (ExpenseControllerTest와 동일 스타일 — BattleController도 X-User-Id 스텁이 아니라
+ * @LoginUserId를 쓰므로 challenge 쪽이 아니라 expense 쪽 컨벤션을 따른다).
+ */
+@WebMvcTest(BattleController.class)
+@AutoConfigureMockMvc(addFilters = false) // 시큐리티 필터 제외 — 웹 계층(상태코드·필드)만 검증
+class BattleControllerTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    @MockitoBean
+    BattleService service;
+
+    @MockitoBean
+    JwtProvider jwtProvider; // SecurityConfig가 요구하는 빈 — addFilters=false라 실제 토큰 검증엔 안 쓰임
+
+    private static final Long OWNER = 1L;
+
+    /**
+     * @LoginUserId가 읽어갈 인증 정보를 테스트 스레드의 SecurityContextHolder에 직접 심는다.
+     * addFilters=false라 JwtFilter가 아예 안 돌기 때문에, .with(authentication(...))처럼
+     * 필터가 복원해주길 기대하는 방식은 동작하지 않는다(ExpenseControllerTest와 동일 이유).
+     */
+    @BeforeEach
+    void setUpSecurityContext() {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(new UsernamePasswordAuthenticationToken(
+                OWNER, null, List.of(new SimpleGrantedAuthority("ROLE_USER"))));
+        SecurityContextHolder.setContext(context);
+    }
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    // ---------- create ----------
+
+    @Test
+    @DisplayName("생성 요청이 정상이면 201 Created와 Location 헤더, 생성 결과 본문을 돌려준다")
+    void create_201() throws Exception {
+        when(service.create(anyLong(), any())).thenReturn(new CreateBattleResponse(
+                1L, "ABCD1234", "짠테크 배틀", 4, 7,
+                LocalDate.of(2026, 8, 1), LocalDate.of(2026, 8, 7), "치킨 사주기", BattleStatus.READY));
+
+        mvc.perform(post("/api/battles")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "title": "짠테크 배틀", "capacity": 4, "durationDays": 7,
+                                  "startDate": "2026-08-01", "penalty": "치킨 사주기" }
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location", "/api/battles/1"))
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.battleCode").value("ABCD1234"))
+                .andExpect(jsonPath("$.data.status").value("READY"));
+    }
+
+    @Test
+    @DisplayName("title이 비어 있으면 400으로 거절한다 (@NotBlank)")
+    void create_400_whenTitleBlank() throws Exception {
+        mvc.perform(post("/api/battles")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "title": "", "capacity": 4, "durationDays": 7,
+                                  "startDate": "2026-08-01", "penalty": "치킨 사주기" }
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("정원이 범위를 벗어나면 서비스가 던진 400(INVALID_CAPACITY_RANGE)을 팀 공통 에러 본문으로 그대로 내려준다")
+    void create_400_whenCapacityOutOfRange() throws Exception {
+        when(service.create(anyLong(), any()))
+                .thenThrow(new CustomException(BattleErrorCode.INVALID_CAPACITY_RANGE));
+
+        mvc.perform(post("/api/battles")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "title": "짠테크 배틀", "capacity": 11, "durationDays": 7,
+                                  "startDate": "2026-08-01", "penalty": "치킨 사주기" }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_CAPACITY_RANGE"));
+    }
+
+    // ---------- getMyBattles ----------
+
+    @Test
+    @DisplayName("목록 조회가 정상이면 200과 배틀 카드 배열을 돌려준다")
+    void getMyBattles_200() throws Exception {
+        when(service.getMyBattles(eq(OWNER), any()))
+                .thenReturn(new BattleListResponse(List.of(new BattleSummary.Ready(
+                        1L, "ABCD1234", "짠테크 배틀", "치킨 사주기",
+                        LocalDate.of(2026, 8, 1), LocalDate.of(2026, 8, 7), BattleStatus.READY,
+                        4, 2))));
+
+        mvc.perform(get("/api/battles"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.battles[0].battleId").value(1))
+                .andExpect(jsonPath("$.data.battles[0].capacity").value(4))
+                .andExpect(jsonPath("$.data.battles[0].joinedCount").value(2));
+    }
+
+    @Test
+    @DisplayName("status 쿼리 파라미터를 그대로 서비스에 전달한다")
+    void getMyBattles_passesStatusFilter() throws Exception {
+        when(service.getMyBattles(OWNER, BattleStatus.ONGOING)).thenReturn(new BattleListResponse(List.of()));
+
+        mvc.perform(get("/api/battles").param("status", "ONGOING"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.battles").isEmpty());
+    }
+
+    // ---------- getInvitation ----------
+
+    @Test
+    @DisplayName("참가 링크 조회가 정상이면 200과 미리보기 본문(battleId 제외)을 돌려준다")
+    void getInvitation_200() throws Exception {
+        when(service.getInvitation(OWNER, "ABCD1234")).thenReturn(new BattleInvitationResponse(
+                "짠테크 배틀", "치킨 사주기", 4, 2,
+                LocalDate.of(2026, 8, 1), LocalDate.of(2026, 8, 7)));
+
+        mvc.perform(get("/api/battles/invitations/ABCD1234"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.title").value("짠테크 배틀"))
+                .andExpect(jsonPath("$.data.joinedCount").value(2))
+                .andExpect(jsonPath("$.data.battleId").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 초대 코드면 404(BATTLE_CODE_NOT_FOUND)를 돌려준다")
+    void getInvitation_404_whenCodeNotFound() throws Exception {
+        when(service.getInvitation(OWNER, "ZZZZ9999"))
+                .thenThrow(new CustomException(BattleErrorCode.BATTLE_CODE_NOT_FOUND));
+
+        mvc.perform(get("/api/battles/invitations/ZZZZ9999"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("BATTLE_CODE_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("정원이 찬 배틀이면 409(BATTLE_FULL)를 돌려준다")
+    void getInvitation_409_whenFull() throws Exception {
+        when(service.getInvitation(OWNER, "ABCD1234"))
+                .thenThrow(new CustomException(BattleErrorCode.BATTLE_FULL));
+
+        mvc.perform(get("/api/battles/invitations/ABCD1234"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("BATTLE_FULL"));
+    }
+
+    @Test
+    @DisplayName("이미 취소된 배틀이면 400(BATTLE_CANCELLED)을 돌려준다 — 다른 409들과 달리 의도적으로 400")
+    void getInvitation_400_whenCancelled() throws Exception {
+        when(service.getInvitation(OWNER, "ABCD1234"))
+                .thenThrow(new CustomException(BattleErrorCode.BATTLE_CANCELLED));
+
+        mvc.perform(get("/api/battles/invitations/ABCD1234"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("BATTLE_CANCELLED"));
+    }
+
+    // ---------- join ----------
+
+    @Test
+    @DisplayName("참가가 정상이면 201 Created와 Location 헤더를 돌려준다 — 반환 데이터가 없어 data 필드는 아예 없다")
+    void join_201() throws Exception {
+        when(service.join(OWNER, "ABCD1234")).thenReturn(1L);
+
+        mvc.perform(post("/api/battles/invitations/ABCD1234"))
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location", "/api/battles/1"))
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.data").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("이미 참가한 배틀이면 409(ALREADY_JOINED)를 돌려준다")
+    void join_409_whenAlreadyJoined() throws Exception {
+        when(service.join(OWNER, "ABCD1234"))
+                .thenThrow(new CustomException(BattleErrorCode.ALREADY_JOINED));
+
+        mvc.perform(post("/api/battles/invitations/ABCD1234"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("ALREADY_JOINED"));
+    }
+}

--- a/src/test/java/Hampouch/server/domain/battle/controller/BattleControllerTest.java
+++ b/src/test/java/Hampouch/server/domain/battle/controller/BattleControllerTest.java
@@ -202,6 +202,9 @@ class BattleControllerTest {
     }
 
     // ---------- join ----------
+    // CANCELLED/ALREADY_STARTED/BATTLE_FULL은 join과 getInvitation이 validateJoinable()을 공유하고
+    // 에러 매핑(GlobalExceptionHandler)도 공통이라 위 getInvitation 케이스로 이미 검증됨 — 여기선
+    // join 고유 관심사(성공 시 저장 흐름, 그리고 참가에서 특히 자주 맞물리는 404/409)만 확인한다.
 
     @Test
     @DisplayName("참가가 정상이면 201 Created와 Location 헤더를 돌려준다 — 반환 데이터가 없어 data 필드는 아예 없다")
@@ -213,6 +216,18 @@ class BattleControllerTest {
                 .andExpect(header().string("Location", "/api/battles/1"))
                 .andExpect(jsonPath("$.code").value("SUCCESS"))
                 .andExpect(jsonPath("$.data").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 초대 코드로 참가를 시도하면 404(BATTLE_CODE_NOT_FOUND)를 돌려준다 " +
+            "— 락 조회(findByBattleCodeForUpdate) 경로도 조회(getInvitation)와 동일한 404 매핑인지 확인")
+    void join_404_whenCodeNotFound() throws Exception {
+        when(service.join(OWNER, "ZZZZ9999"))
+                .thenThrow(new CustomException(BattleErrorCode.BATTLE_CODE_NOT_FOUND));
+
+        mvc.perform(post("/api/battles/invitations/ZZZZ9999"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("BATTLE_CODE_NOT_FOUND"));
     }
 
     @Test

--- a/src/test/java/Hampouch/server/domain/battle/controller/BattleControllerTest.java
+++ b/src/test/java/Hampouch/server/domain/battle/controller/BattleControllerTest.java
@@ -154,18 +154,20 @@ class BattleControllerTest {
     // ---------- getInvitation ----------
 
     @Test
-    @DisplayName("참가 링크 조회가 정상이면 200과 미리보기 본문(battleId 제외)을 돌려준다")
+    @DisplayName("참가 링크 조회가 정상이면 200과 미리보기 본문(battleId 제외, endDate 대신 durationDays)을 돌려준다")
     void getInvitation_200() throws Exception {
         when(service.getInvitation(OWNER, "ABCD1234")).thenReturn(new BattleInvitationResponse(
                 "짠테크 배틀", "치킨 사주기", 4, 2,
-                LocalDate.of(2026, 8, 1), LocalDate.of(2026, 8, 7)));
+                LocalDate.of(2026, 8, 1), 7));
 
         mvc.perform(get("/api/battles/invitations/ABCD1234"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value("SUCCESS"))
                 .andExpect(jsonPath("$.data.title").value("짠테크 배틀"))
                 .andExpect(jsonPath("$.data.joinedCount").value(2))
-                .andExpect(jsonPath("$.data.battleId").doesNotExist());
+                .andExpect(jsonPath("$.data.durationDays").value(7))
+                .andExpect(jsonPath("$.data.battleId").doesNotExist())
+                .andExpect(jsonPath("$.data.endDate").doesNotExist());
     }
 
     @Test

--- a/src/test/java/Hampouch/server/domain/battle/repository/BattleRepositoryTest.java
+++ b/src/test/java/Hampouch/server/domain/battle/repository/BattleRepositoryTest.java
@@ -14,13 +14,14 @@ import org.springframework.context.annotation.Import;
 import org.springframework.dao.DataIntegrityViolationException;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * battleCode 존재 여부 조회와 uq_battle_code 유니크 제약을 H2에 실제 적용해 검증 —
- * BattleCodeGenerator의 충돌 재시도 판단이 여기 의존한다.
+ * battleCode 존재 여부 조회, battleCode 단건 조회(락 유무 두 버전), uq_battle_code 유니크 제약을
+ * H2에 실제 적용해 검증 — BattleCodeGenerator의 충돌 재시도 판단과 참가 플로우가 여기 의존한다.
  */
 @DataJpaTest
 @Import({ClockConfig.class, JpaAuditingConfig.class})
@@ -57,5 +58,37 @@ class BattleRepositoryTest {
         assertThatThrownBy(() -> battleRepository.saveAndFlush(Battle.of("ABCD1234", "다른 배틀", 3, 3,
                 LocalDate.of(2026, 8, 2), "커피 사주기", creator)))
                 .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    @DisplayName("findByBattleCode는 저장된 코드가 있으면 그 배틀을 반환한다")
+    void findByBattleCode_returnsBattleWhenExists() {
+        Battle saved = battleRepository.save(Battle.of("ABCD1234", "짠테크 배틀", 4, 7,
+                LocalDate.of(2026, 8, 1), "치킨 사주기", creator));
+
+        Optional<Battle> found = battleRepository.findByBattleCode("ABCD1234");
+
+        assertThat(found).isPresent();
+        assertThat(found.get().getId()).isEqualTo(saved.getId());
+    }
+
+    @Test
+    @DisplayName("findByBattleCode는 존재하지 않는 코드면 빈 값을 반환한다")
+    void findByBattleCode_returnsEmptyWhenNotExists() {
+        assertThat(battleRepository.findByBattleCode("ZZZZ9999")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findByBattleCodeForUpdate도 findByBattleCode와 동일한 배틀을 반환한다 — " +
+            "PESSIMISTIC_WRITE 자체(동시 요청 직렬화 효과)는 단일 스레드 단위 테스트로 검증할 수 없어, " +
+            "여기선 락을 걸어도 조회 결과 자체는 달라지지 않는다는 것만 확인한다")
+    void findByBattleCodeForUpdate_returnsSameBattleAsPlainFind() {
+        Battle saved = battleRepository.save(Battle.of("ABCD1234", "짠테크 배틀", 4, 7,
+                LocalDate.of(2026, 8, 1), "치킨 사주기", creator));
+
+        Optional<Battle> found = battleRepository.findByBattleCodeForUpdate("ABCD1234");
+
+        assertThat(found).isPresent();
+        assertThat(found.get().getId()).isEqualTo(saved.getId());
     }
 }

--- a/src/test/java/Hampouch/server/domain/battle/service/BattleServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/battle/service/BattleServiceTest.java
@@ -1,5 +1,6 @@
 package Hampouch.server.domain.battle.service;
 
+import Hampouch.server.domain.battle.dto.BattleInvitationResponse;
 import Hampouch.server.domain.battle.dto.BattleListResponse;
 import Hampouch.server.domain.battle.dto.BattleSummary;
 import Hampouch.server.domain.battle.dto.CreateBattleRequest;
@@ -20,12 +21,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -33,13 +36,15 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 /**
- * 생성 검증 로직 + 상태별 카드 매핑 검증. 리포지토리는 Mockito 목 — DB 불필요(ExpenseServiceTest와 동일 스타일).
+ * 생성 검증 로직 + 상태별 카드 매핑 + 참가 링크 조회/참가 검증 로직을 검증.
+ * 리포지토리는 Mockito 목 — DB 불필요(ExpenseServiceTest와 동일 스타일).
  */
 @ExtendWith(MockitoExtension.class)
 class BattleServiceTest {
 
     private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
     private static final Long OWNER = 1L;
+    private static final Long BATTLE_ID = 10L;
 
     @Mock
     BattleRepository battleRepository;
@@ -63,6 +68,25 @@ class BattleServiceTest {
 
     private static CreateBattleRequest request(int capacity, int durationDays, LocalDate startDate) {
         return new CreateBattleRequest("짠테크 배틀", capacity, durationDays, startDate, "치킨 사주기");
+    }
+
+    /** 참가 링크 조회/참가 테스트 공용 — status별 Battle을 만들어 BATTLE_ID를 부여한다. */
+    private static Battle battleWithStatus(BattleStatus status, int capacity) {
+        Battle battle = Battle.of("ABCD1234", "짠테크 배틀", capacity, 7,
+                LocalDate.of(2026, 8, 1), "치킨 사주기", user(99L));
+        ReflectionTestUtils.setField(battle, "id", BATTLE_ID);
+        switch (status) {
+            case ONGOING -> battle.start();
+            case TERMINATED -> {
+                battle.start();
+                battle.terminate(user(2L));
+            }
+            case CANCELLED -> battle.cancel();
+            case READY -> {
+                // Battle.of()가 이미 READY로 만들어줌 — 추가 전이 불필요
+            }
+        }
+        return battle;
     }
 
     // ---------- create ----------
@@ -188,5 +212,128 @@ class BattleServiceTest {
         BattleListResponse res = serviceAt(LocalDate.of(2026, 7, 1)).getMyBattles(OWNER, null);
 
         assertThat(res.battles().get(0)).isInstanceOf(BattleSummary.Terminated.class);
+    }
+
+    // ---------- getInvitation ----------
+    // validateJoinable의 우선순위 4단계(CANCELLED → ALREADY_STARTED → ALREADY_JOINED → BATTLE_FULL)를
+    // 여기서 전부 검증한다 — join()도 같은 private 메서드를 재사용하므로 join 쪽에선 중복 검증하지 않는다.
+
+    @Test
+    @DisplayName("존재하지 않는 battleCode면 404(BATTLE_CODE_NOT_FOUND)를 던진다")
+    void getInvitation_throwsWhenCodeNotFound() {
+        when(battleRepository.findByBattleCode("ZZZZ9999")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 7, 1)).getInvitation(OWNER, "ZZZZ9999"))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", BattleErrorCode.BATTLE_CODE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("CANCELLED 배틀이면 400(BATTLE_CANCELLED)을 던진다 — 다른 사유보다 우선 판단")
+    void getInvitation_throwsWhenCancelled() {
+        Battle battle = battleWithStatus(BattleStatus.CANCELLED, 4);
+        when(battleRepository.findByBattleCode("ABCD1234")).thenReturn(Optional.of(battle));
+
+        assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 7, 1)).getInvitation(OWNER, "ABCD1234"))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", BattleErrorCode.BATTLE_CANCELLED);
+    }
+
+    @Test
+    @DisplayName("READY가 아니면(ONGOING/TERMINATED) 409(BATTLE_ALREADY_STARTED)를 던진다")
+    void getInvitation_throwsWhenAlreadyStarted() {
+        Battle battle = battleWithStatus(BattleStatus.ONGOING, 4);
+        when(battleRepository.findByBattleCode("ABCD1234")).thenReturn(Optional.of(battle));
+
+        assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 7, 1)).getInvitation(OWNER, "ABCD1234"))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", BattleErrorCode.BATTLE_ALREADY_STARTED);
+    }
+
+    @Test
+    @DisplayName("이미 참가한 유저면 409(ALREADY_JOINED)를 던진다 — 정원이 다 찼어도 이 사유가 BATTLE_FULL보다 우선")
+    void getInvitation_throwsWhenAlreadyJoined() {
+        Battle battle = battleWithStatus(BattleStatus.READY, 4);
+        when(battleRepository.findByBattleCode("ABCD1234")).thenReturn(Optional.of(battle));
+        when(battleParticipantRepository.existsByBattle_IdAndUser_Id(BATTLE_ID, OWNER)).thenReturn(true);
+
+        assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 7, 1)).getInvitation(OWNER, "ABCD1234"))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", BattleErrorCode.ALREADY_JOINED);
+    }
+
+    @Test
+    @DisplayName("정원이 다 찼으면 409(BATTLE_FULL)를 던진다")
+    void getInvitation_throwsWhenFull() {
+        Battle battle = battleWithStatus(BattleStatus.READY, 4);
+        when(battleRepository.findByBattleCode("ABCD1234")).thenReturn(Optional.of(battle));
+        when(battleParticipantRepository.existsByBattle_IdAndUser_Id(BATTLE_ID, OWNER)).thenReturn(false);
+        when(battleParticipantRepository.countByBattle_Id(BATTLE_ID)).thenReturn(4);
+
+        assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 7, 1)).getInvitation(OWNER, "ABCD1234"))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", BattleErrorCode.BATTLE_FULL);
+    }
+
+    @Test
+    @DisplayName("참가 가능한 상태면 joinedCount를 포함한 미리보기를 반환한다 (battleId는 응답에 없음)")
+    void getInvitation_returnsPreviewWhenJoinable() {
+        Battle battle = battleWithStatus(BattleStatus.READY, 4);
+        when(battleRepository.findByBattleCode("ABCD1234")).thenReturn(Optional.of(battle));
+        when(battleParticipantRepository.existsByBattle_IdAndUser_Id(BATTLE_ID, OWNER)).thenReturn(false);
+        when(battleParticipantRepository.countByBattle_Id(BATTLE_ID)).thenReturn(2);
+
+        BattleInvitationResponse res = serviceAt(LocalDate.of(2026, 7, 1)).getInvitation(OWNER, "ABCD1234");
+
+        assertThat(res.title()).isEqualTo("짠테크 배틀");
+        assertThat(res.capacity()).isEqualTo(4);
+        assertThat(res.joinedCount()).isEqualTo(2);
+    }
+
+    // ---------- join ----------
+
+    @Test
+    @DisplayName("존재하지 않는 battleCode면 404(BATTLE_CODE_NOT_FOUND)를 던진다 — 락 조회(findByBattleCodeForUpdate)도 동일 처리")
+    void join_throwsWhenCodeNotFound() {
+        when(battleRepository.findByBattleCodeForUpdate("ZZZZ9999")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 7, 1)).join(OWNER, "ZZZZ9999"))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", BattleErrorCode.BATTLE_CODE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("참가 가능하면 참가자를 저장하고 battleId를 반환한다")
+    void join_savesParticipantAndReturnsBattleId() {
+        Battle battle = battleWithStatus(BattleStatus.READY, 4);
+        when(battleRepository.findByBattleCodeForUpdate("ABCD1234")).thenReturn(Optional.of(battle));
+        when(battleParticipantRepository.existsByBattle_IdAndUser_Id(BATTLE_ID, OWNER)).thenReturn(false);
+        when(battleParticipantRepository.countByBattle_Id(BATTLE_ID)).thenReturn(2);
+        when(userRepository.getReferenceById(OWNER)).thenReturn(user(OWNER));
+        ArgumentCaptor<BattleParticipant> captor = ArgumentCaptor.forClass(BattleParticipant.class);
+        when(battleParticipantRepository.save(captor.capture())).thenAnswer(inv -> inv.getArgument(0));
+
+        Long battleId = serviceAt(LocalDate.of(2026, 7, 1)).join(OWNER, "ABCD1234");
+
+        assertThat(battleId).isEqualTo(BATTLE_ID);
+        assertThat(captor.getValue().getUser().getId()).isEqualTo(OWNER);
+        assertThat(captor.getValue().getBattle()).isSameAs(battle);
+    }
+
+    @Test
+    @DisplayName("검증을 통과했더라도 저장 시점에 유니크 제약(uq_battle_participant) 위반이 나면 " +
+            "ALREADY_JOINED로 변환한다 — challenge #31과 동일한, 동시 재요청을 막는 마지막 방어선")
+    void join_convertsUniqueConstraintViolationToAlreadyJoined() {
+        Battle battle = battleWithStatus(BattleStatus.READY, 4);
+        when(battleRepository.findByBattleCodeForUpdate("ABCD1234")).thenReturn(Optional.of(battle));
+        when(battleParticipantRepository.existsByBattle_IdAndUser_Id(BATTLE_ID, OWNER)).thenReturn(false);
+        when(battleParticipantRepository.countByBattle_Id(BATTLE_ID)).thenReturn(2);
+        when(userRepository.getReferenceById(OWNER)).thenReturn(user(OWNER));
+        when(battleParticipantRepository.save(any(BattleParticipant.class)))
+                .thenThrow(new DataIntegrityViolationException("uq_battle_participant"));
+
+        assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 7, 1)).join(OWNER, "ABCD1234"))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", BattleErrorCode.ALREADY_JOINED);
     }
 }

--- a/src/test/java/Hampouch/server/domain/battle/service/BattleServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/battle/service/BattleServiceTest.java
@@ -288,6 +288,7 @@ class BattleServiceTest {
         assertThat(res.title()).isEqualTo("짠테크 배틀");
         assertThat(res.capacity()).isEqualTo(4);
         assertThat(res.joinedCount()).isEqualTo(2);
+        assertThat(res.durationDays()).isEqualTo(7); // endDate 대신 durationDays(2026-08-01 결정)
     }
 
     // ---------- join ----------

--- a/src/test/java/Hampouch/server/domain/battle/service/BattleServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/battle/service/BattleServiceTest.java
@@ -286,8 +286,10 @@ class BattleServiceTest {
         BattleInvitationResponse res = serviceAt(LocalDate.of(2026, 7, 1)).getInvitation(OWNER, "ABCD1234");
 
         assertThat(res.title()).isEqualTo("짠테크 배틀");
+        assertThat(res.penalty()).isEqualTo("치킨 사주기");
         assertThat(res.capacity()).isEqualTo(4);
         assertThat(res.joinedCount()).isEqualTo(2);
+        assertThat(res.startDate()).isEqualTo(LocalDate.of(2026, 8, 1));
         assertThat(res.durationDays()).isEqualTo(7); // endDate 대신 durationDays(2026-08-01 결정)
     }
 

--- a/src/test/java/Hampouch/server/domain/battle/service/BattleServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/battle/service/BattleServiceTest.java
@@ -242,8 +242,15 @@ class BattleServiceTest {
     @Test
     @DisplayName("READY가 아니면(ONGOING/TERMINATED) 409(BATTLE_ALREADY_STARTED)를 던진다")
     void getInvitation_throwsWhenAlreadyStarted() {
-        Battle battle = battleWithStatus(BattleStatus.ONGOING, 4);
-        when(battleRepository.findByBattleCode("ABCD1234")).thenReturn(Optional.of(battle));
+        Battle ongoing = battleWithStatus(BattleStatus.ONGOING, 4);
+        when(battleRepository.findByBattleCode("ABCD1234")).thenReturn(Optional.of(ongoing));
+
+        assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 7, 1)).getInvitation(OWNER, "ABCD1234"))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", BattleErrorCode.BATTLE_ALREADY_STARTED);
+
+        Battle terminated = battleWithStatus(BattleStatus.TERMINATED, 4);
+        when(battleRepository.findByBattleCode("ABCD1234")).thenReturn(Optional.of(terminated));
 
         assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 7, 1)).getInvitation(OWNER, "ABCD1234"))
                 .isInstanceOf(CustomException.class)


### PR DESCRIPTION
## 📎연관된 이슈

- close: #70

## 📄 작업 내용 요약

햄배틀 두 번째 기능(참가 링크 조회/참가) 구현. `#43`으로 merge된 `Battle`/`BattleParticipant` 위에 이어붙인 작업이라 엔티티 변경은 없음.

- `BattleErrorCode`에 `BATTLE_CODE_NOT_FOUND` 추가(기존 목록에서 누락돼 있던 것 반영)
- `BattleRepository`에 `findByBattleCode`(조회용, 락 없음) / `findByBattleCodeForUpdate`(참가용, `PESSIMISTIC_WRITE`) 추가
- `BattleService`에 `getInvitation()`(참가 전 미리보기) / `join()`(참가) 추가 — 두 메서드가 `validateJoinable()`(우선순위: `BATTLE_CANCELLED` → `BATTLE_ALREADY_STARTED` → `ALREADY_JOINED` → `BATTLE_FULL`) 검증 로직을 공유
- `BattleController`에 `GET`/`POST /api/battles/invitations/{battleCode}` 추가 (`POST`는 `201 Created` + `Location: /api/battles/{battleId}`, 응답 데이터 없음)
- `BattleInvitationResponse` DTO 신설 (`battleId` 미노출, `endDate` 대신 `durationDays` 반환 — 초대 화면 Figma 기준)
- 단위 테스트 추가: `BattleRepositoryTest`, `BattleServiceTest`, `BattleControllerTest`(battle 도메인 최초 컨트롤러 테스트) — 동시 참가/정원 초과 방어 로직 포함

## 👀 중요 변경 사항

- **정원 초과 방지에 `PESSIMISTIC_WRITE` 락 도입**: 참가자 중복(`ALREADY_JOINED`)은 기존 `uq_battle_participant` 유니크 제약만으로 충분하지만, 정원 초과는 서로 다른 유저들의 row 개수를 세는 집계라 유니크 제약으로 못 막아서 `findByBattleCodeForUpdate()`로 `Battle` row를 잠그고 그 안에서 카운트 체크 + insert를 수행하도록 함. 향후 battle 관련 다른 쓰기 작업(③④)도 이 Battle row를 건드릴 때 락 경합 가능성을 염두에 둬야 함.
- **`BattleInvitationResponse`에 `endDate` 없음, `durationDays`로 대체**: 프론트가 종료일이 아니라 기간(3/7/14/31 프리셋)을 그대로 보여주는 화면이라 필드를 맞춤. `startDate`는 화면에 아직 없지만 추후 디자인 반영 가능성이 있어 응답엔 유지.
- **참가 가능 여부는 응답 필드가 아니라 항상 에러로 분기**: `GET`이 200을 반환했다는 것 자체가 "참가 가능"을 의미함 (`invitationStatus` 같은 별도 필드 없음).

## 🔖 Uncompleted Tasks

- ③(상세조회+랭킹), ④(자동 취소·무효화·종료 스냅샷 배치)는 별도 이슈로 이어서 진행 예정.
- `durationDays` 검증은 아직 전용 에러코드 없이 `CommonErrorCode.VALIDATION_ERROR` 재사용 중(`#43`에서부터 이어진 갭, 이번 PR 범위 아님).
- 초대 화면에 `startDate` 노출 여부는 디자이너 확인 대기 중 — 반영 안 되면 `BattleInvitationResponse.startDate` 필드 존치 여부 재검토 필요.

## 📢 To Reviewers

- `BattleService.validateJoinable()`의 에러 우선순위(취소 → 시작됨 → 이미참가 → 정원마감)가 합리적인지 한 번 봐주세요.
- `findByBattleCodeForUpdate()`의 `PESSIMISTIC_WRITE` 락 범위(Battle 단건)가 과하거나 부족하지 않은지 확인 부탁드립니다 — 실제 동시 요청 테스트는 단위 테스트로는 한계가 있어서(H2 + 단일 스레드) 리뷰로 로직만 검증하는 상태입니다.