### PR TITLE
fix: 햄배틀 API 명세-코드 불일치 수정 및 취소된 배틀 목록 노출 차단

### DIFF
--- a/src/main/java/Hampouch/server/domain/battle/controller/BattleController.java
+++ b/src/main/java/Hampouch/server/domain/battle/controller/BattleController.java
@@ -1,5 +1,6 @@
 package Hampouch.server.domain.battle.controller;
 
+import Hampouch.server.domain.battle.dto.BattleInvitationResponse;
 import Hampouch.server.domain.battle.dto.BattleListResponse;
 import Hampouch.server.domain.battle.dto.CreateBattleRequest;
 import Hampouch.server.domain.battle.dto.CreateBattleResponse;
@@ -15,7 +16,7 @@ import org.springframework.web.bind.annotation.*;
 import java.net.URI;
 
 /**
- * 햄배틀 생성/목록 조회 API. 참가·상세조회는 이후 이슈.
+ * 햄배틀 생성/목록 조회/참가 링크 조회/참가 API. 상세조회+랭킹은 이후 이슈.
  */
 @RestController
 @RequestMapping(BattleController.BASE_PATH)
@@ -43,5 +44,30 @@ public class BattleController {
             @LoginUserId Long userId,
             @RequestParam(required = false) BattleStatus status) {
         return ApiResponse.success(battleService.getMyBattles(userId, status));
+    }
+
+    /**
+     * GET /api/battles/invitations/{battleCode} — 참가 전 미리보기(로그인 필수).
+     * 참가 가능 여부는 응답 필드가 아니라 에러(BATTLE_FULL 등)로 분기하므로 200이면 곧 참가 가능.
+     */
+    @GetMapping("/invitations/{battleCode}")
+    public ApiResponse<BattleInvitationResponse> getInvitation(
+            @LoginUserId Long userId,
+            @PathVariable String battleCode) {
+        return ApiResponse.success(battleService.getInvitation(userId, battleCode));
+    }
+
+    /**
+     * POST /api/battles/invitations/{battleCode} — 참가. 반환할 데이터가 없어(참가자 등록 자체가
+     * 목적) ApiResponse.success()의 no-arg 버전 사용, 위치는 Location 헤더로 충분히 전달됨.
+     */
+    @PostMapping("/invitations/{battleCode}")
+    public ResponseEntity<ApiResponse<Void>> join(
+            @LoginUserId Long userId,
+            @PathVariable String battleCode) {
+        Long battleId = battleService.join(userId, battleCode);
+        return ResponseEntity
+                .created(URI.create(BASE_PATH + "/" + battleId))
+                .body(ApiResponse.success());
     }
 }

--- a/src/main/java/Hampouch/server/domain/battle/controller/BattleController.java
+++ b/src/main/java/Hampouch/server/domain/battle/controller/BattleController.java
@@ -4,6 +4,7 @@ import Hampouch.server.domain.battle.dto.BattleInvitationResponse;
 import Hampouch.server.domain.battle.dto.BattleListResponse;
 import Hampouch.server.domain.battle.dto.CreateBattleRequest;
 import Hampouch.server.domain.battle.dto.CreateBattleResponse;
+import Hampouch.server.domain.battle.dto.JoinBattleResponse;
 import Hampouch.server.domain.battle.entity.BattleStatus;
 import Hampouch.server.domain.battle.service.BattleService;
 import Hampouch.server.global.common.response.ApiResponse;
@@ -27,7 +28,11 @@ public class BattleController {
 
     private final BattleService battleService;
 
-    /** POST /api/battles — 201 + Location 헤더. */
+    /**
+     * POST /api/battles — 201 + Location 헤더. 성공 메시지를 덮어쓰는 이유: 저장소의 커스텀
+     * 성공 메시지는 전부 쓰기 동작에만 붙는 패턴이라(auth의 회원가입/로그인, expense의 삭제,
+     * 아래 참가) 생성도 여기에 맞춘다. 조회 계열은 기본 문구 유지.
+     */
     @PostMapping
     public ResponseEntity<ApiResponse<CreateBattleResponse>> create(
             @LoginUserId Long userId,
@@ -35,7 +40,7 @@ public class BattleController {
         CreateBattleResponse res = battleService.create(userId, request);
         return ResponseEntity
                 .created(URI.create(BASE_PATH + "/" + res.battleId()))
-                .body(ApiResponse.success(res));
+                .body(ApiResponse.success("햄배틀이 생성됐습니다.", res));
     }
 
     /** GET /api/battles — status 미지정 시 전체 상태 조회. */
@@ -58,16 +63,15 @@ public class BattleController {
     }
 
     /**
-     * POST /api/battles/invitations/{battleCode} — 참가. 반환할 데이터가 없어(참가자 등록 자체가
-     * 목적) ApiResponse.success()의 no-arg 버전 사용, 위치는 Location 헤더로 충분히 전달됨.
+     * POST /api/battles/invitations/{battleCode} — 참가. Location 헤더와 body 양쪽에 battleId를 싣는다
      */
     @PostMapping("/invitations/{battleCode}")
-    public ResponseEntity<ApiResponse<Void>> join(
+    public ResponseEntity<ApiResponse<JoinBattleResponse>> join(
             @LoginUserId Long userId,
             @PathVariable String battleCode) {
-        Long battleId = battleService.join(userId, battleCode);
+        JoinBattleResponse res = battleService.join(userId, battleCode);
         return ResponseEntity
-                .created(URI.create(BASE_PATH + "/" + battleId))
-                .body(ApiResponse.success());
+                .created(URI.create(BASE_PATH + "/" + res.battleId()))
+                .body(ApiResponse.success("햄배틀에 참가했습니다.", res));
     }
 }

--- a/src/main/java/Hampouch/server/domain/battle/dto/BattleInvitationResponse.java
+++ b/src/main/java/Hampouch/server/domain/battle/dto/BattleInvitationResponse.java
@@ -1,0 +1,30 @@
+package Hampouch.server.domain.battle.dto;
+
+import Hampouch.server.domain.battle.entity.Battle;
+
+import java.time.LocalDate;
+
+/**
+ * GET /battles/invitations/{battleCode} 응답
+ * 참가 가능 여부는 별도 필드가 아니라 에러(BATTLE_FULL/BATTLE_ALREADY_STARTED/ALREADY_JOINED/
+ * BATTLE_CANCELLED)로 분기하므로, 이 레코드가 만들어졌다는 사실 자체가 참가 가능을 의미
+ */
+public record BattleInvitationResponse(
+        String title,
+        String penalty,
+        int capacity,
+        int joinedCount,
+        LocalDate startDate,
+        LocalDate endDate
+) {
+    public static BattleInvitationResponse from(Battle battle, int joinedCount) {
+        return new BattleInvitationResponse(
+                battle.getTitle(),
+                battle.getPenalty(),
+                battle.getCapacity(),
+                joinedCount,
+                battle.getStartDate(),
+                battle.getEndDate()
+        );
+    }
+}

--- a/src/main/java/Hampouch/server/domain/battle/dto/BattleInvitationResponse.java
+++ b/src/main/java/Hampouch/server/domain/battle/dto/BattleInvitationResponse.java
@@ -5,9 +5,14 @@ import Hampouch.server.domain.battle.entity.Battle;
 import java.time.LocalDate;
 
 /**
- * GET /battles/invitations/{battleCode} 응답
- * 참가 가능 여부는 별도 필드가 아니라 에러(BATTLE_FULL/BATTLE_ALREADY_STARTED/ALREADY_JOINED/
- * BATTLE_CANCELLED)로 분기하므로, 이 레코드가 만들어졌다는 사실 자체가 참가 가능을 의미
+ * GET /battles/invitations/{battleCode} 응답 — battleId는 포함하지 않는다(참가 전 미리보기라
+ * battleId 리소스는 참가자 전용이라는 원칙, hampouch_battle_api_review 확정 사항). 참가 가능
+ * 여부는 별도 필드가 아니라 에러(BATTLE_FULL/BATTLE_ALREADY_STARTED/ALREADY_JOINED/
+ * BATTLE_CANCELLED)로 분기하므로, 이 레코드가 만들어졌다는 사실 자체가 "참가 가능"을 의미한다.
+ *
+ * endDate 대신 durationDays인 이유(2026-08-01, 초대 링크 진입 화면 Figma 확인): 화면이
+ * "종료일"을 따로 안 보여주고 "7일 · 5인"처럼 durationDays(3/7/14/31 프리셋)를 그대로 노출한다.
+ * startDate는 화면에 아직 없지만 디자이너에게 명시 요청 예정(반영 가능성 높음)이라 미리 유지한다.
  */
 public record BattleInvitationResponse(
         String title,
@@ -15,7 +20,7 @@ public record BattleInvitationResponse(
         int capacity,
         int joinedCount,
         LocalDate startDate,
-        LocalDate endDate
+        int durationDays
 ) {
     public static BattleInvitationResponse from(Battle battle, int joinedCount) {
         return new BattleInvitationResponse(
@@ -24,7 +29,7 @@ public record BattleInvitationResponse(
                 battle.getCapacity(),
                 joinedCount,
                 battle.getStartDate(),
-                battle.getEndDate()
+                battle.getDurationDays()
         );
     }
 }

--- a/src/main/java/Hampouch/server/domain/battle/dto/CreateBattleRequest.java
+++ b/src/main/java/Hampouch/server/domain/battle/dto/CreateBattleRequest.java
@@ -7,24 +7,32 @@ import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 
 /**
- * POST /battles 요청 — capacity/durationDays/startDate 검증은 서비스 계층에서 한다
- * (INVALID_CAPACITY_RANGE/INVALID_START_DATE 전용 BattleErrorCode를 내야 하므로
- * @Min / @Max는 GlobalExceptionHandler가 전부 VALIDATION_ERROR로 검증
+ * POST /battles 요청 — 값의 유효 범위 검증(capacity/durationDays/startDate)은 애노테이션이 아니라
+ * 서비스 계층에서 한다. @Min/@Max로 막으면 GlobalExceptionHandler가 전부 VALIDATION_ERROR로
+ * 뭉개서, 전용 BattleErrorCode(INVALID_CAPACITY_RANGE/INVALID_DURATION_DAYS/INVALID_START_DATE)를
+ * 낼 수 없기 때문. 여기 애노테이션은 "값이 아예 없거나 길이를 넘는" 경우만 담당한다.
+ *
+ * 모든 애노테이션에 message를 명시하는 이유(auth 도메인과 동일한 팀 컨벤션): 생략하면
+ * Hibernate Validator 기본 번들이 쓰이는데, 그 문구는 JVM 기본 로케일을 탄다. 한국어 Windows
+ * 로컬은 ko_KR이라 "공백일 수 없습니다"가 나가지만, 배포 컨테이너(eclipse-temurin, LANG 미설정)는
+ * en_US라 "must not be blank"가 나간다 — 즉 명세에 뭘 적어도 한쪽은 틀린 말이 된다.
  */
 public record CreateBattleRequest(
-        @NotBlank @Size(max = 100)
+        @NotBlank(message = "햄배틀 제목을 입력해주세요.")
+        @Size(max = 100, message = "제목은 100자 이하로 입력해주세요.")
         String title,
 
-        @NotNull
+        @NotNull(message = "참가 정원을 입력해주세요.")
         Integer capacity,
 
-        @NotNull
+        @NotNull(message = "참가 기간을 선택해주세요.")
         Integer durationDays,
 
-        @NotNull
+        @NotNull(message = "시작일을 입력해주세요.")
         LocalDate startDate,
 
-        @NotBlank @Size(max = 100)
+        @NotBlank(message = "벌칙을 입력해주세요.")
+        @Size(max = 100, message = "벌칙은 100자 이하로 입력해주세요.")
         String penalty
 ) {
 }

--- a/src/main/java/Hampouch/server/domain/battle/dto/JoinBattleResponse.java
+++ b/src/main/java/Hampouch/server/domain/battle/dto/JoinBattleResponse.java
@@ -1,0 +1,16 @@
+package Hampouch.server.domain.battle.dto;
+
+import Hampouch.server.domain.battle.entity.Battle;
+
+/**
+ * POST /battles/invitations/{battleCode} 응답 — battleId 하나만 담는다.
+ * battleId는 Location 헤더로도 나가는데 body에 중복해서 담는 이유: 헤더만 두면 클라이언트가
+ * URI 문자열을 직접 잘라 써야 해서, BASE_PATH가 바뀔 때 컴파일 에러 없이 런타임에 조용히 깨진다
+ */
+public record JoinBattleResponse(
+        Long battleId
+) {
+    public static JoinBattleResponse from(Battle battle) {
+        return new JoinBattleResponse(battle.getId());
+    }
+}

--- a/src/main/java/Hampouch/server/domain/battle/repository/BattleParticipantRepository.java
+++ b/src/main/java/Hampouch/server/domain/battle/repository/BattleParticipantRepository.java
@@ -17,10 +17,18 @@ public interface BattleParticipantRepository extends JpaRepository<BattlePartici
     /**
      * GET /battles — 내가 참가 중인 배틀은 BattleParticipant를 통해 확인할 수 있는 정보.
      * BattleRepository가 아니라 여기서 조회를 시작한다. status는 선택 필터(null이면 전체).
-     * JOIN FETCH로 Battle을 함께 가져와 N+1 방지, 정렬은 startDate와 등록 순의 DESC로 고정
+     * JOIN FETCH로 Battle을 함께 가져와 N+1 방지, 정렬은 startDate와 등록 순의 DESC로 고정.
+     *
+     * CANCELLED를 WHERE에서 아예 빼는 이유(2026-08-02 결정): 취소된 배틀은 목록에 노출하지 않기로
+     * 확정했는데, status 필터는 "null이면 전체"라 미지정 조회에 CANCELLED가 그대로 섞여 들어온다.
+     * 그 상태로 BattleService.toSummary()에 닿으면 정의된 카드 shape가 없어 IllegalStateException →
+     * 500이 나간다(지금은 CANCELLED로 만드는 시작일 배치가 없어서 잠재 상태). 필터 분기가 아니라
+     * 쿼리 자체에서 제외해야 미지정 조회까지 한 번에 막힌다.
      */
     @Query("SELECT p FROM BattleParticipant p JOIN FETCH p.battle b " +
-            "WHERE p.user.id = :userId AND (:status IS NULL OR b.status = :status) " +
+            "WHERE p.user.id = :userId " +
+            "AND b.status <> Hampouch.server.domain.battle.entity.BattleStatus.CANCELLED " +
+            "AND (:status IS NULL OR b.status = :status) " +
             "ORDER BY b.startDate DESC, b.id DESC")
     List<BattleParticipant> findMyParticipations(@Param("userId") Long userId, @Param("status") BattleStatus status);
 }

--- a/src/main/java/Hampouch/server/domain/battle/repository/BattleRepository.java
+++ b/src/main/java/Hampouch/server/domain/battle/repository/BattleRepository.java
@@ -1,9 +1,28 @@
 package Hampouch.server.domain.battle.repository;
 
 import Hampouch.server.domain.battle.entity.Battle;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface BattleRepository extends JpaRepository<Battle, Long> {
 
     boolean existsByBattleCode(String battleCode);
+
+    /** 참가 링크 조회(GET /invitations/{battleCode})용 — 락 없는 단순 조회. 없으면 BATTLE_CODE_NOT_FOUND. */
+    Optional<Battle> findByBattleCode(String battleCode);
+
+    /**
+     * 참가(POST /invitations/{battleCode}) 전용 — Battle row를 PESSIMISTIC_WRITE로 잠근다.
+     * 중복 참가는 BattleParticipant의 uq_battle_participant 유니크 제약이 이미 막아주지만,
+     * 정원 초과 여부를 방지를 위해 락이 필요: 4/5명 상태에서 서로 다른 두 유저가 동시에 countByBattle_Id()를 읽으면
+     * 둘 다 자리 있음으로 통과해 6명이 될 수 있기 때문이다.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT b FROM Battle b WHERE b.battleCode = :battleCode")
+    Optional<Battle> findByBattleCodeForUpdate(@Param("battleCode") String battleCode);
 }

--- a/src/main/java/Hampouch/server/domain/battle/service/BattleService.java
+++ b/src/main/java/Hampouch/server/domain/battle/service/BattleService.java
@@ -5,6 +5,7 @@ import Hampouch.server.domain.battle.dto.BattleListResponse;
 import Hampouch.server.domain.battle.dto.BattleSummary;
 import Hampouch.server.domain.battle.dto.CreateBattleRequest;
 import Hampouch.server.domain.battle.dto.CreateBattleResponse;
+import Hampouch.server.domain.battle.dto.JoinBattleResponse;
 import Hampouch.server.domain.battle.entity.Battle;
 import Hampouch.server.domain.battle.entity.BattleParticipant;
 import Hampouch.server.domain.battle.entity.BattleStatus;
@@ -68,6 +69,12 @@ public class BattleService {
      * BattleParticipantRepository에서 조회를 시작
      */
     public BattleListResponse getMyBattles(Long userId, BattleStatus statusFilter) {
+        // 취소된 배틀은 목록에 노출하지 않기로 확정(2026-08-02)했으므로 CANCELLED는 이 API가
+        // 받을 수 없는 값이다. 조용히 빈 배열을 주면 프론트의 잘못된 요청이 그대로 묻히므로 400으로 거절.
+        if (statusFilter == BattleStatus.CANCELLED) {
+            throw new CustomException(CommonErrorCode.VALIDATION_ERROR, "취소된 햄배틀은 조회할 수 없습니다.");
+        }
+
         List<BattleParticipant> participation = battleParticipantRepository.findMyParticipations(userId, statusFilter);
 
         List<BattleSummary> summaries = participation.stream()
@@ -96,7 +103,7 @@ public class BattleService {
      * 걸린 극단적 타이밍 케이스 방어용
      */
     @Transactional
-    public Long join(Long userId, String battleCode) {
+    public JoinBattleResponse join(Long userId, String battleCode) {
         Battle battle = battleRepository.findByBattleCodeForUpdate(battleCode)
                 .orElseThrow(() -> new CustomException(BattleErrorCode.BATTLE_CODE_NOT_FOUND));
         validateJoinable(battle, userId);
@@ -107,7 +114,7 @@ public class BattleService {
         } catch (DataIntegrityViolationException e) {
             throw new CustomException(BattleErrorCode.ALREADY_JOINED);
         }
-        return battle.getId();
+        return JoinBattleResponse.from(battle);
     }
 
     private void validateCapacity(int capacity) {
@@ -116,10 +123,9 @@ public class BattleService {
         }
     }
 
-    /** durationDays는 전용 BattleErrorCode가 없어 공통 VALIDATION_ERROR + 구체 메시지로 처리 */
     private void validateDuration(int durationDays) {
         if (!ALLOWED_DURATIONS.contains(durationDays)) {
-            throw new CustomException(CommonErrorCode.VALIDATION_ERROR, "durationDays는 3/7/14/31만 가능합니다.");
+            throw new CustomException(BattleErrorCode.INVALID_DURATION_DAYS);
         }
     }
 
@@ -171,8 +177,11 @@ public class BattleService {
                     battle.getStartDate(), battle.getEndDate(), battle.getStatus(),
                     null // TODO(③): rank=1 참가자 닉네임으로 교체
             );
+            // 도달 불가 — getMyBattles()의 필터 거절과 findMyParticipations()의 WHERE 제외로
+            // 이미 두 겹 막혀 있다. sealed switch의 완전성 때문에 남기는 방어선이라, 여기 닿았다면
+            // 위 두 곳 중 하나가 깨진 것이므로 조용히 넘기지 않고 터뜨린다.
             case CANCELLED -> throw new IllegalStateException(
-                    "CANCELLED 배틀의 목록 카드 shape가 아직 정의되지 않음");
+                    "CANCELLED 배틀이 목록 조회에 도달함 — 필터/쿼리 제외 로직 확인 필요");
         };
     }
 }

--- a/src/main/java/Hampouch/server/domain/battle/service/BattleService.java
+++ b/src/main/java/Hampouch/server/domain/battle/service/BattleService.java
@@ -1,5 +1,6 @@
 package Hampouch.server.domain.battle.service;
 
+import Hampouch.server.domain.battle.dto.BattleInvitationResponse;
 import Hampouch.server.domain.battle.dto.BattleListResponse;
 import Hampouch.server.domain.battle.dto.BattleSummary;
 import Hampouch.server.domain.battle.dto.CreateBattleRequest;
@@ -15,6 +16,7 @@ import Hampouch.server.global.common.exception.CustomException;
 import Hampouch.server.global.common.exception.domain.BattleErrorCode;
 import Hampouch.server.global.common.exception.domain.CommonErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,7 +26,7 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * 배틀 생성 + 목록 조회의 서비스 계층. 참가/랭킹/배치는 이후 구현 예정.
+ * 배틀 생성/목록/참가 링크 조회/참가의 서비스 계층. 상세조회·랭킹·배치는 이후 구현 예정.
  */
 @Service
 @RequiredArgsConstructor
@@ -75,6 +77,39 @@ public class BattleService {
         return new BattleListResponse(summaries);
     }
 
+    /**
+     * GET /battles/invitations/{battleCode}. 락 없는 단순 조회 — 참가와 달리 여기선 참가자를
+     * insert하지 않으므로 카운트 레이스가 응답 하나 잘못 보여주는 것 이상의 피해를 못 준다
+     */
+    public BattleInvitationResponse getInvitation(Long userId, String battleCode) {
+        Battle battle = battleRepository.findByBattleCode(battleCode)
+                .orElseThrow(() -> new CustomException(BattleErrorCode.BATTLE_CODE_NOT_FOUND));
+        validateJoinable(battle, userId);
+        int joinedCount = battleParticipantRepository.countByBattle_Id(battle.getId());
+        return BattleInvitationResponse.from(battle, joinedCount);
+    }
+
+    /**
+     * POST /battles/invitations/{battleCode}. findByBattleCodeForUpdate로 Battle row를 잠근 채
+     * validateJoinable을 통과해야 insert까지 간다.
+     * DataIntegrityViolationException은 검증 통과 직후 같은 유저의 동시 재요청이 uq_battle_participant에
+     * 걸린 극단적 타이밍 케이스 방어용
+     */
+    @Transactional
+    public Long join(Long userId, String battleCode) {
+        Battle battle = battleRepository.findByBattleCodeForUpdate(battleCode)
+                .orElseThrow(() -> new CustomException(BattleErrorCode.BATTLE_CODE_NOT_FOUND));
+        validateJoinable(battle, userId);
+
+        User user = userRepository.getReferenceById(userId);
+        try {
+            battleParticipantRepository.save(BattleParticipant.of(user, battle));
+        } catch (DataIntegrityViolationException e) {
+            throw new CustomException(BattleErrorCode.ALREADY_JOINED);
+        }
+        return battle.getId();
+    }
+
     private void validateCapacity(int capacity) {
         if (capacity < 2 || capacity > 10) {
             throw new CustomException(BattleErrorCode.INVALID_CAPACITY_RANGE);
@@ -91,6 +126,26 @@ public class BattleService {
     private void validateStartDate(LocalDate startDate) {
         if (startDate.isBefore(LocalDate.now(clock))) {
             throw new CustomException(BattleErrorCode.INVALID_START_DATE);
+        }
+    }
+
+    /**
+     * 참가 링크 조회/참가 공통 검증. CANCELLED된 Battle의 경우 400 Error를 반환하므로 다른 status보다 먼저 검증.
+     * 이후 햄배틀의 상태가 READY(참여 가능)인지 조회 후, ALREADY_JOINED와 BATTLE_FULL을 검증(인원이 찬 경우에도
+     * 이미 참여한 배틀의 경우 ALREADY_JOINED이므로)
+     */
+    private void validateJoinable(Battle battle, Long userId) {
+        if (battle.getStatus() == BattleStatus.CANCELLED) {
+            throw new CustomException(BattleErrorCode.BATTLE_CANCELLED);
+        }
+        if (battle.getStatus() != BattleStatus.READY) {
+            throw new CustomException(BattleErrorCode.BATTLE_ALREADY_STARTED);
+        }
+        if (battleParticipantRepository.existsByBattle_IdAndUser_Id(battle.getId(), userId)) {
+            throw new CustomException(BattleErrorCode.ALREADY_JOINED);
+        }
+        if (battleParticipantRepository.countByBattle_Id(battle.getId()) >= battle.getCapacity()) {
+            throw new CustomException(BattleErrorCode.BATTLE_FULL);
         }
     }
 

--- a/src/main/java/Hampouch/server/domain/battle/service/BattleService.java
+++ b/src/main/java/Hampouch/server/domain/battle/service/BattleService.java
@@ -86,13 +86,13 @@ public class BattleService {
 
     /**
      * GET /battles/invitations/{battleCode}. 락 없는 단순 조회 — 참가와 달리 여기선 참가자를
-     * insert하지 않으므로 카운트 레이스가 응답 하나 잘못 보여주는 것 이상의 피해를 못 준다
+     * insert하지 않으므로 카운트 레이스가 응답 하나 잘못 보여주는 것 이상의 피해를 못 준다.
+     * joinedCount는 validateJoinable()이 BATTLE_FULL 검증에 쓴 값을 그대로 반환받아 재사용
      */
     public BattleInvitationResponse getInvitation(Long userId, String battleCode) {
         Battle battle = battleRepository.findByBattleCode(battleCode)
                 .orElseThrow(() -> new CustomException(BattleErrorCode.BATTLE_CODE_NOT_FOUND));
-        validateJoinable(battle, userId);
-        int joinedCount = battleParticipantRepository.countByBattle_Id(battle.getId());
+        int joinedCount = validateJoinable(battle, userId);
         return BattleInvitationResponse.from(battle, joinedCount);
     }
 
@@ -138,9 +138,11 @@ public class BattleService {
     /**
      * 참가 링크 조회/참가 공통 검증. CANCELLED된 Battle의 경우 400 Error를 반환하므로 다른 status보다 먼저 검증.
      * 이후 햄배틀의 상태가 READY(참여 가능)인지 조회 후, ALREADY_JOINED와 BATTLE_FULL을 검증(인원이 찬 경우에도
-     * 이미 참여한 배틀의 경우 ALREADY_JOINED이므로)
+     * 이미 참여한 배틀의 경우 ALREADY_JOINED이므로).
+     * BATTLE_FULL 검증에 쓴 joinedCount를 반환값으로 노출 — getInvitation()에 재사용해 COUNT 쿼리 중복 호출 방지.
+     * CANCELLED/ALREADY_STARTED/ALREADY_JOINED로 먼저 걸리는 경우엔 그 전까지처럼 COUNT 쿼리 자체가 나가지 않는다(lazy 유지).
      */
-    private void validateJoinable(Battle battle, Long userId) {
+    private int validateJoinable(Battle battle, Long userId) {
         if (battle.getStatus() == BattleStatus.CANCELLED) {
             throw new CustomException(BattleErrorCode.BATTLE_CANCELLED);
         }
@@ -150,9 +152,11 @@ public class BattleService {
         if (battleParticipantRepository.existsByBattle_IdAndUser_Id(battle.getId(), userId)) {
             throw new CustomException(BattleErrorCode.ALREADY_JOINED);
         }
-        if (battleParticipantRepository.countByBattle_Id(battle.getId()) >= battle.getCapacity()) {
+        int joinedCount = battleParticipantRepository.countByBattle_Id(battle.getId());
+        if (joinedCount >= battle.getCapacity()) {
             throw new CustomException(BattleErrorCode.BATTLE_FULL);
         }
+        return joinedCount;
     }
 
     /**

--- a/src/main/java/Hampouch/server/global/common/exception/domain/BattleErrorCode.java
+++ b/src/main/java/Hampouch/server/global/common/exception/domain/BattleErrorCode.java
@@ -14,17 +14,22 @@ public enum BattleErrorCode implements BaseErrorCode {
 
     INVALID_START_DATE(HttpStatus.BAD_REQUEST, "INVALID_START_DATE", "시작일은 오늘 이후 날짜여야 합니다."),
 
-    BATTLE_NOT_FOUND(HttpStatus.NOT_FOUND, "BATTLE_NOT_FOUND", "요청한 햄배틀을 찾을 수 없습니다"),
+    // capacity(INVALID_CAPACITY_RANGE)·startDate(INVALID_START_DATE)와 대칭을 맞추려고 신설.
+    // 이전엔 CommonErrorCode.VALIDATION_ERROR + 커스텀 메시지였는데, 그 경로는 fieldErrors가 없는
+    // 다른 shape로 나가서 프론트가 생성 폼의 세 필드를 같은 방식으로 처리할 수 없었다.
+    INVALID_DURATION_DAYS(HttpStatus.BAD_REQUEST, "INVALID_DURATION_DAYS", "참가 기간은 3일, 7일, 14일, 31일 중에서 선택해야 합니다."),
+
+    BATTLE_NOT_FOUND(HttpStatus.NOT_FOUND, "BATTLE_NOT_FOUND", "요청한 햄배틀을 찾을 수 없습니다."),
     
-    BATTLE_CODE_NOT_FOUND(HttpStatus.NOT_FOUND, "BATTLE_CODE_NOT_FOUND", "요청한 초대 코드를 찾을 수 없습니다"),
+    BATTLE_CODE_NOT_FOUND(HttpStatus.NOT_FOUND, "BATTLE_CODE_NOT_FOUND", "요청한 초대 코드를 찾을 수 없습니다."),
 
     BATTLE_FULL(HttpStatus.CONFLICT, "BATTLE_FULL", "정원이 마감된 햄배틀입니다."),
 
-    BATTLE_ALREADY_STARTED(HttpStatus.CONFLICT, "BATTLE_ALREADY_STARTED", "이미 시작된 햄배틀입니다."),
+    BATTLE_ALREADY_STARTED(HttpStatus.CONFLICT, "BATTLE_ALREADY_STARTED", "이미 시작된 햄배틀에는 참가할 수 없습니다."),
 
     ALREADY_JOINED(HttpStatus.CONFLICT, "ALREADY_JOINED", "이미 참가한 햄배틀입니다."),
 
-    BATTLE_CANCELLED(HttpStatus.BAD_REQUEST, "BATTLE_CANCELLED", "이미 취소된 햄배틀입니다."),
+    BATTLE_CANCELLED(HttpStatus.BAD_REQUEST, "BATTLE_CANCELLED", "참가 인원이 모이지 않아 취소된 햄배틀입니다."),
 
     FORBIDDEN_NOT_PARTICIPANT(HttpStatus.FORBIDDEN, "FORBIDDEN_NOT_PARTICIPANT", "햄배틀 정보는 참가자만 조회할 수 있습니다.");
 

--- a/src/test/java/Hampouch/server/domain/battle/controller/BattleControllerTest.java
+++ b/src/test/java/Hampouch/server/domain/battle/controller/BattleControllerTest.java
@@ -1,0 +1,228 @@
+package Hampouch.server.domain.battle.controller;
+
+import Hampouch.server.domain.battle.dto.BattleInvitationResponse;
+import Hampouch.server.domain.battle.dto.BattleListResponse;
+import Hampouch.server.domain.battle.dto.BattleSummary;
+import Hampouch.server.domain.battle.dto.CreateBattleResponse;
+import Hampouch.server.domain.battle.entity.BattleStatus;
+import Hampouch.server.domain.battle.service.BattleService;
+import Hampouch.server.global.common.exception.CustomException;
+import Hampouch.server.global.common.exception.domain.BattleErrorCode;
+import Hampouch.server.global.jwt.JwtProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * 웹 계층(검증·상태코드·팀 공통 에러 응답 매핑) 검증. 서비스는 목 — DB 불필요
+ * (ExpenseControllerTest와 동일 스타일 — BattleController도 X-User-Id 스텁이 아니라
+ * @LoginUserId를 쓰므로 challenge 쪽이 아니라 expense 쪽 컨벤션을 따른다).
+ */
+@WebMvcTest(BattleController.class)
+@AutoConfigureMockMvc(addFilters = false) // 시큐리티 필터 제외 — 웹 계층(상태코드·필드)만 검증
+class BattleControllerTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    @MockitoBean
+    BattleService service;
+
+    @MockitoBean
+    JwtProvider jwtProvider; // SecurityConfig가 요구하는 빈 — addFilters=false라 실제 토큰 검증엔 안 쓰임
+
+    private static final Long OWNER = 1L;
+
+    /**
+     * @LoginUserId가 읽어갈 인증 정보를 테스트 스레드의 SecurityContextHolder에 직접 심는다.
+     * addFilters=false라 JwtFilter가 아예 안 돌기 때문에, .with(authentication(...))처럼
+     * 필터가 복원해주길 기대하는 방식은 동작하지 않는다(ExpenseControllerTest와 동일 이유).
+     */
+    @BeforeEach
+    void setUpSecurityContext() {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(new UsernamePasswordAuthenticationToken(
+                OWNER, null, List.of(new SimpleGrantedAuthority("ROLE_USER"))));
+        SecurityContextHolder.setContext(context);
+    }
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    // ---------- create ----------
+
+    @Test
+    @DisplayName("생성 요청이 정상이면 201 Created와 Location 헤더, 생성 결과 본문을 돌려준다")
+    void create_201() throws Exception {
+        when(service.create(anyLong(), any())).thenReturn(new CreateBattleResponse(
+                1L, "ABCD1234", "짠테크 배틀", 4, 7,
+                LocalDate.of(2026, 8, 1), LocalDate.of(2026, 8, 7), "치킨 사주기", BattleStatus.READY));
+
+        mvc.perform(post("/api/battles")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "title": "짠테크 배틀", "capacity": 4, "durationDays": 7,
+                                  "startDate": "2026-08-01", "penalty": "치킨 사주기" }
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location", "/api/battles/1"))
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.battleCode").value("ABCD1234"))
+                .andExpect(jsonPath("$.data.status").value("READY"));
+    }
+
+    @Test
+    @DisplayName("title이 비어 있으면 400으로 거절한다 (@NotBlank)")
+    void create_400_whenTitleBlank() throws Exception {
+        mvc.perform(post("/api/battles")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "title": "", "capacity": 4, "durationDays": 7,
+                                  "startDate": "2026-08-01", "penalty": "치킨 사주기" }
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("정원이 범위를 벗어나면 서비스가 던진 400(INVALID_CAPACITY_RANGE)을 팀 공통 에러 본문으로 그대로 내려준다")
+    void create_400_whenCapacityOutOfRange() throws Exception {
+        when(service.create(anyLong(), any()))
+                .thenThrow(new CustomException(BattleErrorCode.INVALID_CAPACITY_RANGE));
+
+        mvc.perform(post("/api/battles")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "title": "짠테크 배틀", "capacity": 11, "durationDays": 7,
+                                  "startDate": "2026-08-01", "penalty": "치킨 사주기" }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_CAPACITY_RANGE"));
+    }
+
+    // ---------- getMyBattles ----------
+
+    @Test
+    @DisplayName("목록 조회가 정상이면 200과 배틀 카드 배열을 돌려준다")
+    void getMyBattles_200() throws Exception {
+        when(service.getMyBattles(eq(OWNER), any()))
+                .thenReturn(new BattleListResponse(List.of(new BattleSummary.Ready(
+                        1L, "ABCD1234", "짠테크 배틀", "치킨 사주기",
+                        LocalDate.of(2026, 8, 1), LocalDate.of(2026, 8, 7), BattleStatus.READY,
+                        4, 2))));
+
+        mvc.perform(get("/api/battles"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.battles[0].battleId").value(1))
+                .andExpect(jsonPath("$.data.battles[0].capacity").value(4))
+                .andExpect(jsonPath("$.data.battles[0].joinedCount").value(2));
+    }
+
+    @Test
+    @DisplayName("status 쿼리 파라미터를 그대로 서비스에 전달한다")
+    void getMyBattles_passesStatusFilter() throws Exception {
+        when(service.getMyBattles(OWNER, BattleStatus.ONGOING)).thenReturn(new BattleListResponse(List.of()));
+
+        mvc.perform(get("/api/battles").param("status", "ONGOING"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.battles").isEmpty());
+    }
+
+    // ---------- getInvitation ----------
+
+    @Test
+    @DisplayName("참가 링크 조회가 정상이면 200과 미리보기 본문(battleId 제외)을 돌려준다")
+    void getInvitation_200() throws Exception {
+        when(service.getInvitation(OWNER, "ABCD1234")).thenReturn(new BattleInvitationResponse(
+                "짠테크 배틀", "치킨 사주기", 4, 2,
+                LocalDate.of(2026, 8, 1), LocalDate.of(2026, 8, 7)));
+
+        mvc.perform(get("/api/battles/invitations/ABCD1234"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.title").value("짠테크 배틀"))
+                .andExpect(jsonPath("$.data.joinedCount").value(2))
+                .andExpect(jsonPath("$.data.battleId").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 초대 코드면 404(BATTLE_CODE_NOT_FOUND)를 돌려준다")
+    void getInvitation_404_whenCodeNotFound() throws Exception {
+        when(service.getInvitation(OWNER, "ZZZZ9999"))
+                .thenThrow(new CustomException(BattleErrorCode.BATTLE_CODE_NOT_FOUND));
+
+        mvc.perform(get("/api/battles/invitations/ZZZZ9999"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("BATTLE_CODE_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("정원이 찬 배틀이면 409(BATTLE_FULL)를 돌려준다")
+    void getInvitation_409_whenFull() throws Exception {
+        when(service.getInvitation(OWNER, "ABCD1234"))
+                .thenThrow(new CustomException(BattleErrorCode.BATTLE_FULL));
+
+        mvc.perform(get("/api/battles/invitations/ABCD1234"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("BATTLE_FULL"));
+    }
+
+    @Test
+    @DisplayName("이미 취소된 배틀이면 400(BATTLE_CANCELLED)을 돌려준다 — 다른 409들과 달리 의도적으로 400")
+    void getInvitation_400_whenCancelled() throws Exception {
+        when(service.getInvitation(OWNER, "ABCD1234"))
+                .thenThrow(new CustomException(BattleErrorCode.BATTLE_CANCELLED));
+
+        mvc.perform(get("/api/battles/invitations/ABCD1234"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("BATTLE_CANCELLED"));
+    }
+
+    // ---------- join ----------
+
+    @Test
+    @DisplayName("참가가 정상이면 201 Created와 Location 헤더를 돌려준다 — 반환 데이터가 없어 data 필드는 아예 없다")
+    void join_201() throws Exception {
+        when(service.join(OWNER, "ABCD1234")).thenReturn(1L);
+
+        mvc.perform(post("/api/battles/invitations/ABCD1234"))
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location", "/api/battles/1"))
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.data").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("이미 참가한 배틀이면 409(ALREADY_JOINED)를 돌려준다")
+    void join_409_whenAlreadyJoined() throws Exception {
+        when(service.join(OWNER, "ABCD1234"))
+                .thenThrow(new CustomException(BattleErrorCode.ALREADY_JOINED));
+
+        mvc.perform(post("/api/battles/invitations/ABCD1234"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("ALREADY_JOINED"));
+    }
+}

--- a/src/test/java/Hampouch/server/domain/battle/controller/BattleControllerTest.java
+++ b/src/test/java/Hampouch/server/domain/battle/controller/BattleControllerTest.java
@@ -105,7 +105,8 @@ class BattleControllerTest {
                                 { "title": "", "capacity": 4, "durationDays": 7,
                                   "startDate": "2026-08-01", "penalty": "치킨 사주기" }
                                 """))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.fieldErrors.title").value("햄배틀 제목을 입력해주세요."));
     }
 
     @Test

--- a/src/test/java/Hampouch/server/domain/battle/controller/BattleControllerTest.java
+++ b/src/test/java/Hampouch/server/domain/battle/controller/BattleControllerTest.java
@@ -202,6 +202,9 @@ class BattleControllerTest {
     }
 
     // ---------- join ----------
+    // CANCELLED/ALREADY_STARTED/BATTLE_FULL은 join과 getInvitation이 validateJoinable()을 공유하고
+    // 에러 매핑(GlobalExceptionHandler)도 공통이라 위 getInvitation 케이스로 이미 검증됨 — 여기선
+    // join 고유 관심사(성공 시 저장 흐름, 그리고 참가에서 특히 자주 맞물리는 404/409)만 확인한다.
 
     @Test
     @DisplayName("참가가 정상이면 201 Created와 Location 헤더를 돌려준다 — 반환 데이터가 없어 data 필드는 아예 없다")
@@ -213,6 +216,18 @@ class BattleControllerTest {
                 .andExpect(header().string("Location", "/api/battles/1"))
                 .andExpect(jsonPath("$.code").value("SUCCESS"))
                 .andExpect(jsonPath("$.data").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 초대 코드로 참가를 시도하면 404(BATTLE_CODE_NOT_FOUND)를 돌려준다 " +
+            "— 락 조회(findByBattleCodeForUpdate) 경로도 조회(getInvitation)와 동일한 404 매핑인지 확인")
+    void join_404_whenCodeNotFound() throws Exception {
+        when(service.join(OWNER, "ZZZZ9999"))
+                .thenThrow(new CustomException(BattleErrorCode.BATTLE_CODE_NOT_FOUND));
+
+        mvc.perform(post("/api/battles/invitations/ZZZZ9999"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("BATTLE_CODE_NOT_FOUND"));
     }
 
     @Test

--- a/src/test/java/Hampouch/server/domain/battle/controller/BattleControllerTest.java
+++ b/src/test/java/Hampouch/server/domain/battle/controller/BattleControllerTest.java
@@ -4,6 +4,7 @@ import Hampouch.server.domain.battle.dto.BattleInvitationResponse;
 import Hampouch.server.domain.battle.dto.BattleListResponse;
 import Hampouch.server.domain.battle.dto.BattleSummary;
 import Hampouch.server.domain.battle.dto.CreateBattleResponse;
+import Hampouch.server.domain.battle.dto.JoinBattleResponse;
 import Hampouch.server.domain.battle.entity.BattleStatus;
 import Hampouch.server.domain.battle.service.BattleService;
 import Hampouch.server.global.common.exception.CustomException;
@@ -90,6 +91,7 @@ class BattleControllerTest {
                 .andExpect(status().isCreated())
                 .andExpect(header().string("Location", "/api/battles/1"))
                 .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.message").value("햄배틀이 생성됐습니다."))
                 .andExpect(jsonPath("$.data.battleCode").value("ABCD1234"))
                 .andExpect(jsonPath("$.data.status").value("READY"));
     }
@@ -209,15 +211,19 @@ class BattleControllerTest {
     // join 고유 관심사(성공 시 저장 흐름, 그리고 참가에서 특히 자주 맞물리는 404/409)만 확인한다.
 
     @Test
-    @DisplayName("참가가 정상이면 201 Created와 Location 헤더를 돌려준다 — 반환 데이터가 없어 data 필드는 아예 없다")
+    @DisplayName("참가가 정상이면 201 Created와 Location 헤더, battleId 본문을 돌려준다 " +
+            "— Location과 body가 같은 battleId를 가리키는지까지 확인(둘을 중복해서 내리는 게 설계 의도라서)")
     void join_201() throws Exception {
-        when(service.join(OWNER, "ABCD1234")).thenReturn(1L);
+        when(service.join(OWNER, "ABCD1234")).thenReturn(new JoinBattleResponse(1L));
 
         mvc.perform(post("/api/battles/invitations/ABCD1234"))
                 .andExpect(status().isCreated())
                 .andExpect(header().string("Location", "/api/battles/1"))
                 .andExpect(jsonPath("$.code").value("SUCCESS"))
-                .andExpect(jsonPath("$.data").doesNotExist());
+                .andExpect(jsonPath("$.message").value("햄배틀에 참가했습니다."))
+                .andExpect(jsonPath("$.data.battleId").value(1))
+                .andExpect(jsonPath("$.data.participantId").doesNotExist())
+                .andExpect(jsonPath("$.data.joinedAt").doesNotExist());
     }
 
     @Test

--- a/src/test/java/Hampouch/server/domain/battle/controller/BattleControllerTest.java
+++ b/src/test/java/Hampouch/server/domain/battle/controller/BattleControllerTest.java
@@ -154,18 +154,20 @@ class BattleControllerTest {
     // ---------- getInvitation ----------
 
     @Test
-    @DisplayName("참가 링크 조회가 정상이면 200과 미리보기 본문(battleId 제외)을 돌려준다")
+    @DisplayName("참가 링크 조회가 정상이면 200과 미리보기 본문(battleId 제외, endDate 대신 durationDays)을 돌려준다")
     void getInvitation_200() throws Exception {
         when(service.getInvitation(OWNER, "ABCD1234")).thenReturn(new BattleInvitationResponse(
                 "짠테크 배틀", "치킨 사주기", 4, 2,
-                LocalDate.of(2026, 8, 1), LocalDate.of(2026, 8, 7)));
+                LocalDate.of(2026, 8, 1), 7));
 
         mvc.perform(get("/api/battles/invitations/ABCD1234"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value("SUCCESS"))
                 .andExpect(jsonPath("$.data.title").value("짠테크 배틀"))
                 .andExpect(jsonPath("$.data.joinedCount").value(2))
-                .andExpect(jsonPath("$.data.battleId").doesNotExist());
+                .andExpect(jsonPath("$.data.durationDays").value(7))
+                .andExpect(jsonPath("$.data.battleId").doesNotExist())
+                .andExpect(jsonPath("$.data.endDate").doesNotExist());
     }
 
     @Test

--- a/src/test/java/Hampouch/server/domain/battle/repository/BattleParticipantRepositoryTest.java
+++ b/src/test/java/Hampouch/server/domain/battle/repository/BattleParticipantRepositoryTest.java
@@ -110,4 +110,20 @@ class BattleParticipantRepositoryTest {
 
         assertThat(result).extracting(p -> p.getBattle().getId()).containsExactly(ready.getId());
     }
+
+    @Test
+    @DisplayName("findMyParticipations는 status 미지정(전체 조회)이어도 CANCELLED 배틀은 빼고 준다 " +
+            "— 필터 분기가 아니라 쿼리에서 제외해야 하는 이유가 바로 이 경로")
+    void findMyParticipations_excludesCancelledEvenWithoutFilter() {
+        Battle ready = battle("AAAA0001", LocalDate.of(2026, 8, 1));
+        Battle cancelled = battle("AAAA0002", LocalDate.of(2026, 9, 1)); // startDate가 늦어 정렬상 먼저 나올 배틀
+        cancelled.cancel();
+        battleRepository.saveAndFlush(cancelled);
+        battleParticipantRepository.save(BattleParticipant.of(me, ready));
+        battleParticipantRepository.save(BattleParticipant.of(me, cancelled));
+
+        List<BattleParticipant> result = battleParticipantRepository.findMyParticipations(me.getId(), null);
+
+        assertThat(result).extracting(p -> p.getBattle().getId()).containsExactly(ready.getId());
+    }
 }

--- a/src/test/java/Hampouch/server/domain/battle/repository/BattleRepositoryTest.java
+++ b/src/test/java/Hampouch/server/domain/battle/repository/BattleRepositoryTest.java
@@ -14,13 +14,14 @@ import org.springframework.context.annotation.Import;
 import org.springframework.dao.DataIntegrityViolationException;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * battleCode 존재 여부 조회와 uq_battle_code 유니크 제약을 H2에 실제 적용해 검증 —
- * BattleCodeGenerator의 충돌 재시도 판단이 여기 의존한다.
+ * battleCode 존재 여부 조회, battleCode 단건 조회(락 유무 두 버전), uq_battle_code 유니크 제약을
+ * H2에 실제 적용해 검증 — BattleCodeGenerator의 충돌 재시도 판단과 참가 플로우가 여기 의존한다.
  */
 @DataJpaTest
 @Import({ClockConfig.class, JpaAuditingConfig.class})
@@ -57,5 +58,37 @@ class BattleRepositoryTest {
         assertThatThrownBy(() -> battleRepository.saveAndFlush(Battle.of("ABCD1234", "다른 배틀", 3, 3,
                 LocalDate.of(2026, 8, 2), "커피 사주기", creator)))
                 .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    @DisplayName("findByBattleCode는 저장된 코드가 있으면 그 배틀을 반환한다")
+    void findByBattleCode_returnsBattleWhenExists() {
+        Battle saved = battleRepository.save(Battle.of("ABCD1234", "짠테크 배틀", 4, 7,
+                LocalDate.of(2026, 8, 1), "치킨 사주기", creator));
+
+        Optional<Battle> found = battleRepository.findByBattleCode("ABCD1234");
+
+        assertThat(found).isPresent();
+        assertThat(found.get().getId()).isEqualTo(saved.getId());
+    }
+
+    @Test
+    @DisplayName("findByBattleCode는 존재하지 않는 코드면 빈 값을 반환한다")
+    void findByBattleCode_returnsEmptyWhenNotExists() {
+        assertThat(battleRepository.findByBattleCode("ZZZZ9999")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findByBattleCodeForUpdate도 findByBattleCode와 동일한 배틀을 반환한다 — " +
+            "PESSIMISTIC_WRITE 자체(동시 요청 직렬화 효과)는 단일 스레드 단위 테스트로 검증할 수 없어, " +
+            "여기선 락을 걸어도 조회 결과 자체는 달라지지 않는다는 것만 확인한다")
+    void findByBattleCodeForUpdate_returnsSameBattleAsPlainFind() {
+        Battle saved = battleRepository.save(Battle.of("ABCD1234", "짠테크 배틀", 4, 7,
+                LocalDate.of(2026, 8, 1), "치킨 사주기", creator));
+
+        Optional<Battle> found = battleRepository.findByBattleCodeForUpdate("ABCD1234");
+
+        assertThat(found).isPresent();
+        assertThat(found.get().getId()).isEqualTo(saved.getId());
     }
 }

--- a/src/test/java/Hampouch/server/domain/battle/service/BattleServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/battle/service/BattleServiceTest.java
@@ -1,5 +1,6 @@
 package Hampouch.server.domain.battle.service;
 
+import Hampouch.server.domain.battle.dto.BattleInvitationResponse;
 import Hampouch.server.domain.battle.dto.BattleListResponse;
 import Hampouch.server.domain.battle.dto.BattleSummary;
 import Hampouch.server.domain.battle.dto.CreateBattleRequest;
@@ -20,12 +21,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -33,13 +36,15 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 /**
- * 생성 검증 로직 + 상태별 카드 매핑 검증. 리포지토리는 Mockito 목 — DB 불필요(ExpenseServiceTest와 동일 스타일).
+ * 생성 검증 로직 + 상태별 카드 매핑 + 참가 링크 조회/참가 검증 로직을 검증.
+ * 리포지토리는 Mockito 목 — DB 불필요(ExpenseServiceTest와 동일 스타일).
  */
 @ExtendWith(MockitoExtension.class)
 class BattleServiceTest {
 
     private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
     private static final Long OWNER = 1L;
+    private static final Long BATTLE_ID = 10L;
 
     @Mock
     BattleRepository battleRepository;
@@ -63,6 +68,25 @@ class BattleServiceTest {
 
     private static CreateBattleRequest request(int capacity, int durationDays, LocalDate startDate) {
         return new CreateBattleRequest("짠테크 배틀", capacity, durationDays, startDate, "치킨 사주기");
+    }
+
+    /** 참가 링크 조회/참가 테스트 공용 — status별 Battle을 만들어 BATTLE_ID를 부여한다. */
+    private static Battle battleWithStatus(BattleStatus status, int capacity) {
+        Battle battle = Battle.of("ABCD1234", "짠테크 배틀", capacity, 7,
+                LocalDate.of(2026, 8, 1), "치킨 사주기", user(99L));
+        ReflectionTestUtils.setField(battle, "id", BATTLE_ID);
+        switch (status) {
+            case ONGOING -> battle.start();
+            case TERMINATED -> {
+                battle.start();
+                battle.terminate(user(2L));
+            }
+            case CANCELLED -> battle.cancel();
+            case READY -> {
+                // Battle.of()가 이미 READY로 만들어줌 — 추가 전이 불필요
+            }
+        }
+        return battle;
     }
 
     // ---------- create ----------
@@ -188,5 +212,128 @@ class BattleServiceTest {
         BattleListResponse res = serviceAt(LocalDate.of(2026, 7, 1)).getMyBattles(OWNER, null);
 
         assertThat(res.battles().get(0)).isInstanceOf(BattleSummary.Terminated.class);
+    }
+
+    // ---------- getInvitation ----------
+    // validateJoinable의 우선순위 4단계(CANCELLED → ALREADY_STARTED → ALREADY_JOINED → BATTLE_FULL)를
+    // 여기서 전부 검증한다 — join()도 같은 private 메서드를 재사용하므로 join 쪽에선 중복 검증하지 않는다.
+
+    @Test
+    @DisplayName("존재하지 않는 battleCode면 404(BATTLE_CODE_NOT_FOUND)를 던진다")
+    void getInvitation_throwsWhenCodeNotFound() {
+        when(battleRepository.findByBattleCode("ZZZZ9999")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 7, 1)).getInvitation(OWNER, "ZZZZ9999"))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", BattleErrorCode.BATTLE_CODE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("CANCELLED 배틀이면 400(BATTLE_CANCELLED)을 던진다 — 다른 사유보다 우선 판단")
+    void getInvitation_throwsWhenCancelled() {
+        Battle battle = battleWithStatus(BattleStatus.CANCELLED, 4);
+        when(battleRepository.findByBattleCode("ABCD1234")).thenReturn(Optional.of(battle));
+
+        assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 7, 1)).getInvitation(OWNER, "ABCD1234"))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", BattleErrorCode.BATTLE_CANCELLED);
+    }
+
+    @Test
+    @DisplayName("READY가 아니면(ONGOING/TERMINATED) 409(BATTLE_ALREADY_STARTED)를 던진다")
+    void getInvitation_throwsWhenAlreadyStarted() {
+        Battle battle = battleWithStatus(BattleStatus.ONGOING, 4);
+        when(battleRepository.findByBattleCode("ABCD1234")).thenReturn(Optional.of(battle));
+
+        assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 7, 1)).getInvitation(OWNER, "ABCD1234"))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", BattleErrorCode.BATTLE_ALREADY_STARTED);
+    }
+
+    @Test
+    @DisplayName("이미 참가한 유저면 409(ALREADY_JOINED)를 던진다 — 정원이 다 찼어도 이 사유가 BATTLE_FULL보다 우선")
+    void getInvitation_throwsWhenAlreadyJoined() {
+        Battle battle = battleWithStatus(BattleStatus.READY, 4);
+        when(battleRepository.findByBattleCode("ABCD1234")).thenReturn(Optional.of(battle));
+        when(battleParticipantRepository.existsByBattle_IdAndUser_Id(BATTLE_ID, OWNER)).thenReturn(true);
+
+        assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 7, 1)).getInvitation(OWNER, "ABCD1234"))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", BattleErrorCode.ALREADY_JOINED);
+    }
+
+    @Test
+    @DisplayName("정원이 다 찼으면 409(BATTLE_FULL)를 던진다")
+    void getInvitation_throwsWhenFull() {
+        Battle battle = battleWithStatus(BattleStatus.READY, 4);
+        when(battleRepository.findByBattleCode("ABCD1234")).thenReturn(Optional.of(battle));
+        when(battleParticipantRepository.existsByBattle_IdAndUser_Id(BATTLE_ID, OWNER)).thenReturn(false);
+        when(battleParticipantRepository.countByBattle_Id(BATTLE_ID)).thenReturn(4);
+
+        assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 7, 1)).getInvitation(OWNER, "ABCD1234"))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", BattleErrorCode.BATTLE_FULL);
+    }
+
+    @Test
+    @DisplayName("참가 가능한 상태면 joinedCount를 포함한 미리보기를 반환한다 (battleId는 응답에 없음)")
+    void getInvitation_returnsPreviewWhenJoinable() {
+        Battle battle = battleWithStatus(BattleStatus.READY, 4);
+        when(battleRepository.findByBattleCode("ABCD1234")).thenReturn(Optional.of(battle));
+        when(battleParticipantRepository.existsByBattle_IdAndUser_Id(BATTLE_ID, OWNER)).thenReturn(false);
+        when(battleParticipantRepository.countByBattle_Id(BATTLE_ID)).thenReturn(2);
+
+        BattleInvitationResponse res = serviceAt(LocalDate.of(2026, 7, 1)).getInvitation(OWNER, "ABCD1234");
+
+        assertThat(res.title()).isEqualTo("짠테크 배틀");
+        assertThat(res.capacity()).isEqualTo(4);
+        assertThat(res.joinedCount()).isEqualTo(2);
+    }
+
+    // ---------- join ----------
+
+    @Test
+    @DisplayName("존재하지 않는 battleCode면 404(BATTLE_CODE_NOT_FOUND)를 던진다 — 락 조회(findByBattleCodeForUpdate)도 동일 처리")
+    void join_throwsWhenCodeNotFound() {
+        when(battleRepository.findByBattleCodeForUpdate("ZZZZ9999")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 7, 1)).join(OWNER, "ZZZZ9999"))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", BattleErrorCode.BATTLE_CODE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("참가 가능하면 참가자를 저장하고 battleId를 반환한다")
+    void join_savesParticipantAndReturnsBattleId() {
+        Battle battle = battleWithStatus(BattleStatus.READY, 4);
+        when(battleRepository.findByBattleCodeForUpdate("ABCD1234")).thenReturn(Optional.of(battle));
+        when(battleParticipantRepository.existsByBattle_IdAndUser_Id(BATTLE_ID, OWNER)).thenReturn(false);
+        when(battleParticipantRepository.countByBattle_Id(BATTLE_ID)).thenReturn(2);
+        when(userRepository.getReferenceById(OWNER)).thenReturn(user(OWNER));
+        ArgumentCaptor<BattleParticipant> captor = ArgumentCaptor.forClass(BattleParticipant.class);
+        when(battleParticipantRepository.save(captor.capture())).thenAnswer(inv -> inv.getArgument(0));
+
+        Long battleId = serviceAt(LocalDate.of(2026, 7, 1)).join(OWNER, "ABCD1234");
+
+        assertThat(battleId).isEqualTo(BATTLE_ID);
+        assertThat(captor.getValue().getUser().getId()).isEqualTo(OWNER);
+        assertThat(captor.getValue().getBattle()).isSameAs(battle);
+    }
+
+    @Test
+    @DisplayName("검증을 통과했더라도 저장 시점에 유니크 제약(uq_battle_participant) 위반이 나면 " +
+            "ALREADY_JOINED로 변환한다 — challenge #31과 동일한, 동시 재요청을 막는 마지막 방어선")
+    void join_convertsUniqueConstraintViolationToAlreadyJoined() {
+        Battle battle = battleWithStatus(BattleStatus.READY, 4);
+        when(battleRepository.findByBattleCodeForUpdate("ABCD1234")).thenReturn(Optional.of(battle));
+        when(battleParticipantRepository.existsByBattle_IdAndUser_Id(BATTLE_ID, OWNER)).thenReturn(false);
+        when(battleParticipantRepository.countByBattle_Id(BATTLE_ID)).thenReturn(2);
+        when(userRepository.getReferenceById(OWNER)).thenReturn(user(OWNER));
+        when(battleParticipantRepository.save(any(BattleParticipant.class)))
+                .thenThrow(new DataIntegrityViolationException("uq_battle_participant"));
+
+        assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 7, 1)).join(OWNER, "ABCD1234"))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", BattleErrorCode.ALREADY_JOINED);
     }
 }

--- a/src/test/java/Hampouch/server/domain/battle/service/BattleServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/battle/service/BattleServiceTest.java
@@ -288,6 +288,7 @@ class BattleServiceTest {
         assertThat(res.title()).isEqualTo("짠테크 배틀");
         assertThat(res.capacity()).isEqualTo(4);
         assertThat(res.joinedCount()).isEqualTo(2);
+        assertThat(res.durationDays()).isEqualTo(7); // endDate 대신 durationDays(2026-08-01 결정)
     }
 
     // ---------- join ----------

--- a/src/test/java/Hampouch/server/domain/battle/service/BattleServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/battle/service/BattleServiceTest.java
@@ -5,6 +5,7 @@ import Hampouch.server.domain.battle.dto.BattleListResponse;
 import Hampouch.server.domain.battle.dto.BattleSummary;
 import Hampouch.server.domain.battle.dto.CreateBattleRequest;
 import Hampouch.server.domain.battle.dto.CreateBattleResponse;
+import Hampouch.server.domain.battle.dto.JoinBattleResponse;
 import Hampouch.server.domain.battle.entity.Battle;
 import Hampouch.server.domain.battle.entity.BattleParticipant;
 import Hampouch.server.domain.battle.entity.BattleStatus;
@@ -109,11 +110,12 @@ class BattleServiceTest {
     }
 
     @Test
-    @DisplayName("durationDays가 3/7/14/31이 아니면 400(VALIDATION_ERROR)을 던진다")
+    @DisplayName("durationDays가 3/7/14/31이 아니면 400(INVALID_DURATION_DAYS)을 던진다 " +
+            "— capacity/startDate와 같은 전용 코드 shape인지 확인")
     void create_rejectsInvalidDuration() {
         assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 7, 1)).create(OWNER, request(4, 10, LocalDate.of(2026, 8, 1))))
                 .isInstanceOf(CustomException.class)
-                .hasFieldOrPropertyWithValue("errorCode", CommonErrorCode.VALIDATION_ERROR);
+                .hasFieldOrPropertyWithValue("errorCode", BattleErrorCode.INVALID_DURATION_DAYS);
     }
 
     @Test
@@ -215,6 +217,17 @@ class BattleServiceTest {
     }
 
     // ---------- getInvitation ----------
+    @Test
+    @DisplayName("status=CANCELLED로 목록을 조회하면 400(VALIDATION_ERROR)으로 거절한다 " +
+            "— 취소된 배틀은 목록에 노출하지 않기로 했으므로 받을 수 없는 값. 리포지토리까지 가지 않는다")
+    void getMyBattles_rejectsCancelledFilter() {
+        assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 7, 1)).getMyBattles(OWNER, BattleStatus.CANCELLED))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", CommonErrorCode.VALIDATION_ERROR);
+
+        verifyNoInteractions(battleParticipantRepository);
+    }
+
     // validateJoinable의 우선순위 4단계(CANCELLED → ALREADY_STARTED → ALREADY_JOINED → BATTLE_FULL)를
     // 여기서 전부 검증한다 — join()도 같은 private 메서드를 재사용하므로 join 쪽에선 중복 검증하지 않는다.
 
@@ -314,9 +327,9 @@ class BattleServiceTest {
         ArgumentCaptor<BattleParticipant> captor = ArgumentCaptor.forClass(BattleParticipant.class);
         when(battleParticipantRepository.save(captor.capture())).thenAnswer(inv -> inv.getArgument(0));
 
-        Long battleId = serviceAt(LocalDate.of(2026, 7, 1)).join(OWNER, "ABCD1234");
+        JoinBattleResponse response = serviceAt(LocalDate.of(2026, 7, 1)).join(OWNER, "ABCD1234");
 
-        assertThat(battleId).isEqualTo(BATTLE_ID);
+        assertThat(response.battleId()).isEqualTo(BATTLE_ID);
         assertThat(captor.getValue().getUser().getId()).isEqualTo(OWNER);
         assertThat(captor.getValue().getBattle()).isSameAs(battle);
     }


### PR DESCRIPTION
## 📎연관된 이슈

- close: #78

## 📄 작업 내용 요약

- 햄배틀 4개 API(생성/목록/참가 링크 조회/참가)의 노션 명세와 실제 코드를 전수 대조해 나온 불일치를 수정. 엔티티·테이블 변경은 없고, 대부분 에러 코드·문구·응답 필드 수준이지만 **`status` 미지정 목록 조회에서 500이 나갈 수 있던 경로**가 하나 포함돼 있음.

- `BattleErrorCode`에 `INVALID_DURATION_DAYS` 신설, `validateDuration()`이 `CommonErrorCode.VALIDATION_ERROR` 대신 이를 던지도록 변경
- `BattleErrorCode` 메시지 문구 통일 (`BATTLE_NOT_FOUND`·`BATTLE_CODE_NOT_FOUND` 마침표 누락, `BATTLE_ALREADY_STARTED`·`BATTLE_CANCELLED` 문구 교체)
- `JoinBattleResponse` DTO 신설 — 참가 응답이 `battleId`를 반환하도록 `BattleService.join()` 반환 타입을 `Long`에서 변경
- `BattleController.create()`의 성공 message를 `"햄배틀이 생성됐습니다."`로 명시
- `CreateBattleRequest`의 모든 검증 애노테이션에 `message` 명시
- `findMyParticipations`에서 `CANCELLED` 배틀 제외 + `getMyBattles()`가 `status=CANCELLED` 요청을 400으로 거절
- 위 변경에 맞춰 `BattleServiceTest`·`BattleControllerTest`·`BattleParticipantRepositoryTest` 수정 및 케이스 2건 추가

## 👀 중요 변경 사항

- **취소된 배틀이 목록 조회에서 500을 유발할 수 있던 경로를 차단**: `status` 필터가 "null이면 전체"라 **미지정 조회에 `CANCELLED`가 섞여 들어오고**, 그대로 `toSummary()`에 닿으면 정의된 카드 shape가 없어 `IllegalStateException` → 500이 나갑니다. 지금 재현되지 않는 건 `CANCELLED`로 전이시키는 시작일 배치가 아직 없어서일 뿐이라, ④ 배치가 붙는 순간 터질 자리였습니다. 쿼리(`findMyParticipations`)에서 제외 + 서비스에서 `status=CANCELLED` 거절, 두 겹으로 막았습니다. **취소된 배틀은 목록에 노출하지 않는 것이 확정 사항**이므로 프론트도 이 상태를 기대하지 않도록 맞춰야 합니다.
- **에러 코드·메시지 변경이 있어 프론트 영향 가능**: `BATTLE_ALREADY_STARTED`("이미 시작된 햄배틀에는 참가할 수 없습니다.")·`BATTLE_CANCELLED`("참가 인원이 모이지 않아 취소된 햄배틀입니다.")·`BATTLE_NOT_FOUND`·`BATTLE_CODE_NOT_FOUND`의 `message` 문자열이 바뀌었고, `durationDays` 검증 실패 응답이 `VALIDATION_ERROR`에서 `INVALID_DURATION_DAYS`로 바뀌었습니다. `code`가 아니라 `message`로 분기하는 클라이언트 코드가 있다면 영향을 받습니다.
- **`durationDays`에 전용 에러 코드를 만든 이유**: 기존엔 `CommonErrorCode.VALIDATION_ERROR` + 커스텀 메시지였는데, 이 경로는 `ErrorResponse.from(errorCode, message)`를 타서 **`fieldErrors`가 없는 다른 shape**로 나갑니다. `capacity`(`INVALID_CAPACITY_RANGE`)·`startDate`(`INVALID_START_DATE`)와 응답 모양이 달라 프론트가 생성 폼의 세 필드를 같은 방식으로 처리할 수 없었습니다. 이제 셋 다 전용 코드 + 400으로 통일됩니다.
- **`CreateBattleRequest`의 검증 메시지를 전부 명시한 이유**: `message`를 생략하면 Hibernate Validator 기본 번들이 쓰이는데 그 문구는 **JVM 기본 로케일을 탑니다**. 한국어 Windows 로컬은 `ko_KR`이라 "공백일 수 없습니다"가, 배포 컨테이너(`eclipse-temurin:21-jre`, `LANG` 미설정)는 `en_US`라 "must not be blank"가 나가서, 명세에 어느 쪽을 적어도 한쪽 환경에서는 틀린 말이 됩니다. auth 도메인이 이미 전부 명시하고 있어 컨벤션에도 맞췄습니다.
- **참가 응답에 `battleId`를 `Location` 헤더와 중복해서 담았습니다**: 헤더만 두면 클라이언트가 URI 문자열을 직접 잘라 써야 해서 `BASE_PATH`가 바뀔 때 컴파일 에러 없이 런타임에 조용히 깨집니다. 명세에 있던 `participantId`·`joinedAt`은 받는 엔드포인트도, 노출하는 화면도 없어 제외했습니다.

## 🔖 Uncompleted Tasks

-  ④ 배치 도입 시 취소 사실을 사용자에게 알릴 다른 경로(알림 등)가 필요한지 재확인 필요.
- `GET /api/battles`의 `ONGOING` 카드 `todayAmount`/`totalAmount`, `TERMINATED` 카드 `winnerNickname`은 여전히 빈 값 스텁 — ③(상세조회+랭킹)에서 교체.
- CORS 설정이 아직 저장소에 없음 — 웹 클라이언트가 붙을 때 `exposedHeaders`에 `Location`을 넣지 않으면 JS에서 헤더를 못 읽습니다. 참가 응답 body에 `battleId`를 담은 것이 이 문제를 일부 완화하지만 CORS 설정 자체는 별도 작업.

## 📢 To Reviewers

- `status=CANCELLED` 요청을 **400으로 거절**하는 게 맞는지, 아니면 빈 배열을 주는 게 나은지 의견 부탁드립니다. 쿼리에서 이미 제외하고 있어 거절하지 않아도 500은 안 나지만, 조용히 빈 배열을 주면 프론트의 잘못된 요청이 묻힌다고 판단해 명시적으로 막았습니다.
- `findMyParticipations`의 JPQL에서 enum 리터럴을 FQN(`Hampouch.server.domain.battle.entity.BattleStatus.CANCELLED`)으로 썼습니다. 저장소에 선례가 없어서, 팀에서 선호하는 다른 표기(파라미터 바인딩 등)가 있으면 알려주세요.
- 커스텀 성공 메시지를 **쓰기 동작에만** 붙이는 컨벤션(auth 7곳·expense 삭제 1곳의 기존 패턴)에 맞춰 생성/참가에만 넣고 조회는 기본 문구로 뒀습니다. 이 기준에 동의하시는지 확인 부탁드립니다.
- 에러 메시지 문구 변경 4건이 사용자에게 보이는 문구라, 특히 `BATTLE_CANCELLED`("참가 인원이 모이지 않아 취소된 햄배틀입니다.")가 과한 설명은 아닌지 봐주세요. 기존 "이미 취소된 햄배틀입니다."는 사용자가 직접 취소한 것 같은 뉘앙스라 바꿨습니다.