### PR TITLE
chore(test): 추천 미니 챌린지 컨트롤러 테스트의 500 시절 서술을 현행 400 기준으로 정정 (#68) [base: develop]

### DIFF
--- a/src/test/java/Hampouch/server/domain/minichallenge/controller/RecommendedMiniChallengeControllerTest.java
+++ b/src/test/java/Hampouch/server/domain/minichallenge/controller/RecommendedMiniChallengeControllerTest.java
@@ -86,12 +86,10 @@ class RecommendedMiniChallengeControllerTest {
     }
 
     @Test
-    @DisplayName("durationDays에 숫자가 아닌 값이 오면 현재는 500이다 — 타입 바인딩 실패의 400 매핑은 공통 핸들러(팀) 몫이라 현 동작을 고정해 둔다")
-    void recommended_nonNumericDuration_currently500() throws Exception {
-        // durationDays=abc는 Integer 변환 실패(MethodArgumentTypeMismatchException)를 일으키는데,
-        // 공통 GlobalExceptionHandler(나연 담당 — 이 브랜치 수정 금지)에 그 예외 전용 핸들러가 없어
-        // Exception 포괄 핸들러로 500 INTERNAL_SERVER_ERROR가 내려간다. 이 테스트는 그 현재 동작을
-        // 고정해 두는 회귀 문서 — 공통 핸들러에 400 매핑이 추가되면(팀 싱크 전달 예정) 400으로 갱신할 것.
+    @DisplayName("durationDays에 숫자가 아닌 값이 오면 400으로 거절하고, 응답 본문의 code는 VALIDATION_ERROR이며 fieldErrors에 durationDays 키가 담긴다 — 쿼리 파라미터를 Integer로 바꾸는 단계에서 실패한 것이라 서비스는 호출되지 않는다")
+    void recommended_400_whenDurationNotNumeric() throws Exception {
+        // 이 400은 컨트롤러가 아니라 공통 GlobalExceptionHandler의 MethodArgumentTypeMismatchException
+        // 핸들러가 만든다 — 그쪽 매핑이 바뀌면 여기가 깨진다.
         mvc.perform(get(PATH).param("durationDays", "abc"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))


### PR DESCRIPTION
## 📎연관된 이슈

- close: #68

## 📄 작업 내용 요약

`RecommendedMiniChallengeControllerTest`의 마지막 테스트가 이름·주석과 단언이 서로 다른 말을 하고 있었습니다. 이름과 주석은 "현재는 500이다"인데 단언은 400 + `VALIDATION_ERROR` + `fieldErrors.durationDays`를 기대하고 통과합니다. 갱신 누락입니다 — 공통 핸들러에 `MethodArgumentTypeMismatchException` 처리가 들어온 뒤(7121c64) 24분 만에 단언만 400으로 바뀌고(3cdecd5) 이름·주석은 그대로 남았습니다.

- DisplayName을 현행 400 동작 서술로 교체했습니다.
- 메서드명 `recommended_nonNumericDuration_currently500` → `recommended_400_whenDurationNotNumeric`. 시점에 묶인 `currently`를 걷어내고 레포 컨트롤러 테스트의 지배 패턴 `<동작>_<상태코드>_when<조건>`에 맞췄습니다.
- 본문 주석 4줄을 한 줄로 줄였습니다. 틀린 내용인 것과 별개로 담당·브랜치·후속 예정 같은 경위 서술이라 남길 값이 아니었고, 남긴 한 줄은 "이 400을 만드는 건 컨트롤러가 아니라 공통 핸들러"라는 제약입니다.

단언과 프로덕션 코드는 건드리지 않았습니다. 테스트 580건 통과.

## 👀 중요 변경 사항

프로덕션 코드 0줄, 응답 계약 변경 없습니다.

이 테스트가 검증하는 400은 미니 챌린지 도메인이 만드는 게 아니라 `GlobalExceptionHandler`의 타입 불일치 처리에서 나옵니다. 그쪽 매핑을 바꾸면 이 테스트가 깨지는데, 그건 오탐이 아니라 의도된 신호입니다.

## 🔖 Uncompleted Tasks

- 같은 성격의 잔재(`(S1)`~`(S7)` 축약어, 이슈 태그, `§`)가 다른 테스트 클래스 몇 곳에 남아 있습니다. 해당 파일을 크게 만질 때 각자 정리합니다.
- 미니 챌린지의 `date`를 `String`으로 받아 서비스에서 직접 파싱하는 우회도 같은 뿌리(공통 핸들러가 400을 만들어 주니 우회가 불필요)이고, #27로 따로 열려 있습니다.

## 📢 To Reviewers

- DisplayName이 길어졌는데 같은 파일의 나머지 세 개와 서술 밀도를 맞춘 것입니다. 이 파일만 튀는 게 아닌지 봐 주세요.
- 이름이 "서비스는 호출되지 않는다"까지 주장하므로 그걸 증명하는 `verify(service, never())` 한 줄은 남겼습니다. 이름에서 그 절을 빼고 단언도 지우는 쪽이 낫다고 보시면 그렇게 하겠습니다.
