### PR TITLE
chore: 정상 로그 확인

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ bin/
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/
+logs/
 
 ### NetBeans ###
 /nbproject/private/

--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -8,4 +8,4 @@ COPY *.jar app.jar
 EXPOSE 8080
 
 # -Xmx300m: JVM이 쓸 수 있는 최대 힙 크기를 명시적으로 제한
-ENTRYPOINT ["java", "-Xmx300m", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-Duser.timezone=Asia/Seoul", "-Xmx300m", "-jar", "app.jar"]

--- a/src/main/java/Hampouch/server/global/filter/AccessLogFilter.java
+++ b/src/main/java/Hampouch/server/global/filter/AccessLogFilter.java
@@ -1,0 +1,38 @@
+package Hampouch.server.global.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class AccessLogFilter extends OncePerRequestFilter {
+
+    // "ACCESS_LOG"라는 별도 이름의 로거 - logback 설정에서 이 이름을 기준으로 콘솔(docker logs)이 아니라 파일로만 보내도록 분리
+    private static final Logger accessLog = LoggerFactory.getLogger("ACCESS_LOG");
+    private static final String HEALTHCHECK_PATH = "/actuator/health";
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        long start = System.currentTimeMillis();
+
+        filterChain.doFilter(request, response);
+
+        // healthcheck 제외
+        if (!HEALTHCHECK_PATH.equals(request.getRequestURI())) {
+            long duration = System.currentTimeMillis() - start;
+            accessLog.info("{} {} -> {} ({}ms)",
+                    request.getMethod(), request.getRequestURI(), response.getStatus(), duration);
+        }
+    }
+}

--- a/src/main/java/Hampouch/server/global/filter/AccessLogFilter.java
+++ b/src/main/java/Hampouch/server/global/filter/AccessLogFilter.java
@@ -6,12 +6,15 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
 @Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
 public class AccessLogFilter extends OncePerRequestFilter {
 
     // "ACCESS_LOG"라는 별도 이름의 로거 - logback 설정에서 이 이름을 기준으로 콘솔(docker logs)이 아니라 파일로만 보내도록 분리
@@ -25,14 +28,24 @@ public class AccessLogFilter extends OncePerRequestFilter {
             FilterChain filterChain
     ) throws ServletException, IOException {
         long start = System.currentTimeMillis();
+        boolean threw = false;
 
-        filterChain.doFilter(request, response);
-
-        // healthcheck 제외
-        if (!HEALTHCHECK_PATH.equals(request.getRequestURI())) {
-            long duration = System.currentTimeMillis() - start;
-            accessLog.info("{} {} -> {} ({}ms)",
-                    request.getMethod(), request.getRequestURI(), response.getStatus(), duration);
+        try {
+            filterChain.doFilter(request, response);
+        } catch (RuntimeException | ServletException | IOException e) {
+            // 필터 체인 안에서 처리되지 않고 전파되는 예외가 있으면, 로그를 남기지 못한 채 그대로 죽어버릴 수 있다.
+            // finally에서 무조건 로그를 남기게 하되 원래 예외는 삼키지 않고 그대로 다시 던져 정상적인 예외 처리 흐름을 유지
+            threw = true;
+            throw e;
+        } finally {
+            if (!HEALTHCHECK_PATH.equals(request.getRequestURI())) {
+                long duration = System.currentTimeMillis() - start;
+                // 예외가 전파된 경우 response.getStatus()가 아직 확정되지 않았을 수 있어 500으로 명시하고, [THREW] 표시로 구분한다.
+                int status = threw ? 500 : response.getStatus();
+                accessLog.info("{} {} -> {} ({}ms){}",
+                        request.getMethod(), request.getRequestURI(), status, duration,
+                        threw ? " [THREW]" : "");
+            }
         }
     }
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -20,3 +20,8 @@ jwt:
   secret: ${JWT_SECRET}
   access-token-expires-in-ms: ${JWT_ACCESS_TOKEN_EXPIRES_IN_MS}
   refresh-token-expires-in-ms: ${JWT_REFRESH_TOKEN_EXPIRES_IN_MS}
+
+management:
+  health:
+    mail:
+      enabled: false

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -11,6 +11,9 @@
     </appender>
 
     <!-- 정상 요청/응답 전용 파일: 컨테이너 안 /app/logs/access.log에 쌓인다. -->
+    <!-- SizeAndTimeBasedRollingPolicy: 날짜가 안 바뀌어도 하루 안에서 maxFileSize를-->
+    <!-- 넘으면 새 파일로 분할하고(%i), totalSizeCap으로 로그 디렉토리 전체 용량에-->
+    <!-- 상한을 둬서 트래픽 급증 시 디스크를 소진해 애플리케이션이 중단되는 걸 방지-->
     <appender name="ACCESS_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>logs/access.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <!-- 기존 콘솔 출력 (docker logs) - 에러/경고 위주 그대로 유지 -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <!-- 정상 요청/응답 전용 파일: 컨테이너 안 /app/logs/access.log에 쌓인다. -->
+    <appender name="ACCESS_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/access.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/access.%d{yyyy-MM-dd}.log.gz</fileNamePattern>
+            <maxHistory>14</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- ACCESS_LOG는 파일로만, 콘솔로는 안 감 -->
+    <logger name="ACCESS_LOG" level="INFO" additivity="false">
+        <appender-ref ref="ACCESS_FILE"/>
+    </logger>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>

--- a/src/test/java/Hampouch/server/global/filter/AccessLogFilterIntegrationTest.java
+++ b/src/test/java/Hampouch/server/global/filter/AccessLogFilterIntegrationTest.java
@@ -1,0 +1,72 @@
+package Hampouch.server.global.filter;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * AccessLogFilter가 정상 요청뿐 아니라, Security에서 401/403으로 짧게 끊기는 요청과
+ * 필터 체인 안에서 예외가 전파되는 요청에도 빠짐없이 로그를 남기는지 검증한다.
+ * ACCESS_LOG 로거에 ListAppender를 붙여 실제로 기록된 로그 이벤트를 메모리에서 직접 확인한다.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+class AccessLogFilterIntegrationTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    Logger accessLogger;
+    ListAppender<ILoggingEvent> listAppender;
+
+    @BeforeEach
+    void setUp() {
+        accessLogger = (Logger) LoggerFactory.getLogger("ACCESS_LOG");
+        listAppender = new ListAppender<>();
+        listAppender.start();
+        accessLogger.addAppender(listAppender);
+    }
+
+    @AfterEach
+    void tearDown() {
+        accessLogger.detachAppender(listAppender);
+    }
+
+    @Test
+    void 인증없이_호출해_401이_나도_ACCESS_LOG에_남는다() throws Exception {
+        // 인증이 필요한 API를 토큰 없이 호출 -> Security 필터 단계에서 401로 짧게 끊김.
+        // AccessLogFilter가 Security보다 먼저 실행되지 않으면 이 요청은 로그에 안 남는다.
+        mvc.perform(get("/api/auth/me"))
+                .andExpect(status().isUnauthorized());
+
+        assertThat(listAppender.list)
+                .anyMatch(event -> event.getFormattedMessage().contains("GET /api/auth/me -> 401"));
+    }
+
+    @Test
+    void 잘못된_요청형식으로_400이_나도_ACCESS_LOG에_남는다() throws Exception {
+        // 검증 실패(400)도 정상 흐름 내에서 응답이 만들어지는 케이스라, 이건 필터 순서와
+        // 무관하게 원래도 로그가 남아야 정상이다. 회귀 확인 차원에서 같이 검증한다.
+        mvc.perform(post("/api/auth/email/send")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"not-an-email\",\"purpose\":\"SIGNUP\"}"))
+                .andExpect(status().isBadRequest());
+
+        assertThat(listAppender.list)
+                .anyMatch(event -> event.getFormattedMessage().contains("POST /api/auth/email/send -> 400"));
+    }
+}

--- a/src/test/java/Hampouch/server/global/filter/AccessLogFilterTest.java
+++ b/src/test/java/Hampouch/server/global/filter/AccessLogFilterTest.java
@@ -1,0 +1,87 @@
+package Hampouch.server.global.filter;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+/**
+ * 필터 체인 안에서 처리되지 않은 예외가 전파되는 경우에도
+ * AccessLogFilter가 원래 예외를 그대로 다시 던지면서(rethrow) 로그도 남기는지 검증한다.
+ * (실제 API로 500을 재현하려면 DB를 끄는 등 별도 조작이 필요해, 필터 자체를 직접
+ *  단위 테스트하는 방식으로 확인한다)
+ */
+class AccessLogFilterTest {
+
+    private final AccessLogFilter filter = new AccessLogFilter();
+
+    Logger accessLogger;
+    ListAppender<ILoggingEvent> listAppender;
+
+    @BeforeEach
+    void setUp() {
+        accessLogger = (Logger) LoggerFactory.getLogger("ACCESS_LOG");
+        listAppender = new ListAppender<>();
+        listAppender.start();
+        accessLogger.addAppender(listAppender);
+    }
+
+    @AfterEach
+    void tearDown() {
+        accessLogger.detachAppender(listAppender);
+    }
+
+    @Test
+    void 필터체인에서_예외가_전파돼도_원래_예외를_다시_던지고_로그를_남긴다() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/test");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain filterChain = mock(FilterChain.class);
+        RuntimeException originalException = new RuntimeException("test exception");
+        doThrow(originalException).when(filterChain).doFilter(request, response);
+
+        // 원래 예외가 삼켜지지 않고 그대로(같은 인스턴스) 다시 던져지는지 확인
+        assertThatThrownBy(() -> filter.doFilter(request, response, filterChain))
+                .isSameAs(originalException);
+
+        // 예외로 끝났어도 ACCESS_LOG에 로그가 남았는지, [THREW] 표시가 있는지 확인
+        assertThat(listAppender.list)
+                .anyMatch(event -> event.getFormattedMessage().contains("GET /api/test")
+                        && event.getFormattedMessage().contains("[THREW]"));
+    }
+
+    @Test
+    void 정상_처리되면_실제_상태코드로_로그가_남는다() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/test");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        response.setStatus(200);
+        FilterChain filterChain = mock(FilterChain.class); // 아무것도 안 던지면 정상 통과
+
+        filter.doFilter(request, response, filterChain);
+
+        assertThat(listAppender.list)
+                .anyMatch(event -> event.getFormattedMessage().contains("GET /api/test -> 200")
+                        && !event.getFormattedMessage().contains("[THREW]"));
+    }
+
+    @Test
+    void healthcheck_경로는_로그에_안_남는다() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/actuator/health");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        response.setStatus(200);
+        FilterChain filterChain = mock(FilterChain.class);
+
+        filter.doFilter(request, response, filterChain);
+
+        assertThat(listAppender.list).isEmpty();
+    }
+}


### PR DESCRIPTION
## 📎연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) closes #[issue number]

- close: #100

## 📄 작업 내용 요약
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
- application-prod.yml에 management.health.mail.enabled: false 추가
- AccessLogFilter 추가 (global/filter)
  - 모든 API 요청의 메서드, 경로, 응답 상태코드, 처리시간을 기록
  - /actuator/health는 10초마다 반복 호출되어 로그를 가득 채우므로 제외
- logback-spring.xml 추가
  - ACCESS_LOG라는 별도 로거로 위 요청/응답 로그를 콘솔이 아닌 파일(logs/access.log)에만 기록하도록 분리
  - 기존 docker logs는 지금처럼 에러/경고 위주로 유지됨
- 배포용 dockerfile에 한국 시간대 설정

## 👀 중요 변경 사항
> API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요
- docker logs hampouch-server로는 여전히 에러/경고만 보입니다. 정상 요청/응답 흐름을 보려면 컨테이너 안의 별도 파일을 확인해야 합니다
`docker exec -it hampouch-server tail -f logs/access.log`

## 🔖 Uncompleted Tasks
> 후속 작업 예정인 사항이 있다면 작성해주세요.
- docker log 확인 가능하도록 팀원 ssh 공개키 설정

## 📢 To Reviewers
> Reviewer가 주로 확인해주었으면 하는 부분을 적어주세요.
- 로그 분리를 위해 logback-spring.xml을 새로 추가했는데, 기존에 로깅 관련 설정이 application.yml에 있던 것과 충돌하는 부분이 없는지 확인 부탁드립니다.