### PR TITLE
fix: 필수 query parameter 누락 시 500 대신 400이 나가도록 수정

### DIFF
--- a/src/main/java/Hampouch/server/global/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/Hampouch/server/global/common/exception/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
@@ -136,6 +137,28 @@ public class GlobalExceptionHandler {
                 "[MethodArgumentTypeMismatchException] {} {} | field={} | value={}",
                 request.getMethod(), request.getRequestURI(),
                 fieldName, e.getValue()
+        );
+
+        return ResponseEntity
+                .status(CommonErrorCode.VALIDATION_ERROR.getHttpStatus())
+                .body(ErrorResponse.validation(fieldErrors));
+    }
+
+    // 필수 @RequestParam이 요청에 아예 안 붙어 온 경우 — 값이 없어 바인딩 자체가 안 되므로 @Valid까지
+    // 못 가고 여기서만 잡을 수 있다. 이 handler가 없으면 fallback 경로를 타 500으로 나간다.
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(
+            MissingServletRequestParameterException e,
+            HttpServletRequest request
+    ) {
+        Map<String, String> fieldErrors = new LinkedHashMap<>();
+        String paramName = e.getParameterName();
+        fieldErrors.put(paramName, paramName + "은(는) 필수 파라미터입니다.");
+
+        log.warn(
+                "[MissingServletRequestParameterException] {} {} | param={} | type={}",
+                request.getMethod(), request.getRequestURI(),
+                paramName, e.getParameterType()
         );
 
         return ResponseEntity

--- a/src/test/java/Hampouch/server/global/common/exception/GlobalExceptionHandlerIntegrationTest.java
+++ b/src/test/java/Hampouch/server/global/common/exception/GlobalExceptionHandlerIntegrationTest.java
@@ -15,7 +15,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 /**
- * 메서드 불일치·미매핑 경로 예외는 컨트롤러에 못 닿고 MVC 단계에서 나므로,
+ * 메서드 불일치·미매핑 경로·필수 파라미터 누락 예외는 컨트롤러에 못 닿고 MVC 단계에서 나므로,
  * 슬라이스가 아니라 실제 매핑·시큐리티 필터를 다 태운 통합으로 검증한다.
  * 로그인이 필요한 경로는 실제 액세스 토큰을 붙여 부른다 — 인증이 없으면 401이 먼저 나가 재현이 안 된다.
  */
@@ -62,5 +62,17 @@ class GlobalExceptionHandlerIntegrationTest {
                 .andExpect(jsonPath("$.code").value("NOT_FOUND"))
                 .andExpect(jsonPath("$.message").value("요청한 리소스를 찾을 수 없습니다."))
                 .andExpect(jsonPath("$.status").value(404));
+    }
+
+    // 필수 @RequestParam이 빠지면 컨트롤러 진입 전 인자 바인딩 단계에서 던져지므로,
+    // 서비스·DB 접근 없이도 재현된다. /api/expenses/day는 date가 필수라 이 케이스에 그대로 쓸 수 있다.
+    @Test
+    @DisplayName("필수 쿼리 파라미터 없이 요청하면 400 상태와 해당 파라미터의 필드 에러로 응답한다")
+    void missingRequiredQueryParameter_returns400WithFieldError() throws Exception {
+        mvc.perform(get("/api/expenses/day").header("Authorization", bearer(1L)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+                .andExpect(jsonPath("$.fieldErrors.date").value("date은(는) 필수 파라미터입니다."))
+                .andExpect(jsonPath("$.status").value(400));
     }
 }


### PR DESCRIPTION
## 📎 연관된 이슈
- close: #77

## 📄 작업 내용 요약
- `GlobalExceptionHandler`에 `MissingServletRequestParameterException` 핸들러 추가 — 필수 `@RequestParam`이 요청에 없으면 `Exception.class` fallback(500) 대신 400 + `VALIDATION_ERROR` + `fieldErrors`로 응답
- `GlobalExceptionHandlerIntegrationTest`에 회귀 테스트 추가 — `GET /api/expenses/day`를 `date` 없이 호출해 400/`VALIDATION_ERROR`/`fieldErrors.date` 확인

## 👀 중요 변경 사항
- 새 에러 코드는 안 만들고 기존 `CommonErrorCode.VALIDATION_ERROR`를 재사용했습니다. #48 에서 이미 이 코드를 재사용한 선례를 그대로 따랐습니다.
- 응답 shape는 기존 `MethodArgumentTypeMismatchException` 핸들러와 동일합니다 — `fieldErrors`에 파라미터명 → **OO은(는) 필수 파라미터입니다.** 하나만 담깁니다. 여러 파라미터가 동시에 빠져도 Spring이 하나씩 순차로 던지기 때문에 한 번의 요청에선 한 개만 잡히는데, 이건 기존 `MethodArgumentTypeMismatchException` 핸들러도 같은 한계라 이번에 새로 생긴 문제는 아닙니다.
- 이번 건까지 반영되면서 #48 / #58 에 이어 `GlobalExceptionHandler`에서 알려져 있던 클라이언트 입력 오류가 500으로 새는 경로 세 개가 전부 막혔습니다.

## 🔖 Uncompleted Tasks

## 📢 To Reviewers
- 필드 에러 메시지 문구가 기존 `MethodArgumentTypeMismatchException` 문구와 톤이 맞는지 봐주세요.
- 회귀 테스트를 기존 `GlobalExceptionHandlerIntegrationTest`(원래 405/404 케이스만 있던 파일)에 얹었는데, 파일명이 이제 메서드/경로 전용이 아니게 됐습니다. 이대로 둬도 될지, 파일을 나누는 게 나을지 의견 부탁드립니다.