### PR TITLE
refactor(mini): date 처리 String 수동 파싱 → LocalDate 직접 바인딩 전환 (#27) [base: develop]

### DIFF
--- a/docs/노션_상세_붙여넣기.md
+++ b/docs/노션_상세_붙여넣기.md
@@ -19,7 +19,7 @@
 >   (challenge 4 참고 문단은 0731 저녁 v4 최종판을 일혁이 직접 붙였고, 0801 새벽 노션 실사로 전문 일치 확인 — 차이 0건)
 > - 🟢 **지금 붙이기(PR #84 열림): challenge 2(GET /current)·challenge 6(GET /history) 재붙여넣기 · expense '오늘은 안 썼어요' 신규 블록** (#67)
 > - ⚠️ challenge 2의 GOAL_TOO_TIGHT 제거는 이 PR 범위가 아니라 이슈 #51이다. 현재 PR 브랜치에는 카드가 남아 있으므로 #51 PR이 열리면 해당 설명을 다시 교체한다.
-> - 🟢 **PR 열리면 붙이기: mini-challenge 1 · mini-challenge 5 재붙여넣기** (#27) — date 형식 오류의 응답 code가 `BAD_REQUEST`에서 `VALIDATION_ERROR`로 바뀐 계약 변경이라 안드가 읽는 값이 달라진다.
+> - 🟢 **지금 붙이기(PR #104 열림): mini-challenge 1 · mini-challenge 5 재붙여넣기** (#27) — date 형식 오류의 응답 code가 `BAD_REQUEST`에서 `VALIDATION_ERROR`로 바뀐 계약 변경이라 안드가 읽는 값이 달라진다.
 > - 🚫 아직 붙이지 않음: challenge 8(한도 조정) · 9(다음 챌린지 추천) — 행·설계 확정 후 반영.
 > - ⏳ 구현되면 추가할 행: 최종 종료(이슈 #50) — 원고 블록도 아직 없음
 

--- a/docs/노션_상세_붙여넣기.md
+++ b/docs/노션_상세_붙여넣기.md
@@ -19,6 +19,7 @@
 >   (challenge 4 참고 문단은 0731 저녁 v4 최종판을 일혁이 직접 붙였고, 0801 새벽 노션 실사로 전문 일치 확인 — 차이 0건)
 > - 🟢 **지금 붙이기(PR #84 열림): challenge 2(GET /current)·challenge 6(GET /history) 재붙여넣기 · expense '오늘은 안 썼어요' 신규 블록** (#67)
 > - ⚠️ challenge 2의 GOAL_TOO_TIGHT 제거는 이 PR 범위가 아니라 이슈 #51이다. 현재 PR 브랜치에는 카드가 남아 있으므로 #51 PR이 열리면 해당 설명을 다시 교체한다.
+> - 🟢 **PR 열리면 붙이기: mini-challenge 1 · mini-challenge 5 재붙여넣기** (#27) — date 형식 오류의 응답 code가 `BAD_REQUEST`에서 `VALIDATION_ERROR`로 바뀐 계약 변경이라 안드가 읽는 값이 달라진다.
 > - 🚫 아직 붙이지 않음: challenge 8(한도 조정) · 9(다음 챌린지 추천) — 행·설계 확정 후 반영.
 > - ⏳ 구현되면 추가할 행: 최종 종료(이슈 #50) — 원고 블록도 아직 없음
 
@@ -474,7 +475,7 @@ EXTEND면 data = { "restId": 3, "plannedResumeDate": "2026-07-20" }
 ▼▼▼▼▼▼▼▼▼▼  복사 시작  ·  붙여넣을 곳 = [mini-challenge 1 — 그날 미니 조회 · GET /api/mini-challenges?date=] 행  ▼▼▼▼▼▼▼▼▼▼
 
 ## Request
-Query: date (생략 시 오늘). 유저 소유 조회(본챌 독립).
+Query: date (생략 시 오늘, 형식은 yyyy-MM-dd). 유저 소유 조회(본챌 독립).
 
 ## Response (200 OK)
 ```json
@@ -493,7 +494,11 @@ Query: date (생략 시 오늘). 유저 소유 조회(본챌 독립).
 ```
 
 ## Error Response
-- date 형식 오류 (400 `BAD_REQUEST`) · 미래 date (400 `MINI_FUTURE_DATE` — 날짜 스트립이 미래 이동 불가라 조회 상황 없음) · 인증 실패 (401)
+- date 형식 오류 (400 `VALIDATION_ERROR`) · 미래 date (400 `MINI_FUTURE_DATE` — 날짜 스트립이 미래 이동 불가라 조회 상황 없음) · 인증 실패 (401)
+```json
+{ "code": "VALIDATION_ERROR", "message": "입력값이 올바르지 않습니다.", "status": 400,
+  "fieldErrors": { "date": "date은(는) LocalDate 형식이어야 합니다." } }
+```
 ```json
 { "code": "MINI_FUTURE_DATE", "message": "미래 날짜는 조회할 수 없습니다.", "status": 400 }
 ```
@@ -600,7 +605,7 @@ Path: miniChallengeId. 요청 바디 없음. (수정 불가 정책 → 삭제 �
   "checked": true
 }
 ```
-date 생략 시 오늘 · 과거 허용 · 미래는 400 차단. checked true=체크(upsert) / false=해제(행 삭제). PUT 멱등.
+date 생략 시 오늘 · 형식은 yyyy-MM-dd · 과거 허용 · 미래는 400 차단. checked true=체크(upsert) / false=해제(행 삭제). PUT 멱등.
 
 ## Response (200 OK)
 ```json
@@ -612,7 +617,7 @@ date 생략 시 오늘 · 과거 허용 · 미래는 400 차단. checked true=�
 ```
 
 ## Error Response
-- date 미니 기간 밖 (400 `MINI_DATE_OUT_OF_RANGE`) · 미래 날짜 (400 `MINI_FUTURE_CHECK` — 미래이면서 기간 밖이기도 하면 이쪽 우선)
+- date 형식 오류 (400 `VALIDATION_ERROR`) · date 미니 기간 밖 (400 `MINI_DATE_OUT_OF_RANGE`) · 미래 날짜 (400 `MINI_FUTURE_CHECK` — 미래이면서 기간 밖이기도 하면 이쪽 우선)
 ```json
 { "code": "MINI_FUTURE_CHECK", "message": "미래 날짜는 체크할 수 없습니다.", "status": 400 }
 ```

--- a/src/main/java/Hampouch/server/domain/minichallenge/controller/MiniChallengeController.java
+++ b/src/main/java/Hampouch/server/domain/minichallenge/controller/MiniChallengeController.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
+import java.time.LocalDate;
 
 /**
  * 미니 챌린지 REST API (미니 챌린지 API 명세 — 정일혁 파트) — 유저 소유·본 챌린지 독립(0707).
@@ -27,11 +28,11 @@ public class MiniChallengeController {
 
     private final MiniChallengeService service;
 
-    /** §1 그날 나의 미니 챌린지. date 생략 시 오늘 — 파싱·검증은 서비스가 담당(형식 오류 400). */
+    /** §1 그날 나의 미니 챌린지. date 생략 시 오늘 — 형식 오류는 바인딩 단계에서 공통 핸들러가 400으로 끊는다. */
     @GetMapping
     public ApiResponse<DailyMiniChallengesResponse> daily(
             @LoginUserId Long userId,
-            @RequestParam(required = false) String date) {
+            @RequestParam(required = false) LocalDate date) {
         return ApiResponse.success(service.getDaily(userId, date));
     }
 

--- a/src/main/java/Hampouch/server/domain/minichallenge/dto/MiniCheckRequest.java
+++ b/src/main/java/Hampouch/server/domain/minichallenge/dto/MiniCheckRequest.java
@@ -2,18 +2,15 @@ package Hampouch.server.domain.minichallenge.dto;
 
 import jakarta.validation.constraints.NotNull;
 
+import java.time.LocalDate;
+
 /**
  * PUT /api/mini-challenges/{id}/check 요청 — PUT + 목표 상태(checked) 전달 = 멱등(명세 §5).
  * date는 생략 가능(생략 시 오늘) — 기본값 채움은 "지금"의 단일 출처인 서비스의 Clock이 담당.
- *
- * date를 LocalDate가 아닌 String으로 받는 이유: 형식이 틀린 값이 오면 LocalDate는 Jackson
- * 역직렬화 단계에서 터지는데, 그 예외는 나연 공통 핸들러의 Exception 폴백에 걸려 500이 된다.
- * 원시값으로 받아 서비스가 직접 파싱해 400으로 컷 — GET의 date 쿼리 파라미터와 같은 방어
- * (§0 공통 규약: 요청 형식 오류 = 400).
  */
 public record MiniCheckRequest(
 
-        String date,
+        LocalDate date,
 
         // checked는 명세상 필수. 전용 에러 코드가 지정되지 않아서(400만 명시) 빈 검증(@Valid)으로 처리 —
         // 누락 시 나연 공통 핸들러가 VALIDATION_ERROR 400을 내린다.

--- a/src/main/java/Hampouch/server/domain/minichallenge/service/MiniChallengeService.java
+++ b/src/main/java/Hampouch/server/domain/minichallenge/service/MiniChallengeService.java
@@ -8,7 +8,6 @@ import Hampouch.server.domain.minichallenge.repository.MiniChallengeDayRepositor
 import Hampouch.server.domain.minichallenge.repository.MiniChallengeRepository;
 import Hampouch.server.domain.minichallenge.repository.RecommendedMiniChallengeRepository;
 import Hampouch.server.global.common.exception.CustomException;
-import Hampouch.server.global.common.exception.domain.CommonErrorCode;
 import Hampouch.server.global.common.exception.domain.MiniChallengeErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,7 +15,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
 import java.time.LocalDate;
-import java.time.format.DateTimeParseException;
 import java.util.*;
 
 @Service
@@ -40,11 +38,9 @@ public class MiniChallengeService {
     /**
      * 그날 나의 미니 챌린지 — 요청 date(생략 시 오늘) 기준 as-of 집계.
      * 집계값은 저장하지 않고 조회 때마다 계산한다 — 저장해 두면 체크/해제 때마다 같이 고쳐야 해 어긋날 수 있다.
-     * date를 String으로 받는 건 공통 핸들러에 바인딩 실패 처리가 없던 시절의 방어 — 지금은 공통 핸들러가
-     * 400으로 받아 주므로 LocalDate 직접 바인딩 전환 대상(TODO #27).
      */
-    public DailyMiniChallengesResponse getDaily(Long userId, String dateParam) {
-        LocalDate date = parseDateOrToday(dateParam);
+    public DailyMiniChallengesResponse getDaily(Long userId, LocalDate requestedDate) {
+        LocalDate date = requestedDate != null ? requestedDate : LocalDate.now(clock);
         // 미래 date는 400 — 화면상 미래 조회가 일어날 상황이 없고, 열어 두면 클라의 날짜 계산 버그가
         // 그럴싸한 빈 응답으로 조용히 넘어간다. 400이면 바로 드러난다.
         if (date.isAfter(LocalDate.now(clock))) {
@@ -142,7 +138,7 @@ public class MiniChallengeService {
     public MiniCheckResponse check(Long userId, Long miniChallengeId, MiniCheckRequest req) {
         MiniChallenge mini = loadOwned(userId, miniChallengeId); // 존재·소유 검사(404/403)가 날짜 검증보다 먼저
         LocalDate today = LocalDate.now(clock);
-        LocalDate date = parseDateOrToday(req.date());
+        LocalDate date = req.date() != null ? req.date() : today;
 
         // 미래 검사를 기간 검사보다 먼저 — 종료일 이후의 미래처럼 둘 다 걸릴 때 MINI_FUTURE_CHECK가
         // 우선이라는 확정을 검사 순서로 보장한다.
@@ -174,18 +170,6 @@ public class MiniChallengeService {
             throw new CustomException(MiniChallengeErrorCode.MINI_FORBIDDEN);
         }
         return mini;
-    }
-
-    /** date 원시값 파싱(GET 쿼리·PUT 바디 공용) — 생략(null·공백)이면 오늘, ISO(yyyy-MM-dd) 파싱 실패면 400. */
-    private LocalDate parseDateOrToday(String dateParam) {
-        if (dateParam == null || dateParam.isBlank()) {
-            return LocalDate.now(clock);
-        }
-        try {
-            return LocalDate.parse(dateParam);
-        } catch (DateTimeParseException e) {
-            throw new CustomException(CommonErrorCode.BAD_REQUEST, e); // 전용 코드명이 없는 형식 오류라 공통 BAD_REQUEST
-        }
     }
 
     /**

--- a/src/test/java/Hampouch/server/domain/minichallenge/controller/MiniChallengeControllerTest.java
+++ b/src/test/java/Hampouch/server/domain/minichallenge/controller/MiniChallengeControllerTest.java
@@ -5,7 +5,6 @@ import Hampouch.server.domain.minichallenge.dto.DailyMiniChallengesResponse;
 import Hampouch.server.domain.minichallenge.dto.MiniCheckResponse;
 import Hampouch.server.domain.minichallenge.service.MiniChallengeService;
 import Hampouch.server.global.common.exception.CustomException;
-import Hampouch.server.global.common.exception.domain.CommonErrorCode;
 import Hampouch.server.global.common.exception.domain.MiniChallengeErrorCode;
 import Hampouch.server.global.jwt.JwtProvider;
 import org.junit.jupiter.api.AfterEach;
@@ -154,14 +153,27 @@ class MiniChallengeControllerTest {
     }
 
     @Test
-    @DisplayName("date 파라미터 형식이 잘못되면 400을 돌려준다")
+    @DisplayName("date 파라미터 형식이 잘못되면 400(VALIDATION_ERROR)과 어긋난 필드 이름을 돌려주고 서비스까지 내려가지 않는다")
     void daily_400_badDateFormat() throws Exception {
-        when(service.getDaily(anyLong(), any()))
-                .thenThrow(new CustomException(CommonErrorCode.BAD_REQUEST));
-
         mvc.perform(get("/api/mini-challenges").param("date", "07/06/2026"))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value("BAD_REQUEST"));
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.fieldErrors.date").exists());
+        verify(service, never()).getDaily(anyLong(), any());
+    }
+
+    @Test
+    @DisplayName("date 파라미터를 아예 안 보내면 서비스에 null이 넘어간다 — 오늘로 채우는 건 서비스의 Clock 몫")
+    void daily_passesNullWhenDateOmitted() throws Exception {
+        when(service.getDaily(anyLong(), any())).thenReturn(new DailyMiniChallengesResponse(
+                LocalDate.of(2026, 7, 6),
+                new DailyMiniChallengesResponse.Summary(0, 0, 0),
+                List.of()));
+
+        mvc.perform(get("/api/mini-challenges"))
+                .andExpect(status().isOk());
+        verify(service).getDaily(1L, null);
     }
 
     @Test
@@ -223,6 +235,20 @@ class MiniChallengeControllerTest {
                                 { "date": "2026-07-06" }
                                 """))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("체크 바디의 date 형식이 잘못되면 400(VALIDATION_ERROR)으로 거절하고 서비스까지 내려가지 않는다 — 제로패딩 없는 2026-7-6은 ISO 형식이 아니다")
+    void check_400_badDateFormat() throws Exception {
+        mvc.perform(put("/api/mini-challenges/5/check")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "date": "2026-7-6", "checked": true }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+                .andExpect(jsonPath("$.status").value(400));
+        verify(service, never()).check(anyLong(), anyLong(), any());
     }
 
     @Test

--- a/src/test/java/Hampouch/server/domain/minichallenge/service/MiniChallengeServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/minichallenge/service/MiniChallengeServiceTest.java
@@ -8,7 +8,6 @@ import Hampouch.server.domain.minichallenge.repository.MiniChallengeDayRepositor
 import Hampouch.server.domain.minichallenge.repository.MiniChallengeRepository;
 import Hampouch.server.domain.minichallenge.repository.RecommendedMiniChallengeRepository;
 import Hampouch.server.global.common.exception.CustomException;
-import Hampouch.server.global.common.exception.domain.CommonErrorCode;
 import Hampouch.server.global.common.exception.domain.MiniChallengeErrorCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -195,7 +194,7 @@ class MiniChallengeServiceTest {
         when(miniChallengeRepository.findById(10L)).thenReturn(Optional.of(mine));
 
         assertThatThrownBy(() -> service()
-                .check(USER, 10L, new MiniCheckRequest(TODAY.plusDays(1).toString(), true)))
+                .check(USER, 10L, new MiniCheckRequest(TODAY.plusDays(1), true)))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", MiniChallengeErrorCode.MINI_FUTURE_CHECK);
     }
@@ -208,7 +207,7 @@ class MiniChallengeServiceTest {
 
         // 내일(7/11)은 미래이면서 기간(7/9~7/9) 밖 — 검사 순서가 바뀌면 코드가 조용히 바뀌므로 테스트로 고정
         assertThatThrownBy(() -> service()
-                .check(USER, 10L, new MiniCheckRequest(TODAY.plusDays(1).toString(), true)))
+                .check(USER, 10L, new MiniCheckRequest(TODAY.plusDays(1), true)))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", MiniChallengeErrorCode.MINI_FUTURE_CHECK);
     }
@@ -220,7 +219,7 @@ class MiniChallengeServiceTest {
         when(miniChallengeRepository.findById(10L)).thenReturn(Optional.of(mine));
 
         assertThatThrownBy(() -> service()
-                .check(USER, 10L, new MiniCheckRequest(TODAY.minusDays(7).toString(), true))) // 7/3 = 시작 전(과거이면서 기간 밖)
+                .check(USER, 10L, new MiniCheckRequest(TODAY.minusDays(7), true))) // 7/3 = 시작 전(과거이면서 기간 밖)
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", MiniChallengeErrorCode.MINI_DATE_OUT_OF_RANGE);
     }
@@ -234,7 +233,7 @@ class MiniChallengeServiceTest {
                 .thenReturn(false);
 
         MiniCheckResponse res = service()
-                .check(USER, 10L, new MiniCheckRequest(TODAY.minusDays(4).toString(), true)); // 7/6 과거·기간 안
+                .check(USER, 10L, new MiniCheckRequest(TODAY.minusDays(4), true)); // 7/6 과거·기간 안
 
         assertThat(res.checked()).isTrue();
         assertThat(res.date()).isEqualTo(TODAY.minusDays(4));
@@ -248,7 +247,7 @@ class MiniChallengeServiceTest {
         when(miniChallengeRepository.findById(10L)).thenReturn(Optional.of(mine));
         when(miniChallengeDayRepository.existsByMiniChallenge_IdAndCheckDate(10L, TODAY)).thenReturn(true);
 
-        MiniCheckResponse res = service().check(USER, 10L, new MiniCheckRequest(TODAY.toString(), true));
+        MiniCheckResponse res = service().check(USER, 10L, new MiniCheckRequest(TODAY, true));
 
         assertThat(res.checked()).isTrue();
         verify(miniChallengeDayRepository, never()).save(any());
@@ -261,7 +260,7 @@ class MiniChallengeServiceTest {
         when(miniChallengeRepository.findById(10L)).thenReturn(Optional.of(mine));
         when(miniChallengeDayRepository.deleteByMiniChallenge_IdAndCheckDate(10L, TODAY)).thenReturn(0);
 
-        MiniCheckResponse res = service().check(USER, 10L, new MiniCheckRequest(TODAY.toString(), false));
+        MiniCheckResponse res = service().check(USER, 10L, new MiniCheckRequest(TODAY, false));
 
         assertThat(res.checked()).isFalse();
         assertThat(res.date()).isEqualTo(TODAY);
@@ -279,26 +278,6 @@ class MiniChallengeServiceTest {
         ArgumentCaptor<MiniChallengeDay> captor = ArgumentCaptor.forClass(MiniChallengeDay.class);
         verify(miniChallengeDayRepository).save(captor.capture());
         assertThat(captor.getValue().getCheckDate()).isEqualTo(TODAY);
-    }
-
-    @Test
-    @DisplayName("체크 바디의 date가 이상한 형식이면 500이 아니라 400(BAD_REQUEST)으로 거절한다 — GET date와 동일한 형식 방어")
-    void check_badRequestWhenBodyDateMalformed() {
-        MiniChallenge mine = MiniChallenge.create(USER, "내 미니", 7, TODAY.minusDays(1));
-        when(miniChallengeRepository.findById(10L)).thenReturn(Optional.of(mine));
-
-        // 제로패딩 누락(2026-7-6)처럼 LocalDate였다면 Jackson 역직렬화에서 500이 됐을 입력
-        assertThatThrownBy(() -> service().check(USER, 10L, new MiniCheckRequest("2026-7-6", true)))
-                .isInstanceOf(CustomException.class)
-                .hasFieldOrPropertyWithValue("errorCode", CommonErrorCode.BAD_REQUEST);
-    }
-
-    @Test
-    @DisplayName("date 파라미터가 이상한 형식이면 500이 아니라 400(BAD_REQUEST)으로 거절한다")
-    void getDaily_badRequestWhenDateMalformed() {
-        assertThatThrownBy(() -> service().getDaily(USER, "2026-13-99"))
-                .isInstanceOf(CustomException.class)
-                .hasFieldOrPropertyWithValue("errorCode", CommonErrorCode.BAD_REQUEST);
     }
 
     @Test
@@ -324,7 +303,7 @@ class MiniChallengeServiceTest {
         when(miniChallengeDayRepository.findByMiniChallenge_IdInAndCheckDateLessThanEqual(any(), any()))
                 .thenReturn(List.of());
 
-        DailyMiniChallengesResponse res = service().getDaily(USER, TODAY.toString());
+        DailyMiniChallengesResponse res = service().getDaily(USER, TODAY);
 
         assertThat(res.summary().totalCount()).isEqualTo(1);
         assertThat(res.items()).hasSize(1);
@@ -357,7 +336,7 @@ class MiniChallengeServiceTest {
     @DisplayName("미래 date 조회는 400(MINI_FUTURE_DATE)으로 차단한다 — 날짜 스트립이 미래로 못 가서 조회될 일이 없는 요청이다")
     void getDaily_rejectsFutureDate() {
         // 검증이 리포지토리 조회보다 앞이라 목 스터빙이 필요 없다 — 미래면 DB에 갈 일 없이 바로 400
-        assertThatThrownBy(() -> service().getDaily(USER, TODAY.plusDays(1).toString())) // 내일(7/11)
+        assertThatThrownBy(() -> service().getDaily(USER, TODAY.plusDays(1))) // 내일(7/11)
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", MiniChallengeErrorCode.MINI_FUTURE_DATE);
     }


### PR DESCRIPTION
## 📎연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) closes #[issue number]

- close: #27

## 📄 작업 내용 요약
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.

- `MiniChallengeController.daily()`의 `date` 쿼리 파라미터를 `String` → `LocalDate` 직접 바인딩으로 전환
- `MiniCheckRequest.date`를 `String` → `LocalDate`로 전환
- `MiniChallengeService.parseDateOrToday` 제거 — `date` 생략 시 오늘 처리는 그대로 유지(null이면 `LocalDate.now(clock)`)
- 서비스 계층에 있던 날짜 형식 400 테스트 2건을 걷어내고, 컨트롤러 테스트에서 공통 핸들러 경로를 검증하도록 옮김(쿼리 파라미터·요청 바디 각 1건 + `date` 생략 시 서비스에 null이 넘어가는지 1건)
- `docs/노션_상세_붙여넣기.md`의 mini-challenge 1·5 블록을 바뀐 에러 코드로 갱신(노션 API 설계 재붙여넣기 대상)

## 👀 중요 변경 사항
> API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요

**에러 계약이 바뀝니다.** 미니 챌린지에서 날짜 형식이 잘못된 요청의 응답 `code`가 `BAD_REQUEST` → `VALIDATION_ERROR`로 바뀝니다. 상태 코드는 400 그대로이고, 형식이 맞는 요청의 동작·응답은 그대로입니다.

- 대상: `GET /api/mini-challenges?date=`의 쿼리 파라미터, `PUT /api/mini-challenges/{id}/check`의 바디 `date`
- 쿼리 파라미터 쪽은 `fieldErrors.date`가 함께 내려갑니다(`MethodArgumentTypeMismatchException` 경로). 바디 쪽은 `fieldErrors` 없이 `VALIDATION_ERROR`만 내려갑니다(`HttpMessageNotReadableException` 경로)
- 허용 형식은 ISO(`yyyy-MM-dd`)입니다. 제로패딩 없는 `2026-7-6`은 이전에도 400이었고 지금도 400인데, 코드 이름만 달라집니다
- 안드에 통보할 문안은 `docs/보낼_문안.md` 21번에 적어 뒀습니다(머지 뒤 발송)

## 🔖 Uncompleted Tasks
> 후속 작업 예정인 사항이 있다면 작성해주세요.

- 노션 "API 설계"의 mini-challenge 1·5 블록 재붙여넣기 — 이 PR이 열린 뒤 진행합니다.

## 📢 To Reviewers
> Reviewer가 주로 확인해주었으면 하는 부분을 적어주세요.

- 이 정리는 PR #21 승인 리뷰에서 @Nayeon07 님이 제안해 주신 후속 작업입니다. 공통 핸들러에 `MethodArgumentTypeMismatchException`·`HttpMessageNotReadableException` 매핑이 생겨서 서비스의 수동 파싱 우회가 필요 없어졌다는 판단이 맞는지 봐주시면 좋겠습니다.
- 이슈에 적어 둔 "본 챌린지 캘린더의 `year`/`month`도 같은 정리 대상인가"는 **아니라고 판단해 이 PR에서 뺐습니다.** 두 파라미터는 이미 `int`로 직접 바인딩되고 있어서 숫자가 아닌 값은 공통 핸들러가 잡습니다. `ChallengeService.getCalendar`에 남아 있는 검사는 형식 우회가 아니라 범위 규칙(`month` 1~12 · `year` 1~9999)이고 전용 에러 코드를 쓰고 있어서, 걷어내면 계약이 사라집니다.
