### PR TITLE
fix(challenge): 목표 금액 상한 도입 및 0원 허용 (0727 자체 결정 반영) (#72) [base: develop]

### DIFF
--- a/docs/노션_상세_붙여넣기.md
+++ b/docs/노션_상세_붙여넣기.md
@@ -18,6 +18,7 @@
 > - ✅ 노션 반영 완료: **challenge 1~7 · challenge 10 · rest 1~2 · mini-challenge 1~5**
 >   (challenge 4 참고 문단은 0731 저녁 v4 최종판을 일혁이 직접 붙였고, 0801 새벽 노션 실사로 전문 일치 확인 — 차이 0건)
 > - 🟢 **지금 붙이기(PR #84 열림): challenge 2(GET /current)·challenge 6(GET /history) 재붙여넣기 · expense '오늘은 안 썼어요' 신규 블록** (#67)
+> - 🟢 **지금 붙이기: challenge 1(POST /challenges) 재붙여넣기** — budgetTotal 범위 0~10,000,000이 Error Response 줄에 들어감 (#72)
 > - ⚠️ challenge 2의 GOAL_TOO_TIGHT 제거는 이 PR 범위가 아니라 이슈 #51이다. 현재 PR 브랜치에는 카드가 남아 있으므로 #51 PR이 열리면 해당 설명을 다시 교체한다.
 > - 🚫 아직 붙이지 않음: challenge 8(한도 조정) · 9(다음 챌린지 추천) — 행·설계 확정 후 반영.
 > - ⏳ 구현되면 추가할 행: 최종 종료(이슈 #50) — 원고 블록도 아직 없음
@@ -53,7 +54,7 @@
 ```
 
 ## Error Response
-- 필드 누락·형식·범위 위반(durationDays 1~100 — 상한 100일은 0714 전체회의 확정), resetByPayday=true인데 paydayDay 없음 (400)
+- 필드 누락·형식·범위 위반(durationDays 1~100 — 상한 100일은 0714 전체회의 확정 · budgetTotal 0~10,000,000 — 0원은 무지출 챌린지로 통과), resetByPayday=true인데 paydayDay 없음 (400)
 ```json
 { "code": "VALIDATION_ERROR", "message": "입력값이 올바르지 않습니다.", "status": 400,
   "fieldErrors": { "durationDays": "100 이하여야 합니다." } }

--- a/src/main/java/Hampouch/server/domain/challenge/dto/AdjustGoalRequest.java
+++ b/src/main/java/Hampouch/server/domain/challenge/dto/AdjustGoalRequest.java
@@ -1,7 +1,9 @@
 package Hampouch.server.domain.challenge.dto;
 
 import Hampouch.server.domain.challenge.entity.AdjustOption;
+import Hampouch.server.domain.challenge.entity.Challenge;
 import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 
 /**
@@ -14,8 +16,9 @@ public record AdjustGoalRequest(
 
         AdjustOption option,
 
-        /** 직접 입력 금액(기간 전체 목표). 하한은 생성 요청의 budgetTotal과 같은 값으로 맞춘다. */
-        @Min(1)
+        /** 직접 입력 금액(기간 전체 목표). 하한·상한은 생성 요청의 budgetTotal과 같은 값으로 맞춘다. */
+        @Min(0)
+        @Max(Challenge.BUDGET_TOTAL_MAX)
         Integer budgetTotal
 ) {
 

--- a/src/main/java/Hampouch/server/domain/challenge/dto/CreateChallengeRequest.java
+++ b/src/main/java/Hampouch/server/domain/challenge/dto/CreateChallengeRequest.java
@@ -1,5 +1,6 @@
 package Hampouch.server.domain.challenge.dto;
 
+import Hampouch.server.domain.challenge.entity.Challenge;
 import jakarta.validation.constraints.*;
 
 import java.time.LocalDate;
@@ -16,8 +17,10 @@ public record CreateChallengeRequest(
         @Max(100)
         Integer durationDays,
 
+        // 0원 = 무지출 챌린지라 하한이 0이다(0727 자체 결정). 상한이 없으면 int 최대까지 통과한다 — 상한 값의 유도는 Challenge.BUDGET_TOTAL_MAX
         @NotNull
-        @Min(1)
+        @Min(0)
+        @Max(Challenge.BUDGET_TOTAL_MAX)
         Integer budgetTotal,
 
         @NotNull

--- a/src/main/java/Hampouch/server/domain/challenge/entity/AdjustOption.java
+++ b/src/main/java/Hampouch/server/domain/challenge/entity/AdjustOption.java
@@ -21,11 +21,13 @@ public enum AdjustOption {
 
     /**
      * 조정 후 목표 금액 = 현재 목표 × 배율, 버림.
-     * long으로 곱한 뒤 int 상한에서 자르는 건 오버플로 방어다 — 생성 요청의 budgetTotal에 상한이 없어
-     * 목표가 int 최대에 가까우면 배율을 곱한 값이 int 범위를 넘고, 그대로 캐스팅하면 음수가 되어 조정이 500으로 나간다.
+     * long으로 곱하는 건 곱셈 자체가 int 범위를 넘지 않게 하는 것이고, 되돌릴 때 잘리지 않는 근거는
+     * 요청 상한이다 — 생성·직접 입력 모두 Challenge.BUDGET_TOTAL_MAX(10,000,000)에서 막히고 조정은 최대 2회라
+     * 도달 가능한 목표는 14,400,000(= 10,000,000 × 1.2²)이 최대다.
+     * 상한 상향 등으로 그 근거가 깨지면 toIntExact가 그 자리에서 터진다 — 맨 캐스팅으로 두면 음수로 뒤집힌 뒤
+     * Challenge.adjustGoal의 음수 가드에 걸려 오버플로가 "budgetTotal은 0 이상" 메시지로 가려진다.
      */
     public int apply(int currentBudgetTotal) {
-        long raised = (long) currentBudgetTotal * percent / 100;
-        return (int) Math.min(raised, Integer.MAX_VALUE);
+        return Math.toIntExact((long) currentBudgetTotal * percent / 100);
     }
 }

--- a/src/main/java/Hampouch/server/domain/challenge/entity/Challenge.java
+++ b/src/main/java/Hampouch/server/domain/challenge/entity/Challenge.java
@@ -29,6 +29,14 @@ import java.util.List;
 // 기능은 JpaAuditingConfig가 켜고, 시각은 컴퓨터 시계가 아니라 공용 Clock(Asia/Seoul, ClockConfig)에서 얻음 — 테스트에선 고정 시계로 교체 가능
 public class Challenge {
 
+    /**
+     * 목표 금액의 요청 상한(원). 0727 자체 결정이 금액 필드(목표·일별 지출)에 공통으로 준 값이고, 유도는 일별 지출 쪽이다 —
+     * 100일치를 int로 누산하면 21.4억을 넘겨서 안전 경계가 약 2,147만이고 그 절반을 잡았다. 목표 금액만 놓고 보면 훨씬 헐거운
+     * 값이라 여기서 오버플로를 읽어내지 말 것(조정 배율이 int를 넘기려면 약 17.9억이 필요하다).
+     * 엔티티 불변식도 아니다 — 프리셋 조정이 배율을 곱하므로 저장된 budgetTotal은 이 값을 넘을 수 있다(상한 × 1.2² = 14,400,000).
+     */
+    public static final int BUDGET_TOTAL_MAX = 10_000_000;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY) // 번호 발급은 DB(auto_increment) 몫 — 대체로 1씩 증가하지만 롤백 시 구멍 가능. 고유 식별자로만 쓰고 순서 논리엔 쓰지 말 것
     private Long id;

--- a/src/test/java/Hampouch/server/domain/challenge/controller/ChallengeControllerTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/controller/ChallengeControllerTest.java
@@ -118,6 +118,45 @@ class ChallengeControllerTest {
     }
 
     @Test
+    @DisplayName("목표 금액이 0원이면 무지출 챌린지로 보고 201로 생성한다")
+    void create_201_whenBudgetZero() throws Exception {
+        when(service.create(anyLong(), any())).thenReturn(new CreateChallengeResponse(
+                1L, 0, LocalDate.of(2026, 12, 1), LocalDate.of(2026, 12, 30), ChallengeStatus.IN_PROGRESS));
+
+        mvc.perform(post("/api/challenges")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "durationDays": 30, "budgetTotal": 0, "startDate": "2026-12-01" }
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.dailyLimit").value(0));
+    }
+
+    @Test
+    @DisplayName("목표 금액이 음수면 400으로 거절한다")
+    void create_400_whenBudgetNegative() throws Exception {
+        mvc.perform(post("/api/challenges")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "durationDays": 30, "budgetTotal": -1, "startDate": "2026-12-01" }
+                                """))
+                .andExpect(status().isBadRequest());
+        verify(service, never()).create(anyLong(), any());
+    }
+
+    @Test
+    @DisplayName("목표 금액이 상한 10,000,000원을 넘으면 400으로 거절한다")
+    void create_400_whenBudgetOverMax() throws Exception {
+        mvc.perform(post("/api/challenges")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "durationDays": 30, "budgetTotal": 10000001, "startDate": "2026-12-01" }
+                                """))
+                .andExpect(status().isBadRequest());
+        verify(service, never()).create(anyLong(), any());
+    }
+
+    @Test
     @DisplayName("월급날 리셋을 켜고 월급날을 안 보내면 400으로 거절한다 (S6)")
     void create_400_whenPaydayMissing() throws Exception {
         mvc.perform(post("/api/challenges")
@@ -353,12 +392,40 @@ class ChallengeControllerTest {
     }
 
     @Test
-    @DisplayName("직접 입력 금액이 0 이하면 400으로 거절한다")
-    void adjust_400_whenDirectAmountNotPositive() throws Exception {
+    @DisplayName("직접 입력 금액이 0원이어도 200으로 처리된다 — 생성과 같은 하한이라 무지출로 낮추는 조정이 된다")
+    void adjust_200_whenDirectAmountZero() throws Exception {
+        when(service.adjustGoal(anyLong(), anyLong(), any()))
+                .thenReturn(new AdjustGoalResponse(1L, 0, 0, 1, 2));
+
         mvc.perform(post("/api/challenges/1/adjust")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 { "budgetTotal": 0 }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.budgetTotal").value(0))
+                .andExpect(jsonPath("$.data.dailyLimit").value(0));
+    }
+
+    @Test
+    @DisplayName("직접 입력 금액이 음수면 400으로 거절한다")
+    void adjust_400_whenDirectAmountNegative() throws Exception {
+        mvc.perform(post("/api/challenges/1/adjust")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "budgetTotal": -1 }
+                                """))
+                .andExpect(status().isBadRequest());
+        verify(service, never()).adjustGoal(anyLong(), anyLong(), any());
+    }
+
+    @Test
+    @DisplayName("직접 입력 금액이 상한 10,000,000원을 넘으면 400으로 거절한다 — 생성 요청과 같은 상한이다")
+    void adjust_400_whenDirectAmountOverMax() throws Exception {
+        mvc.perform(post("/api/challenges/1/adjust")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "budgetTotal": 10000001 }
                                 """))
                 .andExpect(status().isBadRequest());
         verify(service, never()).adjustGoal(anyLong(), anyLong(), any());

--- a/src/test/java/Hampouch/server/domain/challenge/service/ChallengeCalculatorTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/service/ChallengeCalculatorTest.java
@@ -220,6 +220,17 @@ class ChallengeCalculatorTest {
     }
 
     @Test
+    @DisplayName("조정으로 도달할 수 있는 목표 금액의 최대치는 요청 상한에 1.2배를 두 번 먹인 14,400,000원이다")
+    void adjustOption_reachableMaximumFromRequestCeiling() {
+        // 요청 상한을 올리면 이 값이 함께 커지고, AdjustOption.apply가 int로 되돌릴 때 잘리지 않는다는 근거가 무너진다
+        int first = AdjustOption.PLUS_20.apply(Challenge.BUDGET_TOTAL_MAX);
+        int second = AdjustOption.PLUS_20.apply(first);
+
+        assertThat(first).isEqualTo(12_000_000);
+        assertThat(second).isEqualTo(14_400_000);
+    }
+
+    @Test
     @DisplayName("기간 도중 한도를 올려도 조정 전 날짜는 옛 한도로 집계된다 — 기록 없는 날의 절약액도 그날 한도로 계산한다")
     void summarizeForResult_keepsPreAdjustmentDaysOnOldLimit() {
         Challenge ch = Challenge.builder()


### PR DESCRIPTION
## 📎연관된 이슈

- close: #72

## 📄 작업 내용 요약

챌린지 목표 금액에 상한이 없어 `2147483647`까지 통과했고, 0727 자체 결정의 하한 완화(0원 = 무지출 챌린지)도 반영돼 있지 않았습니다. 두 값을 결정대로 맞췄습니다.

- `CreateChallengeRequest.budgetTotal`을 `@Min(1)` → `@Min(0)` + `@Max(10_000_000)`으로 바꿨습니다.
- `AdjustGoalRequest.budgetTotal`(조정 화면의 직접 입력 칸)도 같은 하한·상한으로 맞췄습니다. 생성과 다른 값을 두면 같은 금액이 화면마다 다르게 거절됩니다.
- 상한은 `Challenge.BUDGET_TOTAL_MAX` 상수로 두고 두 DTO가 함께 참조합니다.
- `AdjustOption.apply`의 `Math.min(raised, Integer.MAX_VALUE)` 클램프를 걷어냈습니다. 그 방어는 "생성 요청에 상한이 없다"를 전제로 붙어 있던 것이라, 상한이 생기면 걸릴 입력이 없어집니다 — 생성·직접 입력이 모두 10,000,000에서 막히고 조정이 최대 2회(`ChallengeCalculator.maxAdjustmentCount`)라 `apply`에 들어올 수 있는 최대 입력이 12,000,000입니다. 대신 `Math.toIntExact`로 바꿔, 나중에 그 전제가 깨지면 그 자리에서 터지게 했습니다.
- 경계 테스트를 더했습니다 — 생성(0원 201 / 음수 400 / 상한 초과 400), 조정 직접 입력(0원 200 / 음수 400 / 상한 초과 400), 그리고 조정으로 도달 가능한 목표 금액의 최대치(14,400,000) 고정.

기존 테스트 하나(`직접 입력 금액이 0 이하면 400`)는 0원이 통과로 바뀌어 교체했습니다. 테스트 582건 통과.

## 👀 중요 변경 사항

**에러 계약이 바뀝니다.** `POST /api/challenges`와 `POST /api/challenges/{id}/adjust` 양쪽에서 목표 금액 0원이 400 → 통과, 10,000,000 초과가 통과 → 400이 됩니다. 안드가 0원을 미리 막고 있다면 서버는 이제 받습니다.

`Challenge.BUDGET_TOTAL_MAX`는 **요청 상한이지 엔티티 불변식이 아닙니다.** 프리셋 조정이 배율을 곱하므로 저장된 `budgetTotal`은 이 값을 넘을 수 있습니다(최대 14,400,000 = 상한 × 1.2²). 엔티티에 같은 상한을 가드로 걸면 조정이 깨집니다.

## 🔖 Uncompleted Tasks

- 0727 결정은 상한을 금액 필드 **둘**(목표·일별 지출)에 주기로 했는데 이 PR은 목표 금액만 반영합니다. `DayUpsertRequest.spentAmount`는 아직 `@Min(0)`뿐이라 100일치를 int로 누산하는 `ChallengeCalculator.summarizeForResult`에서 뒤집힐 수 있습니다. #72 의 제목·체크리스트가 목표 금액으로 잡혀 있어 별도 이슈로 뺍니다.
- 팀 노션 "API 설계" challenge 1 블록 재붙여넣기 — 400 조건에 범위가 들어갑니다.

## 📢 To Reviewers

- **10,000,000이라는 값 자체는 시안 근거가 없습니다.** 금액을 입력하는 화면 두 곳 — 온보딩 STEP 3 [2816:9606](https://www.figma.com/design/pNZSNgB7Ci0tlkywr96bYv/?node-id=2816-9606), 목표 금액 수정 [2838:19483](https://www.figma.com/design/pNZSNgB7Ci0tlkywr96bYv/?node-id=2838-19483) — 에 최대값 표기도 초과 문구도 없는 것을 확인했습니다. 0727에 "금액 하한·상한은 서버가 정한다"로 PM 질문에서 내린 값이고, 유도는 일별 지출 쪽(100일 누산 경계 약 2,147만의 절반)이라 목표 금액만 놓고 보면 헐거운 값입니다. 디자인이 나중에 다른 상한을 그리면 그쪽을 따르면 됩니다.
- `Math.toIntExact` 대신 맨 캐스팅으로 둬도 동작은 같습니다. 다만 그 경우 전제가 깨졌을 때 음수로 뒤집힌 뒤 `Challenge.adjustGoal`의 음수 가드에 걸려서, 오버플로가 "budgetTotal은 0 이상이어야 합니다" 메시지로 가려집니다. 도달 불가 경로에 예외를 두는 게 과한지 봐 주세요.
