### PR TITLE
feat(challenge): 최종 종료 확정 (POST /challenges/{id}/close) + 종료 후 기록 잠금 (#50) [base: develop]

### DIFF
--- a/docs/노션_상세_붙여넣기.md
+++ b/docs/노션_상세_붙여넣기.md
@@ -20,7 +20,7 @@
 > - 🟢 **지금 붙이기(PR #84 열림): challenge 2(GET /current)·challenge 6(GET /history) 재붙여넣기 · expense '오늘은 안 썼어요' 신규 블록** (#67)
 > - ⚠️ challenge 2의 GOAL_TOO_TIGHT 제거는 이 PR 범위가 아니라 이슈 #51이다. 현재 PR 브랜치에는 카드가 남아 있으므로 #51 PR이 열리면 해당 설명을 다시 교체한다.
 > - 🚫 아직 붙이지 않음: challenge 8(한도 조정) · 9(다음 챌린지 추천) — 행·설계 확정 후 반영.
-> - ⏳ 구현되면 추가할 행: 최종 종료(이슈 #50) — 원고 블록도 아직 없음
+> - 🟡 **PR 열리면 붙이기(#50 최종 종료)**: challenge 11 **신규 행 생성**(맨 아래 블록) · challenge 4 재붙여넣기(응답에 closedAt 추가·참고 문단의 "잠금은 서버 구현 예정" 삭제) · challenge 5 재붙여넣기(409 CHALLENGE_ALREADY_CLOSED 추가) · expense '오늘은 안 썼어요' 재붙여넣기(에러 한 줄 추가)
 
 
 ▼▼▼▼▼▼▼▼▼▼  복사 시작  ·  붙여넣을 곳 = [challenge 1 — 챌린지 생성 · POST /api/challenges] 행  ▼▼▼▼▼▼▼▼▼▼
@@ -175,7 +175,7 @@ Path: id (종료된 SUCCESS/FAIL 챌린지). 요청 바디 없음.
   "code": "SUCCESS",
   "message": "요청이 성공했습니다.",
   "data": {
-    "challengeId": 1, "status": "SUCCESS",
+    "challengeId": 1, "status": "SUCCESS", "closedAt": null,
     "period": { "startDate": "2026-05-01", "endDate": "2026-05-14", "durationDays": 14 },
     "summary": {
       "successDays": 14, "overDays": 0, "savedAmount": 68200, "overAmount": 0,
@@ -194,7 +194,7 @@ Path: id (종료된 SUCCESS/FAIL 챌린지). 요청 바디 없음.
 ```
 - 챌린지 id 없음 (404) · 남의 챌린지 (403) · 인증 실패 (401)
 
-> 참고: categoryBreakdown/emotionBreakdown은 령준 지출(EXPENSE) 연동 전 빈 배열([]). 기록이 없는 날은 0원 지출로 보고, 달력 표시와 successDays 계산에서 그 날 하루는 '성공한 날'로 칩니다(챌린지 전체 성패와는 별개). status는 챌린지 전체의 성패입니다 — 기간 종료(end_date 경과) 시점에 자동 저장되는 게 아니라, 그 뒤 결과·지난 챌린지 조회가 왔을 때 그 자리에서 계산해 저장합니다(기간 총지출이 budgetTotal 이하면 SUCCESS, 넘으면 FAIL. 정해진 시각에 도는 배치 없음). 최종 종료(결과 화면의 '챌린지 종료' 버튼) 전까지는 저장된 뒤라도 기간 내 지출을 수정하면 다시 계산됩니다. 최종 종료 뒤에는 지출 수정이 잠깁니다 — 잠금은 서버 구현 예정. overDays는 하루 한도를 넘긴 날의 수, overAmount는 그런 날들의 초과분(그 날 지출−하루 한도)을 기간 전체로 합한 금액입니다 — 총예산(budgetTotal) 초과분이 아닙니다. savedAmount도 같은 방식으로, 한도 아래로 쓴 날들의 남긴 금액을 기간 전체로 합한 값입니다(기록 없는 날은 한도 전액). 하루 한도를 넘긴 날은 달력에 '실패한 날'로 남지만 챌린지 성패는 총액만 보므로, status가 SUCCESS인데 overDays·overAmount가 0이 아닌 응답이 정상입니다.
+> 참고: categoryBreakdown/emotionBreakdown은 령준 지출(EXPENSE) 연동 전 빈 배열([]). 기록이 없는 날은 0원 지출로 보고, 달력 표시와 successDays 계산에서 그 날 하루는 '성공한 날'로 칩니다(챌린지 전체 성패와는 별개). status는 챌린지 전체의 성패입니다 — 기간 종료(end_date 경과) 시점에 자동 저장되는 게 아니라, 그 뒤 결과·지난 챌린지 조회가 왔을 때 그 자리에서 계산해 저장합니다(기간 총지출이 budgetTotal 이하면 SUCCESS, 넘으면 FAIL. 정해진 시각에 도는 배치 없음). 최종 종료(결과 화면의 '챌린지 종료' 버튼) 전까지는 저장된 뒤라도 기간 내 지출을 수정하면 다시 계산됩니다. 최종 종료 뒤에는 그 기간의 지출과 일별 기록이 모두 잠깁니다(challenge 11 참고). closedAt은 최종 종료 시각이고 아직 누르지 않았으면 null이라, 이 값으로 '지출 수정하기 / 챌린지 종료' 팝업을 띄울지 정하면 됩니다. overDays는 하루 한도를 넘긴 날의 수, overAmount는 그런 날들의 초과분(그 날 지출−하루 한도)을 기간 전체로 합한 금액입니다 — 총예산(budgetTotal) 초과분이 아닙니다. savedAmount도 같은 방식으로, 한도 아래로 쓴 날들의 남긴 금액을 기간 전체로 합한 값입니다(기록 없는 날은 한도 전액). 하루 한도를 넘긴 날은 달력에 '실패한 날'로 남지만 챌린지 성패는 총액만 보므로, status가 SUCCESS인데 overDays·overAmount가 0이 아닌 응답이 정상입니다.
 
 ▲▲▲▲▲▲▲▲▲▲  복사 끝  ▲▲▲▲▲▲▲▲▲▲
 
@@ -232,9 +232,14 @@ Path: id (종료된 SUCCESS/FAIL 챌린지). 요청 바디 없음.
 ```json
 { "code": "VALIDATION_ERROR", "message": "입력값이 올바르지 않습니다.", "status": 400, "fieldErrors": { "spentAmount": "0 이상이어야 합니다." } }
 ```
+- 최종 종료된 챌린지 (409)
+```json
+{ "code": "CHALLENGE_ALREADY_CLOSED", "message": "이미 최종 종료된 챌린지입니다.", "status": 409 }
+```
 - 남의 챌린지 (403) · 챌린지 id 없음 (404) · 인증 실패 (401)
 
 > 참고: 판정 status = spentAmount ≤ dailyLimit ? SUCCESS : OVER. 운영에선 령준 지출 조회 메서드로 대체 예정 — 이 엔드포인트는 테스트/시드 전용.
+> 최종 종료(challenge 11) 뒤에는 날짜 검증보다 먼저 409로 막힙니다 — 기간 안 날짜여도 마찬가지입니다.
 
 ▲▲▲▲▲▲▲▲▲▲  복사 끝  ▲▲▲▲▲▲▲▲▲▲
 
@@ -639,8 +644,50 @@ date는 필수이며 오늘 또는 과거만 허용. 진행 중 챌린지 유무
 
 ## Error Response
 - 날짜 누락·미래 날짜 (400 `VALIDATION_ERROR`)
+- 최종 종료된 챌린지 기간의 날짜 (409)
+```json
+{ "code": "EXPENSE_CHALLENGE_CLOSED", "message": "최종 종료된 챌린지 기간의 기록은 변경할 수 없습니다.", "status": 409 }
+```
 - 인증 실패 (401)
 
 > `오늘은 안 썼어요`는 0원 지출 항목이 아니라, 지출 항목 없이 날짜 입력을 마쳤다는 `no_spend_day` 기록이다. 그 날짜에 ACTIVE 지출이나 기존 기록이 있으면 새 행을 만들지 않고 PUT 요청을 200 OK로 완료한다. 같은 날짜에 일반 지출을 생성·수정하면 이 기록을 삭제한다. GET /api/expenses/day의 hasRecord는 ACTIVE 지출 또는 이 기록이 있으면 true다. 일반 0원 지출은 expenses에 포함되고, `오늘은 안 썼어요`는 expenses에 포함되지 않는다.
+
+▲▲▲▲▲▲▲▲▲▲  복사 끝  ▲▲▲▲▲▲▲▲▲▲
+
+
+▼▼▼▼▼▼▼▼▼▼  복사 시작  ·  붙여넣을 곳 = API 설계 표에 [challenge 11 — 최종 종료 · POST /api/challenges/{id}/close] 신규 행 생성  ▼▼▼▼▼▼▼▼▼▼
+
+## Request
+요청 바디 없음. 결과 팝업에서 '챌린지 종료'를 누를 때 호출한다(같은 팝업의 다른 선택지가 '지출 수정하기').
+
+## Response (200 OK)
+```json
+{
+  "code": "SUCCESS",
+  "message": "요청이 성공했습니다.",
+  "data": { "challengeId": 1, "status": "SUCCESS", "closedAt": "2026-05-15T09:30:00" }
+}
+```
+
+## Error Response
+- 기간이 아직 안 끝남 (409)
+```json
+{ "code": "CHALLENGE_NOT_ENDED", "message": "아직 진행 중인 챌린지입니다. (결과 미확정 — /current 사용)", "status": 409 }
+```
+- 이미 최종 종료됨 (409)
+```json
+{ "code": "CHALLENGE_ALREADY_CLOSED", "message": "이미 최종 종료된 챌린지입니다.", "status": 409 }
+```
+- 중도 포기·자동 취소로 끝난 챌린지 (409)
+```json
+{ "code": "CHALLENGE_NOT_CLOSABLE", "message": "중도 포기하거나 자동 취소된 챌린지는 최종 종료할 수 없습니다.", "status": 409 }
+```
+- 남의 챌린지 (403) · 챌린지 id 없음 (404) · 인증 실패 (401)
+
+> 지출이 잠기는 시점은 기간 종료가 아니라 이 요청입니다(0727 PM 확정). 기간이 끝나도 유저가 '챌린지 종료'를 누르기 전까지는 그 기간의 지출을 계속 고칠 수 있고 결과도 다시 계산됩니다.
+> 기간이 끝났는데 결과 화면을 한 번도 안 열어 성패가 아직 저장되기 전이면, 이 요청이 그 자리에서 계산해 저장합니다. 그래서 응답의 status로 성패를 처음 받을 수 있습니다.
+> 잠긴 뒤 막히는 요청: POST /challenges/{id}/days(409 CHALLENGE_ALREADY_CLOSED) · 그 기간 날짜의 지출 생성·수정·삭제와 '오늘은 안 썼어요' 기록(409 EXPENSE_CHALLENGE_CLOSED). 삭제까지 막는 것은 지운 기록이 유저 눈에는 사라진 것과 같기 때문이고, 생성까지 막는 것은 수정만 막으면 새로 넣는 경로로 그 기간 합계가 바뀌기 때문입니다.
+> 기간 마지막 날 당일은 아직 기간 중이라 409입니다(중도 포기의 경계와 같습니다).
+> 최종 종료를 누르지 않아도 다음 챌린지는 시작할 수 있습니다 — 챌린지 생성이 끝난 챌린지의 성패를 먼저 확정하고 진행합니다.
 
 ▲▲▲▲▲▲▲▲▲▲  복사 끝  ▲▲▲▲▲▲▲▲▲▲

--- a/src/main/java/Hampouch/server/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/Hampouch/server/domain/challenge/controller/ChallengeController.java
@@ -95,6 +95,14 @@ public class ChallengeController {
         return ApiResponse.success(service.adjustGoal(userId, id, request));
     }
 
+    /** 최종 종료 — 결과 팝업의 [챌린지 종료]. give-up과 같은 상태 전이라 200. */
+    @PostMapping("/{id}/close")
+    public ApiResponse<CloseResponse> close(
+            @LoginUserId Long userId,
+            @PathVariable Long id) {
+        return ApiResponse.success(service.close(userId, id));
+    }
+
     @PostMapping("/{id}/days")
     public ApiResponse<DayUpsertResponse> upsertDay(
             @LoginUserId Long userId,

--- a/src/main/java/Hampouch/server/domain/challenge/dto/CloseResponse.java
+++ b/src/main/java/Hampouch/server/domain/challenge/dto/CloseResponse.java
@@ -1,0 +1,18 @@
+package Hampouch.server.domain.challenge.dto;
+
+import Hampouch.server.domain.challenge.entity.Challenge;
+import Hampouch.server.domain.challenge.entity.ChallengeStatus;
+
+import java.time.LocalDateTime;
+
+/**
+ * POST /api/challenges/{id}/close 응답 — 최종 종료 확정 결과.
+ * status를 함께 돌려주는 이유는 종료를 누르는 순간 미확정 챌린지의 성패가 정해지기 때문이다 —
+ * 결과 화면을 안 열고 바로 눌렀다면 클라가 여기서 처음 성패를 받는다.
+ */
+public record CloseResponse(Long challengeId, ChallengeStatus status, LocalDateTime closedAt) {
+
+    public static CloseResponse from(Challenge c) {
+        return new CloseResponse(c.getId(), c.getStatus(), c.getClosedAt());
+    }
+}

--- a/src/main/java/Hampouch/server/domain/challenge/dto/ResultResponse.java
+++ b/src/main/java/Hampouch/server/domain/challenge/dto/ResultResponse.java
@@ -4,6 +4,7 @@ import Hampouch.server.domain.challenge.entity.Challenge;
 import Hampouch.server.domain.challenge.entity.ChallengeStatus;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 /**
@@ -15,6 +16,7 @@ import java.util.List;
 public record ResultResponse(
         Long challengeId,
         ChallengeStatus status,
+        LocalDateTime closedAt,                  // 최종 종료 시각. null이면 아직 안 눌러 [지출 수정하기]·[챌린지 종료] 팝업을 띄울 상태
         Period period,
         Summary summary,
         List<CategoryAmount> categoryBreakdown,  // 결과 화면 "카테고리별 지출 금액" 그래프용 (배달 38400, 카페 23500…). 령준 연동 전엔 빈 배열

--- a/src/main/java/Hampouch/server/domain/challenge/entity/Challenge.java
+++ b/src/main/java/Hampouch/server/domain/challenge/entity/Challenge.java
@@ -88,6 +88,13 @@ public class Challenge {
     @Column(length = 20)
     private EndReason endReason;
 
+    /**
+     * 유저가 결과 팝업에서 [챌린지 종료]를 누른 시각 — null이면 아직 안 눌렀다는 뜻이다.
+     * status와 다른 축이다: status는 성패(기간이 끝나면 조회가 확정)이고 이 값은 잠금이라,
+     * 기간이 끝나 SUCCESS로 확정된 뒤에도 유저가 누르기 전까지는 지출을 마저 고칠 수 있다.
+     */
+    private LocalDateTime closedAt;
+
     @CreatedDate
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
@@ -227,8 +234,35 @@ public class Challenge {
         this.dailyLimit = newDailyLimit;
     }
 
+    /**
+     * 최종 종료 — 유저 선언으로 기록을 잠근다. 성패는 이미 정해져 있으므로 status는 건드리지 않는다.
+     * 클라 요청 오류(409)는 서비스가 먼저 거르므로 여기 검사에 걸리면 서버 코드 실수다(giveUp과 같은 원칙).
+     */
+    public void close(LocalDateTime at) {
+        if (isInProgress()) {
+            throw new IllegalStateException("결과가 확정된 챌린지만 최종 종료할 수 있다: " + status);
+        }
+        if (isClosed()) {
+            throw new IllegalStateException("이미 최종 종료된 챌린지다: " + closedAt);
+        }
+        this.closedAt = at;
+    }
+
     public boolean isInProgress() {
         return status == ChallengeStatus.IN_PROGRESS;
+    }
+
+    public boolean isClosed() {
+        return closedAt != null;
+    }
+
+    /**
+     * 결과가 일별 기록에서 계산된 것인가 — 그래서 지출을 고치면 재계산되고, 최종 종료로 얼릴 대상이 된다.
+     * 포기(GIVEN_UP)·자동 취소(MISSING_DAILY_INPUT)는 선언·제재라 endReason이 채워지고 재계산에서 빠진다.
+     * "endReason == null" 을 호출부마다 직접 쓰지 않고 이 이름으로 물어 의도를 드러낸다(재계산 가드·최종 종료 가드 공용).
+     */
+    public boolean isResultFromRecords() {
+        return endReason == null;
     }
 
     public boolean isOwnedBy(Long userId) {

--- a/src/main/java/Hampouch/server/domain/challenge/repository/ChallengeRepository.java
+++ b/src/main/java/Hampouch/server/domain/challenge/repository/ChallengeRepository.java
@@ -4,89 +4,58 @@ import Hampouch.server.domain.challenge.entity.Challenge;
 import Hampouch.server.domain.challenge.entity.ChallengeStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
 /**
- * 챌린지 저장소. findById·save 같은 CRUD 기본기는 이 파일에 선언이 없어도 쓸 수 있다 —
- * 부모 인터페이스 사슬(JpaRepository ← ListCrudRepository ← CrudRepository)에 이미 선언돼
- * 있어 상속으로 물려받기 때문. 구현 클래스도 우리가 안 만든다 — 스프링 데이터가 부팅 때
- * 이 인터페이스의 프록시 구현체를 만들어 빈으로 등록한다(CRUD 기본기는 SimpleJpaRepository 구현).
- * 아래 파생 쿼리들도 선언만 하면 구현은 스프링이 메서드 이름을 해석해 만든다 —
- * 기본기와 파생 쿼리는 선언 출처만 다를 뿐(부모 vs 이 파일) 구현 주체는 둘 다 스프링이다.
- *
- * findById가 0 또는 1건인 근거는 DB 기본 키 제약(같은 id 두 행은 존재 불가) —
- * 도메인 규칙(코드 게이트)에 기대는 findInProgress의 "0 또는 1"보다 강한 보장이다.
+ * 챌린지 저장소 — 파생 쿼리는 선언만 하면 스프링 데이터가 구현한다.
  */
 public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
 
-    /**
-     * 동시 진행 1개 가정 — 생성 시 중복 체크용 파생 쿼리.
-     * status(IN_PROGRESS)까지 보는 이유: 유저의 끝난 챌린지(SUCCESS/FAIL)도 DB에 남으므로,
-     * userId만 보면 과거에 챌린지 한 유저는 새로 못 만듦. "진행 중"만 세야 함.
-     * 직접 호출하지 말고 아래 existsInProgress(상태 고정판)를 쓸 것.
-     */
+    /** status까지 보는 이유: 끝난 챌린지(SUCCESS/FAIL)도 DB에 남아, userId만 세면 과거에 챌린지 한 유저가 새로 못 만든다. */
     boolean existsByUserIdAndStatus(Long userId, ChallengeStatus status);
 
     /**
-     * 진행 중 챌린지 1건 조회용 파생 쿼리 (홈/현황, 만료 lazy 확정).
-     *
-     * userId+status 조합이 "딱 1건"인 건 쿼리가 보장하는 게 아니라 도메인 규칙이 보장한다 —
-     * 동시 진행은 1개뿐(create의 existsInProgress 게이트가 409로 차단)이라 IN_PROGRESS는
-     * 유저당 최대 1행. 반환 타입 Optional은 그 규칙을 믿고 "0 아니면 1"을 기대한다는 선언이고,
-     * 실제 2행 이상이 걸리면 Spring Data가 IncorrectResultSizeDataAccessException을 던진다(500).
-     * 그래서 이 쿼리는 IN_PROGRESS 전용 — SUCCESS/FAIL은 유저당 여러 개 쌓이는 게 정상이라
-     * 그런 조회는 List를 반환하는 아래 히스토리 쿼리 몫이다.
-     * 직접 호출하지 말고 아래 findInProgress(상태 고정판)를 쓸 것.
+     * IN_PROGRESS 조회용(상태 고정판 findInProgress로 감싼다). userId+IN_PROGRESS가 "0 또는 1"인 건
+     * 쿼리가 아니라 도메인 규칙(동시 진행 1개)이 보장한다 — 2행 이상이면 Spring Data가 500(IncorrectResultSize)을 던진다.
+     * SUCCESS/FAIL은 유저당 여럿이라 List를 반환하는 아래 히스토리 쿼리 몫이다.
      */
     Optional<Challenge> findByUserIdAndStatus(Long userId, ChallengeStatus status);
 
-    /**
-     * 진행 중 챌린지 존재 여부 — create의 동시 진행 1개 게이트 전용.
-     * 파생 쿼리 이름 문법에는 값(IN_PROGRESS)을 박을 자리가 없어(이름은 속성만 정하고 값은 파라미터)
-     * default 메서드로 감싸 상태를 고정했다 — 호출부가 다른 상태를 넘길 통로를 구조로 막는다.
-     */
+    /** 파생 쿼리 이름엔 값(IN_PROGRESS)을 못 박아 default로 상태를 고정한다 — 챌린지 서비스는 이 둘로 진행 중을 묻는다. */
     default boolean existsInProgress(Long userId) {
         return existsByUserIdAndStatus(userId, ChallengeStatus.IN_PROGRESS);
     }
 
-    /**
-     * 진행 중 챌린지 조회 — 동시 진행 1개 규칙 위에서 0 또는 1건(규칙 근거는 위 파생 쿼리 주석).
-     * IN_PROGRESS 전용이라는 계약을 주석이 아니라 시그니처로 지키기 위한 상태 고정판 —
-     * 서비스는 이것만 호출한다.
-     */
     default Optional<Challenge> findInProgress(Long userId) {
         return findByUserIdAndStatus(userId, ChallengeStatus.IN_PROGRESS);
     }
 
     /**
-     * 지난 챌린지 리스트(#4) — 종료된 것만, 최근 종료(endDate 내림차순)가 먼저.
-     * "IN_PROGRESS가 아닌 전부"가 아니라 보여줄 상태를 In(SUCCESS, FAIL)으로 명시하는 이유:
-     * VOID 같은 상태가 추가됐을 때 Not 조건은 그 상태를 자동으로 리스트에 흘려보낸다.
-     * 미입력 자동 취소 VOID는 지난 기록에서 제외하므로 보여줄 상태만 명시한다.
-     * endDate가 같으면 id 내림차순(나중에 만든 것 먼저) — 정렬이 매번 같도록 붙인 보조 기준(자체 결정).
-     *
-     * 이름 읽는 법(조건부): findBy 뒤 UserId(키워드 없음 = 같음 비교) And StatusIn(컬렉션 안의 값 중 하나, SQL IN)
-     * → WHERE user_id = ? AND status IN (...). 메서드 파라미터는 이 조건 순서대로 대응 — In 조건이라
-     * 두 번째 파라미터가 단일 값이 아닌 Collection이다. OrderBy 키워드를 만나는 지점에서 조건부가 끝난다.
-     * 이름 읽는 법(정렬부): OrderBy 뒤는 "속성+방향" 쌍의 나열 — EndDateDesc, IdDesc
-     * → SQL의 ORDER BY end_date DESC, id DESC. 방향을 생략하면 Asc가 기본이라 Desc는 매번 붙여야 한다.
-     * 두 키가 각각 따로 전체를 정렬하는 게 아니라, 둘째 키(id)는 첫 키(endDate)가 같은 행들 사이에서만 순서를 정한다.
+     * 지난 챌린지 리스트(#4) — 최근 종료(endDate 내림차순)가 먼저. 보여줄 상태를 In(SUCCESS, FAIL)으로 명시하는 이유(함정):
+     * Not(IN_PROGRESS)으로 짜면 나중에 추가된 VOID(자동 취소)가 저절로 리스트에 흘러든다. endDate 동률은 id 내림차순으로 안정 정렬.
      */
     List<Challenge> findByUserIdAndStatusInOrderByEndDateDescIdDesc(Long userId, Collection<ChallengeStatus> statuses);
 
     /**
-     * 직전 종료 챌린지 1건 — 휴식기 홈의 keptRecords(#8) 재료.
-     * findFirst = 정렬 결과의 맨 앞 1건만(SQL LIMIT 1) — List로 다 가져와 첫 원소를 집는 게 아니라 쿼리가 1건으로 끝난다.
-     *
-     * "직전"의 정렬이 히스토리의 endDate가 아니라 생성 시각(createdAt)인 이유: 중도 포기 챌린지는 endDate가
-     * 원래 목표 기간 그대로 보존돼 미래일 수 있어서, endDate 내림차순은 "예전에 포기한 긴 챌린지"를
-     * 나중에 실제로 끝낸 챌린지보다 최근으로 오판한다(예: 30일짜리 이틀 만에 포기 → 그 뒤 7일짜리 완주).
-     * 동시 진행 1개 규칙이라 챌린지는 순차로만 생기고, 종료된 것들 중에선 마지막에 만든 것이 곧
-     * 마지막에 끝난 것 — 생성순이 종료순을 정확히 대신한다. 생성순은 의미 그대로인 createdAt이 지고
-     * id는 같은 시각일 때의 보조 기준만 맡는다(id 필드 주석의 "순서 논리에 쓰지 말 것" 규칙 + 히스토리
-     * 보조 정렬과 동일한 역할 분담).
+     * 직전 종료 챌린지 1건 — 휴식기 홈 keptRecords(#8). 정렬이 endDate가 아니라 createdAt인 이유(함정):
+     * 포기 챌린지는 endDate가 원래 목표 기간이라 미래일 수 있어, endDate 내림차순은 옛날에 포기한 긴 챌린지를 최근으로 오판한다.
+     * 동시 진행 1개라 생성순이 곧 종료순 — id는 같은 시각일 때의 보조 기준.
      */
     Optional<Challenge> findFirstByUserIdAndStatusInOrderByCreatedAtDescIdDesc(Long userId, Collection<ChallengeStatus> statuses);
+
+    /**
+     * 그 날짜를 기간에 품은 최종 종료(#50) 챌린지가 있는가 — 지출 잠금 판정용.
+     * 날짜 파라미터가 둘인 건 조건이 둘이라서다(start ≤ 날짜, end ≥ 날짜). 아래 isDateLockedByClosedChallenge로 부른다.
+     */
+    boolean existsByUserIdAndClosedAtIsNotNullAndStartDateLessThanEqualAndEndDateGreaterThanEqual(
+            Long userId, LocalDate onOrAfterStart, LocalDate onOrBeforeEnd);
+
+    /** 잠금 판정 단일 출처 — 같은 날짜를 두 번 넘기는 위 이름을 호출부마다 반복하지 않는다. */
+    default boolean isDateLockedByClosedChallenge(Long userId, LocalDate date) {
+        return existsByUserIdAndClosedAtIsNotNullAndStartDateLessThanEqualAndEndDateGreaterThanEqual(
+                userId, date, date);
+    }
 }

--- a/src/main/java/Hampouch/server/domain/challenge/repository/ChallengeRepository.java
+++ b/src/main/java/Hampouch/server/domain/challenge/repository/ChallengeRepository.java
@@ -2,14 +2,19 @@ package Hampouch.server.domain.challenge.repository;
 
 import Hampouch.server.domain.challenge.entity.Challenge;
 import Hampouch.server.domain.challenge.entity.ChallengeStatus;
+import Hampouch.server.domain.expense.service.ExpenseDateLockQuery;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
-public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
+public interface ChallengeRepository extends JpaRepository<Challenge, Long>, ExpenseDateLockQuery {
 
     boolean existsByUserIdAndStatus(Long userId, ChallengeStatus status);
 
@@ -32,15 +37,28 @@ public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
     Optional<Challenge> findFirstByUserIdAndStatusInOrderByCreatedAtDescIdDesc(Long userId, Collection<ChallengeStatus> statuses);
 
     /**
-     * 그 날짜를 기간에 품은 최종 종료(#50) 챌린지가 있는가 — 지출 잠금 판정용.
-     * 날짜 파라미터가 둘인 건 조건이 둘이라서다(start ≤ 날짜, end ≥ 날짜). 아래 isDateLockedByClosedChallenge로 부른다.
+     * 지출 변경과 최종 종료가 같은 챌린지 행을 잠가 직렬화되도록, 종료 여부를 읽기 전에 행 잠금을 잡는다.
+     * endReason이 있는 포기·자동 취소 챌린지는 최종 종료 대상이 아니므로 제외한다.
      */
-    boolean existsByUserIdAndClosedAtIsNotNullAndStartDateLessThanEqualAndEndDateGreaterThanEqual(
-            Long userId, LocalDate onOrAfterStart, LocalDate onOrBeforeEnd);
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+            SELECT c FROM Challenge c
+            WHERE c.userId = :userId
+              AND c.endReason IS NULL
+              AND c.startDate <= :date
+              AND c.endDate >= :date
+            ORDER BY c.startDate ASC, c.id ASC
+            """)
+    List<Challenge> findRecordBasedChallengesContainingDateForUpdate(
+            @Param("userId") Long userId, @Param("date") LocalDate date);
 
-    /** 잠금 판정 단일 출처 — 같은 날짜를 두 번 넘기는 위 이름을 호출부마다 반복하지 않는다. */
-    default boolean isDateLockedByClosedChallenge(Long userId, LocalDate date) {
-        return existsByUserIdAndClosedAtIsNotNullAndStartDateLessThanEqualAndEndDateGreaterThanEqual(
-                userId, date, date);
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT c FROM Challenge c WHERE c.id = :id")
+    Optional<Challenge> findByIdForUpdate(@Param("id") Long id);
+
+    @Override
+    default boolean isExpenseChangeProhibited(Long userId, LocalDate date) {
+        return findRecordBasedChallengesContainingDateForUpdate(userId, date).stream()
+                .anyMatch(Challenge::isClosed);
     }
 }

--- a/src/main/java/Hampouch/server/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/Hampouch/server/domain/challenge/service/ChallengeService.java
@@ -18,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -243,13 +244,45 @@ public class ChallengeService {
                 s.successDays(), s.overDays(), s.savedAmount(), s.overAmount(),
                 s.maxStreak(), c.getBudgetTotal(), s.actualSpent());
         // categoryBreakdown / emotionBreakdown 은 령준 지출(EXPENSE) 의존 → 연동 확정까지 빈 배열
-        return new ResultResponse(c.getId(), c.getStatus(), period, summary, List.of(), List.of());
+        return new ResultResponse(c.getId(), c.getStatus(), c.getClosedAt(), period, summary, List.of(), List.of());
+    }
+
+    /**
+     * 최종 종료 — 유저가 결과 팝업의 [챌린지 종료]를 눌러 기록을 잠근다(팝업 문구 "챌린지가 최종 종료되면
+     * 지출 수정이 불가해요"). 기간 종료가 아니라 이 시점이 잠금 경계라, 그 전까지는 지출을 마저 고치고
+     * 결과가 다시 계산되는 구간이 있다(결과 팝업의 다른 선택지 [지출 수정하기]).
+     *
+     * 결과 화면을 안 열고 바로 눌러도 되도록 만료 미확정분을 여기서 확정한다 — 확정을 그대로 두면
+     * 잠긴 챌린지가 IN_PROGRESS로 남아 다음 챌린지 생성까지 막는다.
+     * 중도 포기·자동 취소는 이 흐름을 타지 않는다(409): 기록에서 나온 결과가 아니라 지출을 고쳐도
+     * 재계산되지 않으므로 잠글 대상이 없고, 잠그면 그 기간 지출 수정만 새로 막히게 된다.
+     */
+    @Transactional
+    public CloseResponse close(Long userId, Long challengeId) {
+        Challenge c = loadOwned(userId, challengeId);
+        if (c.isClosed()) {
+            throw new CustomException(ChallengeErrorCode.CHALLENGE_ALREADY_CLOSED);
+        }
+        if (c.isInProgress() && !isExpired(c)) {
+            throw new CustomException(ChallengeErrorCode.CHALLENGE_NOT_ENDED);
+        }
+        finalizeIfExpired(c);
+        // 포기·자동 취소는 기록에서 계산된 결과가 아니라 얼릴 대상이 없다(그 기간 지출 편집만 새로 막힌다) → 거절
+        if (!c.isResultFromRecords()) {
+            throw new CustomException(ChallengeErrorCode.CHALLENGE_NOT_CLOSABLE);
+        }
+        c.close(LocalDateTime.now(clock));
+        return CloseResponse.from(c);
     }
 
     /** 일별 지출 수신 → 그날 판정 upsert. */
     @Transactional
     public DayUpsertResponse upsertDay(Long userId, Long challengeId, DayUpsertRequest req) {
         Challenge c = loadOwned(userId, challengeId);
+        // 최종 종료된 챌린지의 기록은 못 고친다 — 날짜 검사(400)보다 먼저 보는 이유는 요청 값이 아니라 상태 문제라서
+        if (c.isClosed()) {
+            throw new CustomException(ChallengeErrorCode.CHALLENGE_ALREADY_CLOSED);
+        }
         if (req.date().isBefore(c.getStartDate()) || req.date().isAfter(c.getEndDate())) {
             throw new CustomException(ChallengeErrorCode.DAY_OUT_OF_RANGE);
         }
@@ -267,7 +300,7 @@ public class ChallengeService {
                         ChallengeDay.of(c, req.date(), req.spentAmount(), status, dailyLimit)));
 
         // 기록으로 계산된 종료 상태만 다시 계산한다. 중도 포기와 미입력 자동 취소는 지출을 고쳐도 되살리지 않는다.
-        if (!c.isInProgress() && c.getEndReason() == null) {
+        if (!c.isInProgress() && c.isResultFromRecords()) {
             ChallengeSummary s = ChallengeCalculator.summarizeForResult(
                     challengeDayRepository.findByChallenge_Id(challengeId),
                     timelineOf(c), c.getStartDate(), c.getEndDate());

--- a/src/main/java/Hampouch/server/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/Hampouch/server/domain/challenge/service/ChallengeService.java
@@ -259,7 +259,7 @@ public class ChallengeService {
      */
     @Transactional
     public CloseResponse close(Long userId, Long challengeId) {
-        Challenge c = loadOwned(userId, challengeId);
+        Challenge c = loadOwnedForUpdate(userId, challengeId);
         if (c.isClosed()) {
             throw new CustomException(ChallengeErrorCode.CHALLENGE_ALREADY_CLOSED);
         }
@@ -278,7 +278,7 @@ public class ChallengeService {
     /** 일별 지출 수신 → 그날 판정 upsert. */
     @Transactional
     public DayUpsertResponse upsertDay(Long userId, Long challengeId, DayUpsertRequest req) {
-        Challenge c = loadOwned(userId, challengeId);
+        Challenge c = loadOwnedForUpdate(userId, challengeId);
         // 최종 종료된 챌린지의 기록은 못 고친다 — 날짜 검사(400)보다 먼저 보는 이유는 요청 값이 아니라 상태 문제라서
         if (c.isClosed()) {
             throw new CustomException(ChallengeErrorCode.CHALLENGE_ALREADY_CLOSED);
@@ -513,6 +513,15 @@ public class ChallengeService {
 
     private Challenge loadOwned(Long userId, Long challengeId) {
         Challenge c = challengeRepository.findById(challengeId)
+                .orElseThrow(() -> new CustomException(ChallengeErrorCode.CHALLENGE_NOT_FOUND));
+        if (!c.isOwnedBy(userId)) {
+            throw new CustomException(ChallengeErrorCode.CHALLENGE_FORBIDDEN);
+        }
+        return c;
+    }
+
+    private Challenge loadOwnedForUpdate(Long userId, Long challengeId) {
+        Challenge c = challengeRepository.findByIdForUpdate(challengeId)
                 .orElseThrow(() -> new CustomException(ChallengeErrorCode.CHALLENGE_NOT_FOUND));
         if (!c.isOwnedBy(userId)) {
             throw new CustomException(ChallengeErrorCode.CHALLENGE_FORBIDDEN);

--- a/src/main/java/Hampouch/server/domain/expense/service/ExpenseDateLockQuery.java
+++ b/src/main/java/Hampouch/server/domain/expense/service/ExpenseDateLockQuery.java
@@ -1,0 +1,8 @@
+package Hampouch.server.domain.expense.service;
+
+import java.time.LocalDate;
+
+public interface ExpenseDateLockQuery {
+
+    boolean isExpenseChangeProhibited(Long userId, LocalDate date);
+}

--- a/src/main/java/Hampouch/server/domain/expense/service/ExpenseService.java
+++ b/src/main/java/Hampouch/server/domain/expense/service/ExpenseService.java
@@ -1,7 +1,5 @@
 package Hampouch.server.domain.expense.service;
 
-import Hampouch.server.domain.challenge.entity.ChallengeStatus;
-import Hampouch.server.domain.challenge.repository.ChallengeRepository;
 import Hampouch.server.domain.expense.dto.*;
 import Hampouch.server.domain.expense.entity.*;
 import Hampouch.server.domain.expense.repository.ExpenseDailyTotal;
@@ -31,7 +29,7 @@ public class ExpenseService {
 
     private final ExpenseRepository expenseRepository;
     private final NoSpendDayRepository noSpendDayRepository;
-    private final ChallengeRepository challengeRepository;
+    private final ExpenseDateLockQuery expenseDateLockQuery;
     private final UserRepository userRepository;
     private final Clock clock; //buildSummary()가 dailyAverage 계산 시 오늘까지 경과일수를 구하기 위한 기준
     // 한국 시간 기준으로 통일 된 Bean 활용
@@ -45,8 +43,7 @@ public class ExpenseService {
      */
     @Transactional
     public ExpenseCreateResponse create(Long userId, ExpenseCreateRequest request) {
-        validateWithinChallengePeriod(userId, request.date());
-        validateNotLockedByClosedChallenge(userId, request.date());
+        validateExpenseChangeAllowed(userId, request.date());
 
         User user = userRepository.getReferenceById(userId);
         if (user.getLastUpdated() == null || request.date().isAfter(user.getLastUpdated()))
@@ -66,7 +63,7 @@ public class ExpenseService {
      */
     @Transactional
     public void recordNoSpend(Long userId, NoSpendRecordRequest request) {
-        validateNotLockedByClosedChallenge(userId, request.date());
+        validateExpenseChangeAllowed(userId, request.date());
         if (expenseRepository.existsByUser_IdAndExpenseDateAndStatus(
                 userId, request.date(), ExpenseStatus.ACTIVE)) {
             return;
@@ -93,17 +90,11 @@ public class ExpenseService {
      * PUT /expenses/{expenseId}. ExpenseCreateRequest/Response를 그대로 재사용(두 DTO의 자체 Javadoc 참조).
      * attachCustomTags를 매번 다시 호출하는 이유는 Expense.update() Javadoc과 동일 — category/emotion이 ETC에서
      * 다른 값으로(또는 그 반대로) 바뀌었을 수 있어 customCategory/customEmotion을 매번 새 상태 기준으로 재확정해야 함.
-     * 날짜 검증(validateWithinChallengePeriod)은 request.date()가 기존 날짜와 실제로 다를 때만 수행
      */
     @Transactional
     public ExpenseCreateResponse update(Long userId, Long expenseId, ExpenseCreateRequest request) {
         Expense expense = loadOwned(userId, expenseId);
-        if (!request.date().equals(expense.getExpenseDate())) {
-            validateWithinChallengePeriod(userId, request.date());
-            validateNotLockedByClosedChallenge(userId, request.date());
-        }
-        // 옮겨 오는 날짜뿐 아니라 원래 날짜도 본다 — 잠긴 기간의 지출을 기간 밖으로 빼내면 그 기간 기록이 바뀐다
-        validateNotLockedByClosedChallenge(userId, expense.getExpenseDate());
+        validateExpenseChangeAllowed(userId, expense.getExpenseDate(), request.date());
 
         User user = expense.getUser();
         LocalDate oldDate = expense.getExpenseDate();
@@ -130,7 +121,7 @@ public class ExpenseService {
     @Transactional
     public void delete(Long userId, Long expenseId) {
         Expense expense = loadOwned(userId, expenseId);
-        validateNotLockedByClosedChallenge(userId, expense.getExpenseDate());
+        validateExpenseChangeAllowed(userId, expense.getExpenseDate());
         LocalDate deletedDate = expense.getExpenseDate();
         User user = expense.getUser();
         expense.delete();
@@ -232,30 +223,21 @@ public class ExpenseService {
     }
 
     /**
-     * 진행 중인 메인 챌린지 기간 검증.
-     * 챌린지가 있으면 그 기간(startDate~endDate) 밖 날짜를 막는다.
-     * 챌린지가 없으면 검증하지 않는다 — ChallengeService는 종료된 challenge의 status가
-     * 바로 변화하지 않음. 끝난 챌린지 기간의 날짜는 여기가 아니라
-     * validateNotLockedByClosedChallenge가 최종 종료 여부로 가른다.
+     * 최종 종료된 챌린지 기간 잠금(#50) — 유저가 결과 팝업에서 [챌린지 종료]를 누른 뒤에는 그 기간의
+     * 기록을 더 못 바꾼다. 수정·삭제뿐 아니라 생성·무지출 기록도 모두 그 기간의 기록을 바꾼다.
      */
-    private void validateWithinChallengePeriod(Long userId, LocalDate date) {
-        challengeRepository.findByUserIdAndStatus(userId, ChallengeStatus.IN_PROGRESS)
-                .ifPresent(challenge -> {
-                    if (date.isBefore(challenge.getStartDate()) || date.isAfter(challenge.getEndDate())) {
-                        throw new CustomException(ExpenseErrorCode.EXPENSE_DATE_OUT_OF_CHALLENGE_PERIOD);
-                    }
-                });
+    private void validateExpenseChangeAllowed(Long userId, LocalDate date) {
+        if (expenseDateLockQuery.isExpenseChangeProhibited(userId, date)) {
+            throw new CustomException(ExpenseErrorCode.EXPENSE_CHALLENGE_CLOSED);
+        }
     }
 
-    /**
-     * 최종 종료된 챌린지 기간 잠금(#50) — 유저가 결과 팝업에서 [챌린지 종료]를 누른 뒤에는 그 기간의
-     * 기록을 더 못 바꾼다. 위 validateWithinChallengePeriod와 대상이 다르다: 그쪽은 진행 중 챌린지가
-     * 기간 밖 날짜를 막는 것이고, 이쪽은 이미 끝나 잠긴 기간 안의 날짜를 막는다.
-     * 수정·삭제뿐 아니라 생성·무지출 기록도 막는 이유는 셋 다 그 기간의 기록을 바꾸기 때문이다.
-     */
-    private void validateNotLockedByClosedChallenge(Long userId, LocalDate date) {
-        if (challengeRepository.isDateLockedByClosedChallenge(userId, date)) {
-            throw new CustomException(ExpenseErrorCode.EXPENSE_CHALLENGE_CLOSED);
+    private void validateExpenseChangeAllowed(Long userId, LocalDate first, LocalDate second) {
+        LocalDate earlier = first.isBefore(second) ? first : second;
+        LocalDate later = first.isBefore(second) ? second : first;
+        validateExpenseChangeAllowed(userId, earlier);
+        if (!earlier.equals(later)) {
+            validateExpenseChangeAllowed(userId, later);
         }
     }
 

--- a/src/main/java/Hampouch/server/domain/expense/service/ExpenseService.java
+++ b/src/main/java/Hampouch/server/domain/expense/service/ExpenseService.java
@@ -46,6 +46,7 @@ public class ExpenseService {
     @Transactional
     public ExpenseCreateResponse create(Long userId, ExpenseCreateRequest request) {
         validateWithinChallengePeriod(userId, request.date());
+        validateNotLockedByClosedChallenge(userId, request.date());
 
         User user = userRepository.getReferenceById(userId);
         if (user.getLastUpdated() == null || request.date().isAfter(user.getLastUpdated()))
@@ -65,6 +66,7 @@ public class ExpenseService {
      */
     @Transactional
     public void recordNoSpend(Long userId, NoSpendRecordRequest request) {
+        validateNotLockedByClosedChallenge(userId, request.date());
         if (expenseRepository.existsByUser_IdAndExpenseDateAndStatus(
                 userId, request.date(), ExpenseStatus.ACTIVE)) {
             return;
@@ -98,7 +100,10 @@ public class ExpenseService {
         Expense expense = loadOwned(userId, expenseId);
         if (!request.date().equals(expense.getExpenseDate())) {
             validateWithinChallengePeriod(userId, request.date());
+            validateNotLockedByClosedChallenge(userId, request.date());
         }
+        // 옮겨 오는 날짜뿐 아니라 원래 날짜도 본다 — 잠긴 기간의 지출을 기간 밖으로 빼내면 그 기간 기록이 바뀐다
+        validateNotLockedByClosedChallenge(userId, expense.getExpenseDate());
 
         User user = expense.getUser();
         LocalDate oldDate = expense.getExpenseDate();
@@ -125,6 +130,7 @@ public class ExpenseService {
     @Transactional
     public void delete(Long userId, Long expenseId) {
         Expense expense = loadOwned(userId, expenseId);
+        validateNotLockedByClosedChallenge(userId, expense.getExpenseDate());
         LocalDate deletedDate = expense.getExpenseDate();
         User user = expense.getUser();
         expense.delete();
@@ -229,7 +235,8 @@ public class ExpenseService {
      * 진행 중인 메인 챌린지 기간 검증.
      * 챌린지가 있으면 그 기간(startDate~endDate) 밖 날짜를 막는다.
      * 챌린지가 없으면 검증하지 않는다 — ChallengeService는 종료된 challenge의 status가
-     * 바로 변화하지 않음. challenge가 없을 때 지출 입력 일자 제한은 이슈 #50에서 별도로 처리
+     * 바로 변화하지 않음. 끝난 챌린지 기간의 날짜는 여기가 아니라
+     * validateNotLockedByClosedChallenge가 최종 종료 여부로 가른다.
      */
     private void validateWithinChallengePeriod(Long userId, LocalDate date) {
         challengeRepository.findByUserIdAndStatus(userId, ChallengeStatus.IN_PROGRESS)
@@ -238,6 +245,18 @@ public class ExpenseService {
                         throw new CustomException(ExpenseErrorCode.EXPENSE_DATE_OUT_OF_CHALLENGE_PERIOD);
                     }
                 });
+    }
+
+    /**
+     * 최종 종료된 챌린지 기간 잠금(#50) — 유저가 결과 팝업에서 [챌린지 종료]를 누른 뒤에는 그 기간의
+     * 기록을 더 못 바꾼다. 위 validateWithinChallengePeriod와 대상이 다르다: 그쪽은 진행 중 챌린지가
+     * 기간 밖 날짜를 막는 것이고, 이쪽은 이미 끝나 잠긴 기간 안의 날짜를 막는다.
+     * 수정·삭제뿐 아니라 생성·무지출 기록도 막는 이유는 셋 다 그 기간의 기록을 바꾸기 때문이다.
+     */
+    private void validateNotLockedByClosedChallenge(Long userId, LocalDate date) {
+        if (challengeRepository.isDateLockedByClosedChallenge(userId, date)) {
+            throw new CustomException(ExpenseErrorCode.EXPENSE_CHALLENGE_CLOSED);
+        }
     }
 
     /**

--- a/src/main/java/Hampouch/server/global/common/exception/domain/ChallengeErrorCode.java
+++ b/src/main/java/Hampouch/server/global/common/exception/domain/ChallengeErrorCode.java
@@ -18,6 +18,9 @@ public enum ChallengeErrorCode implements BaseErrorCode {
     CHALLENGE_NOT_IN_PROGRESS(HttpStatus.CONFLICT, "CHALLENGE_NOT_IN_PROGRESS", "이미 종료된 챌린지입니다."),
     // 남은 횟수는 기간에 따라 1회 또는 2회라 메시지에 숫자를 박지 않는다 — 실제 값은 응답의 usedCount·maxCount로 간다
     ADJUSTMENT_LIMIT_EXCEEDED(HttpStatus.CONFLICT, "ADJUSTMENT_LIMIT_EXCEEDED", "한도 조정 가능 횟수를 모두 사용했습니다."),
+    // 최종 종료 재요청과 종료 뒤 기록 수정이 같은 코드를 쓴다 — 클라가 처한 상황은 달라도 사실은 하나다
+    CHALLENGE_ALREADY_CLOSED(HttpStatus.CONFLICT, "CHALLENGE_ALREADY_CLOSED", "이미 최종 종료된 챌린지입니다."),
+    CHALLENGE_NOT_CLOSABLE(HttpStatus.CONFLICT, "CHALLENGE_NOT_CLOSABLE", "중도 포기하거나 자동 취소된 챌린지는 최종 종료할 수 없습니다."),
     DAY_OUT_OF_RANGE(HttpStatus.BAD_REQUEST, "DAY_OUT_OF_RANGE", "날짜가 챌린지 기간 밖입니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/Hampouch/server/global/common/exception/domain/ExpenseErrorCode.java
+++ b/src/main/java/Hampouch/server/global/common/exception/domain/ExpenseErrorCode.java
@@ -20,6 +20,9 @@ public enum ExpenseErrorCode implements BaseErrorCode {
 
     EXPENSE_DATE_OUT_OF_CHALLENGE_PERIOD(HttpStatus.BAD_REQUEST, "EXPENSE_DATE_OUT_OF_CHALLENGE_PERIOD", "진행 중인 메인 챌린지 기간 내에서만 지출 입력이 가능합니다."),
 
+    /** 최종 종료(#50)로 잠긴 기간. 기간 밖 날짜(400)와 달리 요청은 옳고 상태가 막는 것이라 409다. */
+    EXPENSE_CHALLENGE_CLOSED(HttpStatus.CONFLICT, "EXPENSE_CHALLENGE_CLOSED", "최종 종료된 챌린지 기간의 기록은 변경할 수 없습니다."),
+
     EXPENSE_ANALYSIS_INVALID_PERIOD(HttpStatus.BAD_REQUEST, "EXPENSE_ANALYSIS_INVALID_PERIOD", "분석 시작일은 종료일보다 늦을 수 없습니다."),
 
     EXPENSE_ANALYSIS_FUTURE_PERIOD(HttpStatus.BAD_REQUEST, "EXPENSE_ANALYSIS_FUTURE_PERIOD", "아직 시작하지 않은 기간은 분석할 수 없습니다."),

--- a/src/main/java/Hampouch/server/global/common/exception/domain/ExpenseErrorCode.java
+++ b/src/main/java/Hampouch/server/global/common/exception/domain/ExpenseErrorCode.java
@@ -7,8 +7,7 @@ import org.springframework.http.HttpStatus;
 
 /**
  * expense 도메인 전용 에러 코드.
- * FORBIDDEN이 Common/Auth/Challenge에 각자 따로 있는 것과 동일하게, 개념이 겹치는 코드(예: 챌린지 기간 밖 날짜)라도
- * 다른 도메인의 ErrorCode를 재사용하지 않고 이 도메인 전용으로 둔다 — 도메인 경계를 ErrorCode 레벨에서도 유지.
+ * 다른 도메인의 ErrorCode를 재사용하지 않고 이 도메인 전용으로 둔다.
  */
 @Getter
 @RequiredArgsConstructor
@@ -18,9 +17,7 @@ public enum ExpenseErrorCode implements BaseErrorCode {
 
     EXPENSE_FORBIDDEN(HttpStatus.FORBIDDEN, "EXPENSE_FORBIDDEN", "해당 지출 내역에 접근 권한이 없습니다."),
 
-    EXPENSE_DATE_OUT_OF_CHALLENGE_PERIOD(HttpStatus.BAD_REQUEST, "EXPENSE_DATE_OUT_OF_CHALLENGE_PERIOD", "진행 중인 메인 챌린지 기간 내에서만 지출 입력이 가능합니다."),
-
-    /** 최종 종료(#50)로 잠긴 기간. 기간 밖 날짜(400)와 달리 요청은 옳고 상태가 막는 것이라 409다. */
+    /** 최종 종료(#50)로 잠긴 기간이라 409다. */
     EXPENSE_CHALLENGE_CLOSED(HttpStatus.CONFLICT, "EXPENSE_CHALLENGE_CLOSED", "최종 종료된 챌린지 기간의 기록은 변경할 수 없습니다."),
 
     EXPENSE_ANALYSIS_INVALID_PERIOD(HttpStatus.BAD_REQUEST, "EXPENSE_ANALYSIS_INVALID_PERIOD", "분석 시작일은 종료일보다 늦을 수 없습니다."),

--- a/src/test/java/Hampouch/server/domain/challenge/ChallengeFlowIntegrationTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/ChallengeFlowIntegrationTest.java
@@ -169,6 +169,61 @@ class ChallengeFlowIntegrationTest {
     }
 
     @Test
+    @DisplayName("기간이 끝난 챌린지는 최종 종료를 누르기 전까지 일별 기록을 고칠 수 있고, 누르는 순간 성패가 확정되며 그 뒤의 기록 수정과 재종료는 409로 막힌다")
+    void closeFinalizesResultAndLocksRecords() throws Exception {
+        long user = 50_001L;
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        // 기간이 끝난 챌린지는 생성 API로 못 만든다(통합 테스트는 시계를 못 돌림) → 어제 끝난 챌린지를 직접 심는다
+        Challenge ch = challengeRepository.save(Challenge.builder()
+                .userId(user).durationDays(7).startDate(today.minusDays(7))
+                .budgetTotal(70000).dailyLimit(10000).build());
+        LocalDate lastDay = today.minusDays(1);
+
+        // 결과 팝업의 [지출 수정하기] 구간 — 기간은 끝났지만 아직 안 잠겨 기록 수정이 통한다
+        mvc.perform(post("/api/challenges/" + ch.getId() + "/days")
+                        .header("Authorization", bearer(user))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"date\":\"" + lastDay + "\",\"spentAmount\":9000}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("SUCCESS"));
+
+        // [챌린지 종료] — 결과 화면을 한 번도 안 열었어도 여기서 성패가 확정된다
+        mvc.perform(post("/api/challenges/" + ch.getId() + "/close").header("Authorization", bearer(user)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("SUCCESS")) // 총지출 9000 ≤ 목표 70000
+                .andExpect(jsonPath("$.data.closedAt").exists());
+
+        mvc.perform(post("/api/challenges/" + ch.getId() + "/days")
+                        .header("Authorization", bearer(user))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"date\":\"" + lastDay + "\",\"spentAmount\":99000}"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("CHALLENGE_ALREADY_CLOSED"));
+
+        mvc.perform(post("/api/challenges/" + ch.getId() + "/close").header("Authorization", bearer(user)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("CHALLENGE_ALREADY_CLOSED"));
+
+        // 결과 조회에 종료 시각이 실린다 — 클라는 이 값으로 종료 팝업을 다시 띄울지 정한다
+        mvc.perform(get("/api/challenges/" + ch.getId() + "/result").header("Authorization", bearer(user)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.closedAt").exists());
+
+        Challenge reloaded = challengeRepository.findById(ch.getId()).orElseThrow();
+        assertThat(reloaded.getStatus()).isEqualTo(ChallengeStatus.SUCCESS);
+        assertThat(reloaded.getClosedAt()).isNotNull();
+        assertThat(challengeDayRepository.findByChallenge_IdAndDayDate(ch.getId(), lastDay).orElseThrow()
+                .getSpentAmount()).isEqualTo(9000); // 잠긴 뒤 요청이 기록을 못 바꿨다
+
+        // 최종 종료한 뒤에는 새 챌린지를 시작할 수 있다
+        mvc.perform(post("/api/challenges")
+                        .header("Authorization", bearer(user))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"durationDays\":7,\"budgetTotal\":70000,\"startDate\":\"" + today + "\"}"))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
     @DisplayName("현재 챌린지 조회가 3일 연속 미입력을 감지하면 요청 종료 후 DB에도 자동 취소 상태가 남는다")
     void currentAutoCancelCommitsAfterRequest() throws Exception {
         Long user = 67_001L;

--- a/src/test/java/Hampouch/server/domain/challenge/controller/ChallengeControllerTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/controller/ChallengeControllerTest.java
@@ -20,6 +20,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.hamcrest.Matchers.hasKey;
@@ -451,7 +452,7 @@ class ChallengeControllerTest {
         var period = new ResultResponse.Period(LocalDate.of(2026, 5, 1), LocalDate.of(2026, 5, 14), 14);
         var summary = new ResultResponse.Summary(14, 0, 68200, 0, 14, 280000, 211800);
         when(service.getResult(anyLong(), anyLong()))
-                .thenReturn(new ResultResponse(1L, ChallengeStatus.SUCCESS, period, summary, List.of(), List.of()));
+                .thenReturn(new ResultResponse(1L, ChallengeStatus.SUCCESS, null, period, summary, List.of(), List.of()));
 
         mvc.perform(get("/api/challenges/1/result"))
                 .andExpect(status().isOk())
@@ -461,5 +462,67 @@ class ChallengeControllerTest {
                 .andExpect(jsonPath("$.data.summary.actualSpent").value(211800))
                 .andExpect(jsonPath("$.data.categoryBreakdown").isArray())
                 .andExpect(jsonPath("$.data.emotionBreakdown").isArray());
+    }
+
+    @Test
+    @DisplayName("아직 최종 종료하지 않은 챌린지의 결과 응답은 closedAt 필드가 null로 나간다 — 클라가 이 값으로 종료 팝업을 띄울지 정한다")
+    void result_closedAtNullWhenNotClosed() throws Exception {
+        var period = new ResultResponse.Period(LocalDate.of(2026, 5, 1), LocalDate.of(2026, 5, 14), 14);
+        var summary = new ResultResponse.Summary(14, 0, 68200, 0, 14, 280000, 211800);
+        when(service.getResult(anyLong(), anyLong()))
+                .thenReturn(new ResultResponse(1L, ChallengeStatus.SUCCESS, null, period, summary, List.of(), List.of()));
+
+        mvc.perform(get("/api/challenges/1/result"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.closedAt").value(nullValue()));
+    }
+
+    @Test
+    @DisplayName("최종 종료 요청이 정상이면 200과 확정된 성패·종료 시각을 돌려준다 — 새 리소스가 생기는 게 아니라 상태가 바뀌는 것이라 201이 아니다")
+    void close_200() throws Exception {
+        when(service.close(anyLong(), anyLong())).thenReturn(
+                new CloseResponse(1L, ChallengeStatus.SUCCESS, LocalDateTime.of(2026, 5, 20, 9, 30)));
+
+        mvc.perform(post("/api/challenges/1/close"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.challengeId").value(1))
+                .andExpect(jsonPath("$.data.status").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.closedAt").value("2026-05-20T09:30:00"));
+    }
+
+    @Test
+    @DisplayName("기간이 안 끝난 챌린지의 최종 종료 요청은 409와 팀 공통 에러 본문(CHALLENGE_NOT_ENDED)을 돌려준다")
+    void close_409_whenNotEnded() throws Exception {
+        when(service.close(anyLong(), anyLong()))
+                .thenThrow(new CustomException(ChallengeErrorCode.CHALLENGE_NOT_ENDED));
+
+        mvc.perform(post("/api/challenges/1/close"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("CHALLENGE_NOT_ENDED"))
+                .andExpect(jsonPath("$.status").value(409));
+    }
+
+    @Test
+    @DisplayName("이미 최종 종료한 챌린지의 종료 요청은 409와 팀 공통 에러 본문(CHALLENGE_ALREADY_CLOSED)을 돌려준다")
+    void close_409_whenAlreadyClosed() throws Exception {
+        when(service.close(anyLong(), anyLong()))
+                .thenThrow(new CustomException(ChallengeErrorCode.CHALLENGE_ALREADY_CLOSED));
+
+        mvc.perform(post("/api/challenges/1/close"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("CHALLENGE_ALREADY_CLOSED"))
+                .andExpect(jsonPath("$.status").value(409));
+    }
+
+    @Test
+    @DisplayName("로그인 정보 없이 최종 종료를 요청하면 401로 거절되고 서비스는 호출되지 않는다")
+    void close_401_whenNoAuthentication() throws Exception {
+        TestSecurityContextHolder.clearContext();
+
+        mvc.perform(post("/api/challenges/1/close"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTH_UNAUTHORIZED"));
+        verify(service, never()).close(anyLong(), anyLong());
     }
 }

--- a/src/test/java/Hampouch/server/domain/challenge/entity/ChallengeTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/entity/ChallengeTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -28,7 +29,7 @@ class ChallengeTest {
 
     @Test
     @DisplayName("유효한 값으로 생성하면 종료일(시작일 포함 기간의 마지막 날)과 시작 상태(진행 중)가 채워진다")
-    void 유효한_값이면_종료일과_시작상태가_채워진다() {
+    void build_computesEndDateAndStartsInProgress() {
         Challenge challenge = validBuilder().build();
 
         assertThat(challenge.getStartDate()).isEqualTo(LocalDate.of(2026, 6, 1));
@@ -38,35 +39,35 @@ class ChallengeTest {
 
     @Test
     @DisplayName("유저 식별자를 빠뜨리면(null) 생성자 검사가 IllegalArgumentException으로 막는다")
-    void 유저식별자가_null이면_생성이_막힌다() {
+    void build_rejectsNullUserId() {
         assertThatThrownBy(() -> validBuilder().userId(null).build())
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     @DisplayName("시작일을 빠뜨리면(null) 종료일 계산 전에 생성자 검사가 IllegalArgumentException으로 막는다")
-    void 시작일이_null이면_생성이_막힌다() {
+    void build_rejectsNullStartDate() {
         assertThatThrownBy(() -> validBuilder().startDate(null).build())
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     @DisplayName("기간이 1일 미만이면 생성자 검사가 IllegalArgumentException으로 막는다")
-    void 기간이_1미만이면_생성이_막힌다() {
+    void build_rejectsDurationBelowOne() {
         assertThatThrownBy(() -> validBuilder().durationDays(0).build())
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     @DisplayName("예산이 음수면 생성자 검사가 IllegalArgumentException으로 막는다")
-    void 예산이_음수면_생성이_막힌다() {
+    void build_rejectsNegativeBudget() {
         assertThatThrownBy(() -> validBuilder().budgetTotal(-1).build())
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     @DisplayName("예산 0원은 생성을 막지 않는다 — 구조적으로 문제없고(하루 한도 0으로 계산됨) 최소 예산 하한은 확정된 규칙이 없어 엔티티가 단정하지 않는다")
-    void 예산_0원은_허용된다() {
+    void build_allowsZeroBudget() {
         Challenge challenge = validBuilder().budgetTotal(0).build();
 
         assertThat(challenge.getBudgetTotal()).isZero();
@@ -75,14 +76,14 @@ class ChallengeTest {
 
     @Test
     @DisplayName("하루 한도가 음수면 생성자 검사가 IllegalArgumentException으로 막는다")
-    void 하루한도가_음수면_생성이_막힌다() {
+    void build_rejectsNegativeDailyLimit() {
         assertThatThrownBy(() -> validBuilder().dailyLimit(-1).build())
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     @DisplayName("집중 카테고리를 교체하면 챌린지가 갖고 있던 카테고리는 사라지고, 넘긴 카테고리만 넘긴 순서대로 남는다")
-    void 집중카테고리_교체는_저장돼_있던_것을_통째로_바꾼다() {
+    void replaceWeakCategories_replacesAllExisting() {
         Challenge challenge = validBuilder().build();
         challenge.replaceWeakCategories(List.of("배달", "카페"));
 
@@ -95,7 +96,7 @@ class ChallengeTest {
 
     @Test
     @DisplayName("같은 카테고리를 여러 번 보내도 한 개로 접혀 저장된다 — 한 챌린지에 같은 카테고리 두 줄은 저장할 수 없기 때문")
-    void 집중카테고리_교체는_중복을_제거한다() {
+    void replaceWeakCategories_dedupes() {
         Challenge challenge = validBuilder().build();
 
         challenge.replaceWeakCategories(List.of("카페", "카페", "배달"));
@@ -107,7 +108,7 @@ class ChallengeTest {
 
     @Test
     @DisplayName("집중 카테고리를 하나도 없는 목록으로 교체하면 챌린지가 갖고 있던 카테고리가 전부 사라진다")
-    void 집중카테고리_하나도_없는_요청은_전부_해제한다() {
+    void replaceWeakCategories_clearsWhenEmpty() {
         Challenge challenge = validBuilder().build();
         challenge.replaceWeakCategories(List.of("배달", "카페"));
 
@@ -118,7 +119,7 @@ class ChallengeTest {
 
     @Test
     @DisplayName("3일 연속 지출 미입력으로 자동 취소하면 VOID 상태와 종료 사유가 함께 남고 다시 취소할 수 없다")
-    void 지출_미입력_자동취소는_VOID와_종료사유를_남긴다() {
+    void cancelForMissingInput_setsVoidWithReason() {
         Challenge challenge = validBuilder().build();
 
         challenge.cancelForMissingInput();
@@ -126,5 +127,39 @@ class ChallengeTest {
         assertThat(challenge.getStatus()).isEqualTo(ChallengeStatus.VOID);
         assertThat(challenge.getEndReason()).isEqualTo(EndReason.MISSING_DAILY_INPUT);
         assertThatThrownBy(challenge::cancelForMissingInput).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    @DisplayName("결과가 확정된 챌린지를 최종 종료하면 종료 시각만 남고 성패(SUCCESS)는 그대로다")
+    void close_recordsTimeWithoutChangingStatus() {
+        Challenge challenge = validBuilder().build();
+        challenge.applyResult(ChallengeStatus.SUCCESS);
+
+        challenge.close(LocalDateTime.of(2026, 6, 15, 9, 30));
+
+        assertThat(challenge.isClosed()).isTrue();
+        assertThat(challenge.getClosedAt()).isEqualTo(LocalDateTime.of(2026, 6, 15, 9, 30));
+        assertThat(challenge.getStatus()).isEqualTo(ChallengeStatus.SUCCESS);
+    }
+
+    @Test
+    @DisplayName("진행 중인 챌린지를 최종 종료하려 하면 IllegalStateException으로 막는다 — 기간이 안 끝난 요청은 서비스가 409로 먼저 거르므로, 여기까지 왔다면 그 검사를 건너뛰고 호출한 서버 코드 실수라는 뜻")
+    void close_rejectsInProgress() {
+        Challenge challenge = validBuilder().build();
+
+        assertThatThrownBy(() -> challenge.close(LocalDateTime.of(2026, 6, 15, 9, 30)))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    @DisplayName("이미 최종 종료한 챌린지를 다시 종료하려 하면 IllegalStateException으로 막아 첫 종료 시각을 지킨다")
+    void close_rejectsSecondClose() {
+        Challenge challenge = validBuilder().build();
+        challenge.applyResult(ChallengeStatus.SUCCESS);
+        challenge.close(LocalDateTime.of(2026, 6, 15, 9, 30));
+
+        assertThatThrownBy(() -> challenge.close(LocalDateTime.of(2026, 6, 16, 9, 30)))
+                .isInstanceOf(IllegalStateException.class);
+        assertThat(challenge.getClosedAt()).isEqualTo(LocalDateTime.of(2026, 6, 15, 9, 30));
     }
 }

--- a/src/test/java/Hampouch/server/domain/challenge/repository/ChallengeRepositoryTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/repository/ChallengeRepositoryTest.java
@@ -12,6 +12,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.dao.DataIntegrityViolationException;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -118,6 +119,26 @@ class ChallengeRepositoryTest {
 
         assertThat(challengeRepository.existsInProgress(1L)).isTrue();
         assertThat(challengeRepository.existsInProgress(2L)).isTrue();
+    }
+
+    @Test
+    @DisplayName("최종 종료된 기록 기반 챌린지의 기간만 지출 변경 금지로 판정하고 포기 챌린지는 제외한다")
+    void expenseDateLockQuery_distinguishesClosedFromGivenUpChallenge() {
+        LocalDate start = LocalDate.of(2026, 6, 1);
+        LocalDate date = LocalDate.of(2026, 6, 3);
+        Challenge resultBased = persist(3L, start, 7, ChallengeStatus.SUCCESS);
+
+        assertThat(challengeRepository.isExpenseChangeProhibited(3L, date)).isFalse();
+
+        resultBased.close(LocalDateTime.of(2026, 6, 10, 12, 0));
+        challengeRepository.flush();
+        assertThat(challengeRepository.isExpenseChangeProhibited(3L, date)).isTrue();
+        assertThat(challengeRepository.isExpenseChangeProhibited(3L, start.minusDays(1))).isFalse();
+
+        Challenge givenUp = persist(4L, start, 7, null);
+        givenUp.giveUp();
+        challengeRepository.flush();
+        assertThat(challengeRepository.isExpenseChangeProhibited(4L, date)).isFalse();
     }
 
     @Test

--- a/src/test/java/Hampouch/server/domain/challenge/service/ChallengeServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/service/ChallengeServiceTest.java
@@ -23,6 +23,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.Clock;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
@@ -899,6 +900,125 @@ class ChallengeServiceTest {
 
         assertThat(res.status()).isEqualTo(ChallengeStatus.FAIL);
         assertThat(ch.getEndReason()).isEqualTo(EndReason.GIVEN_UP);
+    }
+
+    @Test
+    @DisplayName("기간이 끝난 챌린지를 최종 종료하면 결과 화면을 한 번도 안 열었어도 그 자리에서 성패가 확정되고 종료 시각이 남는다")
+    void close_finalizesExpiredAndRecordsTime() {
+        Challenge ch = inProgress(LocalDate.of(2026, 6, 1)); // 06-01~06-14, 목표 280000
+        ReflectionTestUtils.setField(ch, "id", 10L);
+        when(challengeRepository.findById(10L)).thenReturn(Optional.of(ch));
+        when(challengeDayRepository.findByChallenge_Id(10L)).thenReturn(List.of(
+                ChallengeDay.of(ch, LocalDate.of(2026, 6, 1), 10000, DayStatus.SUCCESS, ch.getDailyLimit())));
+
+        CloseResponse res = serviceAt(LocalDate.of(2026, 6, 20)).close(USER, 10L);
+
+        assertThat(res.challengeId()).isEqualTo(10L);
+        assertThat(res.status()).isEqualTo(ChallengeStatus.SUCCESS); // 총지출 10000 ≤ 목표 280000
+        assertThat(ch.getStatus()).isEqualTo(ChallengeStatus.SUCCESS);
+        assertThat(ch.getClosedAt()).isEqualTo(LocalDateTime.of(2026, 6, 20, 12, 0));
+    }
+
+    @Test
+    @DisplayName("이미 결과가 확정된 챌린지를 최종 종료하면 성패는 그대로 두고 종료 시각만 남긴다")
+    void close_locksAlreadyFinalizedChallenge() {
+        Challenge ended = endedWithId(10L, LocalDate.of(2026, 5, 1), 14, 280000, 20000, ChallengeStatus.FAIL);
+        when(challengeRepository.findById(10L)).thenReturn(Optional.of(ended));
+
+        CloseResponse res = serviceAt(LocalDate.of(2026, 6, 5)).close(USER, 10L);
+
+        assertThat(res.status()).isEqualTo(ChallengeStatus.FAIL);
+        assertThat(ended.getClosedAt()).isEqualTo(LocalDateTime.of(2026, 6, 5, 12, 0));
+        verify(challengeDayRepository, never()).findByChallenge_Id(any()); // 확정이 끝나 있어 재계산 조회가 안 나간다
+    }
+
+    @Test
+    @DisplayName("기간이 아직 안 끝난 챌린지를 최종 종료하려 하면 409(CHALLENGE_NOT_ENDED)로 거절하고 잠그지 않는다 — 마지막 날 당일도 아직 기간 중이다")
+    void close_conflictWhenNotEnded() {
+        Challenge ch = inProgress(LocalDate.of(2026, 6, 1)); // 06-01~06-14
+        ReflectionTestUtils.setField(ch, "id", 10L);
+        when(challengeRepository.findById(10L)).thenReturn(Optional.of(ch));
+
+        assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 6, 14)).close(USER, 10L))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ChallengeErrorCode.CHALLENGE_NOT_ENDED);
+
+        assertThat(ch.isClosed()).isFalse();
+        assertThat(ch.getStatus()).isEqualTo(ChallengeStatus.IN_PROGRESS);
+    }
+
+    @Test
+    @DisplayName("이미 최종 종료한 챌린지를 다시 종료하려 하면 409(CHALLENGE_ALREADY_CLOSED)로 거절하고 첫 종료 시각을 유지한다")
+    void close_conflictWhenAlreadyClosed() {
+        Challenge ended = endedWithId(10L, LocalDate.of(2026, 5, 1), 14, 280000, 20000, ChallengeStatus.SUCCESS);
+        ended.close(LocalDateTime.of(2026, 5, 20, 9, 0));
+        when(challengeRepository.findById(10L)).thenReturn(Optional.of(ended));
+
+        assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 6, 5)).close(USER, 10L))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ChallengeErrorCode.CHALLENGE_ALREADY_CLOSED);
+
+        assertThat(ended.getClosedAt()).isEqualTo(LocalDateTime.of(2026, 5, 20, 9, 0));
+    }
+
+    @Test
+    @DisplayName("중도 포기한 챌린지는 최종 종료 대상이 아니라 409(CHALLENGE_NOT_CLOSABLE)로 거절한다 — 포기 결과는 지출을 고쳐도 재계산되지 않아 잠글 것이 없고, 잠그면 그 기간 지출 수정만 새로 막힌다")
+    void close_conflictWhenGivenUp() {
+        Challenge ch = inProgress(LocalDate.of(2026, 6, 1));
+        ReflectionTestUtils.setField(ch, "id", 10L);
+        ch.giveUp();
+        when(challengeRepository.findById(10L)).thenReturn(Optional.of(ch));
+
+        assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 6, 20)).close(USER, 10L))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ChallengeErrorCode.CHALLENGE_NOT_CLOSABLE);
+
+        assertThat(ch.isClosed()).isFalse();
+    }
+
+    @Test
+    @DisplayName("없는 챌린지를 최종 종료하면 404(CHALLENGE_NOT_FOUND)를 던진다")
+    void close_notFound() {
+        when(challengeRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 6, 5)).close(USER, 99L))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ChallengeErrorCode.CHALLENGE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("최종 종료한 챌린지에 일별 지출을 다시 보내면 409(CHALLENGE_ALREADY_CLOSED)로 거절하고 기존 기록을 그대로 둔다")
+    void upsertDay_conflictWhenClosed() {
+        Challenge ended = endedWithId(10L, LocalDate.of(2026, 6, 1), 14, 280000, 20000, ChallengeStatus.SUCCESS);
+        ended.close(LocalDateTime.of(2026, 6, 20, 9, 0));
+        LocalDate date = LocalDate.of(2026, 6, 3);
+        ChallengeDay existing = ChallengeDay.of(ended, date, 1000, DayStatus.SUCCESS, ended.getDailyLimit());
+        when(challengeRepository.findById(10L)).thenReturn(Optional.of(ended));
+
+        assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 6, 21))
+                .upsertDay(USER, 10L, new DayUpsertRequest(date, 99999, null, null)))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ChallengeErrorCode.CHALLENGE_ALREADY_CLOSED);
+
+        assertThat(existing.getSpentAmount()).isEqualTo(1000);
+    }
+
+    @Test
+    @DisplayName("최종 종료를 누르지 않은 채 기간만 끝난 챌린지가 있어도 새 챌린지를 만들 수 있다 — 생성 경로가 만료분을 먼저 확정하므로 종료 팝업을 무시한 유저가 다음 챌린지를 못 여는 상태에 갇히지 않는다")
+    void create_allowedWhenPreviousExpiredButNeverClosed() {
+        Challenge expired = inProgress(LocalDate.of(2026, 6, 1)); // 06-01~06-14, 종료를 안 누른 상태
+        ReflectionTestUtils.setField(expired, "id", 10L);
+        when(challengeRepository.findInProgress(USER)).thenReturn(Optional.of(expired));
+        when(challengeDayRepository.findByChallenge_Id(10L)).thenReturn(List.of());
+        when(challengeRepository.existsInProgress(USER)).thenReturn(false); // 위에서 확정돼 진행 중이 아님
+        when(challengeRepository.save(any(Challenge.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        var req = new CreateChallengeRequest(7, 70000, LocalDate.of(2026, 6, 20), false, null, null);
+        CreateChallengeResponse res = serviceAt(LocalDate.of(2026, 6, 20)).create(USER, req);
+
+        assertThat(res.status()).isEqualTo(ChallengeStatus.IN_PROGRESS);
+        assertThat(expired.getStatus()).isEqualTo(ChallengeStatus.SUCCESS); // 생성 경로가 확정
+        assertThat(expired.isClosed()).isFalse();                           // 확정과 잠금은 다른 축
     }
 
     @Test

--- a/src/test/java/Hampouch/server/domain/challenge/service/ChallengeServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/service/ChallengeServiceTest.java
@@ -134,7 +134,7 @@ class ChallengeServiceTest {
     @DisplayName("챌린지 기간 밖 날짜로 일별 입력하면 400을 던진다 (S7)")
     void upsertDay_outOfRange() {
         Challenge ch = inProgress(LocalDate.of(2026, 6, 1)); // 06-01~06-14
-        when(challengeRepository.findById(10L)).thenReturn(Optional.of(ch));
+        when(challengeRepository.findByIdForUpdate(10L)).thenReturn(Optional.of(ch));
         var req = new DayUpsertRequest(LocalDate.of(2026, 6, 20), 5000, null, null);
 
         assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 6, 5)).upsertDay(USER, 10L, req))
@@ -147,7 +147,7 @@ class ChallengeServiceTest {
         Challenge ch = inProgress(LocalDate.of(2026, 6, 1)); // dailyLimit = 280000/14 = 20000
         LocalDate date = LocalDate.of(2026, 6, 3);
         ChallengeDay existing = ChallengeDay.of(ch, date, 1000, DayStatus.SUCCESS, ch.getDailyLimit());
-        when(challengeRepository.findById(10L)).thenReturn(Optional.of(ch));
+        when(challengeRepository.findByIdForUpdate(10L)).thenReturn(Optional.of(ch));
         when(challengeDayRepository.findByChallenge_IdAndDayDate(10L, date)).thenReturn(Optional.of(existing));
 
         var req = new DayUpsertRequest(date, 99999, null, null); // 한도 초과로 변경
@@ -194,7 +194,7 @@ class ChallengeServiceTest {
         ch.applyResult(ChallengeStatus.SUCCESS); // 이미 SUCCESS로 확정된 챌린지
         LocalDate date = LocalDate.of(2026, 6, 3);
         ChallengeDay existing = ChallengeDay.of(ch, date, 1000, DayStatus.SUCCESS, ch.getDailyLimit());
-        when(challengeRepository.findById(10L)).thenReturn(Optional.of(ch));
+        when(challengeRepository.findByIdForUpdate(10L)).thenReturn(Optional.of(ch));
         when(challengeDayRepository.findByChallenge_IdAndDayDate(10L, date)).thenReturn(Optional.of(existing));
         when(challengeDayRepository.findByChallenge_Id(10L)).thenReturn(List.of(existing));
 
@@ -210,7 +210,7 @@ class ChallengeServiceTest {
         ch.applyResult(ChallengeStatus.FAIL); // 계산으로 확정된 FAIL(endReason 없음) — 포기 아님
         LocalDate date = LocalDate.of(2026, 6, 3);
         ChallengeDay existing = ChallengeDay.of(ch, date, 300000, DayStatus.OVER, ch.getDailyLimit());
-        when(challengeRepository.findById(10L)).thenReturn(Optional.of(ch));
+        when(challengeRepository.findByIdForUpdate(10L)).thenReturn(Optional.of(ch));
         when(challengeDayRepository.findByChallenge_IdAndDayDate(10L, date)).thenReturn(Optional.of(existing));
         when(challengeDayRepository.findByChallenge_Id(10L)).thenReturn(List.of(existing));
 
@@ -471,7 +471,7 @@ class ChallengeServiceTest {
         Challenge ch = inProgressWithId(10L, LocalDate.of(2026, 6, 1));
         ReflectionTestUtils.setField(ch, "dailyLimit", 22000); // 6/5에 20000 → 22000으로 조정된 상태
         LocalDate pastDay = LocalDate.of(2026, 6, 3);
-        when(challengeRepository.findById(10L)).thenReturn(Optional.of(ch));
+        when(challengeRepository.findByIdForUpdate(10L)).thenReturn(Optional.of(ch));
         when(challengeAdjustmentRepository.findByChallenge_IdOrderByEffectiveDateAscIdAsc(10L))
                 .thenReturn(List.of(ChallengeAdjustment.builder()
                         .challenge(ch).sequenceNumber(1).effectiveDate(LocalDate.of(2026, 6, 5))
@@ -907,7 +907,7 @@ class ChallengeServiceTest {
     void close_finalizesExpiredAndRecordsTime() {
         Challenge ch = inProgress(LocalDate.of(2026, 6, 1)); // 06-01~06-14, 목표 280000
         ReflectionTestUtils.setField(ch, "id", 10L);
-        when(challengeRepository.findById(10L)).thenReturn(Optional.of(ch));
+        when(challengeRepository.findByIdForUpdate(10L)).thenReturn(Optional.of(ch));
         when(challengeDayRepository.findByChallenge_Id(10L)).thenReturn(List.of(
                 ChallengeDay.of(ch, LocalDate.of(2026, 6, 1), 10000, DayStatus.SUCCESS, ch.getDailyLimit())));
 
@@ -923,7 +923,7 @@ class ChallengeServiceTest {
     @DisplayName("이미 결과가 확정된 챌린지를 최종 종료하면 성패는 그대로 두고 종료 시각만 남긴다")
     void close_locksAlreadyFinalizedChallenge() {
         Challenge ended = endedWithId(10L, LocalDate.of(2026, 5, 1), 14, 280000, 20000, ChallengeStatus.FAIL);
-        when(challengeRepository.findById(10L)).thenReturn(Optional.of(ended));
+        when(challengeRepository.findByIdForUpdate(10L)).thenReturn(Optional.of(ended));
 
         CloseResponse res = serviceAt(LocalDate.of(2026, 6, 5)).close(USER, 10L);
 
@@ -933,11 +933,11 @@ class ChallengeServiceTest {
     }
 
     @Test
-    @DisplayName("기간이 아직 안 끝난 챌린지를 최종 종료하려 하면 409(CHALLENGE_NOT_ENDED)로 거절하고 잠그지 않는다 — 마지막 날 당일도 아직 기간 중이다")
+    @DisplayName("기간이 아직 안 끝난 챌린지를 최종 종료하려 하면 409(CHALLENGE_NOT_ENDED)로 거절하고 지출 변경 금지 상태로 만들지 않는다 — 마지막 날 당일도 아직 기간 중이다")
     void close_conflictWhenNotEnded() {
         Challenge ch = inProgress(LocalDate.of(2026, 6, 1)); // 06-01~06-14
         ReflectionTestUtils.setField(ch, "id", 10L);
-        when(challengeRepository.findById(10L)).thenReturn(Optional.of(ch));
+        when(challengeRepository.findByIdForUpdate(10L)).thenReturn(Optional.of(ch));
 
         assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 6, 14)).close(USER, 10L))
                 .isInstanceOf(CustomException.class)
@@ -952,7 +952,7 @@ class ChallengeServiceTest {
     void close_conflictWhenAlreadyClosed() {
         Challenge ended = endedWithId(10L, LocalDate.of(2026, 5, 1), 14, 280000, 20000, ChallengeStatus.SUCCESS);
         ended.close(LocalDateTime.of(2026, 5, 20, 9, 0));
-        when(challengeRepository.findById(10L)).thenReturn(Optional.of(ended));
+        when(challengeRepository.findByIdForUpdate(10L)).thenReturn(Optional.of(ended));
 
         assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 6, 5)).close(USER, 10L))
                 .isInstanceOf(CustomException.class)
@@ -962,12 +962,12 @@ class ChallengeServiceTest {
     }
 
     @Test
-    @DisplayName("중도 포기한 챌린지는 최종 종료 대상이 아니라 409(CHALLENGE_NOT_CLOSABLE)로 거절한다 — 포기 결과는 지출을 고쳐도 재계산되지 않아 잠글 것이 없고, 잠그면 그 기간 지출 수정만 새로 막힌다")
+    @DisplayName("중도 포기한 챌린지는 최종 종료 대상이 아니라 409(CHALLENGE_NOT_CLOSABLE)로 거절한다 — 포기 결과는 지출을 고쳐도 재계산되지 않으므로 해당 기간을 지출 변경 금지 상태로 만들지 않는다")
     void close_conflictWhenGivenUp() {
         Challenge ch = inProgress(LocalDate.of(2026, 6, 1));
         ReflectionTestUtils.setField(ch, "id", 10L);
         ch.giveUp();
-        when(challengeRepository.findById(10L)).thenReturn(Optional.of(ch));
+        when(challengeRepository.findByIdForUpdate(10L)).thenReturn(Optional.of(ch));
 
         assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 6, 20)).close(USER, 10L))
                 .isInstanceOf(CustomException.class)
@@ -979,7 +979,7 @@ class ChallengeServiceTest {
     @Test
     @DisplayName("없는 챌린지를 최종 종료하면 404(CHALLENGE_NOT_FOUND)를 던진다")
     void close_notFound() {
-        when(challengeRepository.findById(99L)).thenReturn(Optional.empty());
+        when(challengeRepository.findByIdForUpdate(99L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 6, 5)).close(USER, 99L))
                 .isInstanceOf(CustomException.class)
@@ -993,7 +993,7 @@ class ChallengeServiceTest {
         ended.close(LocalDateTime.of(2026, 6, 20, 9, 0));
         LocalDate date = LocalDate.of(2026, 6, 3);
         ChallengeDay existing = ChallengeDay.of(ended, date, 1000, DayStatus.SUCCESS, ended.getDailyLimit());
-        when(challengeRepository.findById(10L)).thenReturn(Optional.of(ended));
+        when(challengeRepository.findByIdForUpdate(10L)).thenReturn(Optional.of(ended));
 
         assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 6, 21))
                 .upsertDay(USER, 10L, new DayUpsertRequest(date, 99999, null, null)))
@@ -1028,7 +1028,7 @@ class ChallengeServiceTest {
         ch.giveUp(); // FAIL + GIVEN_UP — 유일한 기록이 초과(아래)여도 포기가 선행된 상황
         LocalDate date = LocalDate.of(2026, 6, 3);
         ChallengeDay existing = ChallengeDay.of(ch, date, 99999, DayStatus.OVER, ch.getDailyLimit());
-        when(challengeRepository.findById(10L)).thenReturn(Optional.of(ch));
+        when(challengeRepository.findByIdForUpdate(10L)).thenReturn(Optional.of(ch));
         when(challengeDayRepository.findByChallenge_IdAndDayDate(10L, date)).thenReturn(Optional.of(existing));
 
         serviceAt(LocalDate.of(2026, 6, 10)).upsertDay(USER, 10L, new DayUpsertRequest(date, 1000, null, null));
@@ -1045,7 +1045,7 @@ class ChallengeServiceTest {
         ch.cancelForMissingInput();
         LocalDate date = LocalDate.of(2026, 6, 3);
         ChallengeDay existing = ChallengeDay.of(ch, date, 0, DayStatus.SUCCESS, ch.getDailyLimit());
-        when(challengeRepository.findById(10L)).thenReturn(Optional.of(ch));
+        when(challengeRepository.findByIdForUpdate(10L)).thenReturn(Optional.of(ch));
         when(challengeDayRepository.findByChallenge_IdAndDayDate(10L, date)).thenReturn(Optional.of(existing));
 
         serviceAt(LocalDate.of(2026, 6, 10))

--- a/src/test/java/Hampouch/server/domain/expense/ExpenseTransactionIntegrationTest.java
+++ b/src/test/java/Hampouch/server/domain/expense/ExpenseTransactionIntegrationTest.java
@@ -3,12 +3,14 @@ package Hampouch.server.domain.expense;
 import Hampouch.server.domain.challenge.entity.Challenge;
 import Hampouch.server.domain.challenge.entity.ChallengeStatus;
 import Hampouch.server.domain.challenge.repository.ChallengeRepository;
+import Hampouch.server.domain.challenge.service.ChallengeService;
 import Hampouch.server.domain.expense.dto.ExpenseCreateRequest;
 import Hampouch.server.domain.expense.dto.ExpenseCreateResponse;
 import Hampouch.server.domain.expense.dto.NoSpendRecordRequest;
 import Hampouch.server.domain.expense.entity.*;
 import Hampouch.server.domain.expense.repository.ExpenseRepository;
 import Hampouch.server.domain.expense.repository.NoSpendDayRepository;
+import Hampouch.server.domain.expense.service.ExpenseDateLockQuery;
 import Hampouch.server.domain.expense.service.ExpenseService;
 import Hampouch.server.domain.user.entity.User;
 import Hampouch.server.domain.user.repository.UserRepository;
@@ -18,19 +20,27 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.concurrent.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
+@Import(ExpenseTransactionIntegrationTest.PausingLockQueryConfig.class)
 class ExpenseTransactionIntegrationTest {
 
     @Autowired
     ExpenseService expenseService;
+    @Autowired
+    ChallengeService challengeService;
     @Autowired
     ExpenseRepository expenseRepository;
     @Autowired
@@ -39,6 +49,8 @@ class ExpenseTransactionIntegrationTest {
     UserRepository userRepository;
     @Autowired
     ChallengeRepository challengeRepository;
+    @Autowired
+    PausingExpenseDateLockQuery pausingExpenseDateLockQuery;
 
     @Test
     @DisplayName("무지출 기록과 지출 생성·수정·삭제가 끝날 때마다 DB를 다시 조회해도 행 상태와 마지막 기록일이 유지된다")
@@ -84,6 +96,75 @@ class ExpenseTransactionIntegrationTest {
     }
 
     @Test
+    @DisplayName("진행 중 챌린지가 있어도, 그 챌린지 기간 밖이면서 최종 종료된 챌린지 기간에 속하지 않는 날짜에는 지출을 생성할 수 있다")
+    void activeChallengeDoesNotRestrictExpenseDate() {
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        LocalDate outsideDate = today.minusDays(10);
+        User user = userRepository.save(User.createLocalUser(
+                "expense-active-challenge@hampouch.test", "encoded", "진행중범위밖"));
+        Long userId = user.getId();
+        challengeRepository.save(Challenge.builder()
+                .userId(userId).durationDays(7).startDate(today)
+                .budgetTotal(70000).dailyLimit(10000).build());
+
+        ExpenseCreateResponse created = expenseService.create(userId, request("과거 지출", 8000, outsideDate));
+
+        Expense saved = expenseRepository.findById(created.expenseId()).orElseThrow();
+        assertThat(saved.getExpenseDate()).isEqualTo(outsideDate);
+    }
+
+    @Test
+    @DisplayName("지출 수정이 챌린지 행 락을 획득한 뒤에는 최종 종료가 수정 트랜잭션 종료까지 기다린다")
+    void closeWaitsForExpenseMutationThatAlreadyCheckedLock() throws Exception {
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        LocalDate expenseDate = today.minusDays(3);
+        User user = userRepository.save(User.createLocalUser(
+                "expense-close-race@hampouch.test", "encoded", "종료경쟁"));
+        Long userId = user.getId();
+        Expense expense = expenseRepository.save(Expense.of(
+                "점심", 8000, ExpenseCategory.CAFE, ExpenseEmotion.STRESS, expenseDate, user));
+        Challenge challenge = Challenge.builder()
+                .userId(userId).durationDays(7).startDate(today.minusDays(7))
+                .budgetTotal(70000).dailyLimit(10000).build();
+        challenge.applyResult(ChallengeStatus.SUCCESS);
+        challengeRepository.save(challenge);
+
+        pausingExpenseDateLockQuery.pauseNextCheck();
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<?> updateFuture = executor.submit(() ->
+                    expenseService.update(userId, expense.getId(), request("저녁", 99000, expenseDate)));
+            assertThat(pausingExpenseDateLockQuery.awaitCheck()).isTrue();
+
+            CountDownLatch closeStarted = new CountDownLatch(1);
+            Future<?> closeFuture = executor.submit(() -> {
+                closeStarted.countDown();
+                challengeService.close(userId, challenge.getId());
+            });
+            assertThat(closeStarted.await(5, TimeUnit.SECONDS)).isTrue();
+            boolean closeWasBlocked;
+            try {
+                closeFuture.get(500, TimeUnit.MILLISECONDS);
+                closeWasBlocked = false;
+            } catch (TimeoutException expected) {
+                closeWasBlocked = true;
+            } finally {
+                pausingExpenseDateLockQuery.release();
+            }
+
+            updateFuture.get(5, TimeUnit.SECONDS);
+            closeFuture.get(5, TimeUnit.SECONDS);
+
+            assertThat(closeWasBlocked).isTrue();
+            assertThat(expenseRepository.findById(expense.getId()).orElseThrow().getPrice()).isEqualTo(99000);
+            assertThat(challengeRepository.findById(challenge.getId()).orElseThrow().isClosed()).isTrue();
+        } finally {
+            pausingExpenseDateLockQuery.release();
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
     @DisplayName("최종 종료된 챌린지 기간의 지출은 수정·삭제와 무지출 기록이 모두 409로 막히고, 막힌 뒤 DB의 지출 행도 그대로다")
     void closedChallengePeriodBlocksExpenseChanges() {
         LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
@@ -91,8 +172,6 @@ class ExpenseTransactionIntegrationTest {
         User user = userRepository.save(User.createLocalUser(
                 "expense-closed-challenge@hampouch.test", "encoded", "종료잠금"));
         Long userId = user.getId();
-        // 지출은 서비스가 아니라 리포지토리로 심는다 — 다른 통합 테스트가 숫자 유저 id를 직접 박아 심은
-        // 진행 중 챌린지와 이 유저의 발급 id가 겹칠 수 있어서, 생성 경로의 기간 검증에 결과가 좌우된다
         Expense seeded = expenseRepository.save(Expense.of(
                 "점심", 8000, ExpenseCategory.CAFE, ExpenseEmotion.STRESS, lockedDate, user));
 
@@ -134,5 +213,58 @@ class ExpenseTransactionIntegrationTest {
                 ExpenseEmotion.STRESS,
                 null,
                 date);
+    }
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class PausingLockQueryConfig {
+
+        @Bean
+        @Primary
+        PausingExpenseDateLockQuery pausingExpenseDateLockQuery(ChallengeRepository challengeRepository) {
+            return new PausingExpenseDateLockQuery(challengeRepository);
+        }
+    }
+
+    static class PausingExpenseDateLockQuery implements ExpenseDateLockQuery {
+
+        private final ChallengeRepository delegate;
+        private volatile CountDownLatch checked = new CountDownLatch(0);
+        private volatile CountDownLatch release = new CountDownLatch(0);
+
+        PausingExpenseDateLockQuery(ChallengeRepository delegate) {
+            this.delegate = delegate;
+        }
+
+        synchronized void pauseNextCheck() {
+            checked = new CountDownLatch(1);
+            release = new CountDownLatch(1);
+        }
+
+        boolean awaitCheck() throws InterruptedException {
+            return checked.await(5, TimeUnit.SECONDS);
+        }
+
+        void release() {
+            release.countDown();
+        }
+
+        @Override
+        public boolean isExpenseChangeProhibited(Long userId, LocalDate date) {
+            boolean changeProhibited = delegate.isExpenseChangeProhibited(userId, date);
+            CountDownLatch currentChecked = checked;
+            CountDownLatch currentRelease = release;
+            if (currentChecked.getCount() > 0) {
+                currentChecked.countDown();
+                try {
+                    if (!currentRelease.await(5, TimeUnit.SECONDS)) {
+                        throw new IllegalStateException("잠금 확인 일시정지가 제한 시간 안에 해제되지 않았습니다.");
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException("잠금 확인 일시정지가 중단됐습니다.", e);
+                }
+            }
+            return changeProhibited;
+        }
     }
 }

--- a/src/test/java/Hampouch/server/domain/expense/ExpenseTransactionIntegrationTest.java
+++ b/src/test/java/Hampouch/server/domain/expense/ExpenseTransactionIntegrationTest.java
@@ -1,5 +1,8 @@
 package Hampouch.server.domain.expense;
 
+import Hampouch.server.domain.challenge.entity.Challenge;
+import Hampouch.server.domain.challenge.entity.ChallengeStatus;
+import Hampouch.server.domain.challenge.repository.ChallengeRepository;
 import Hampouch.server.domain.expense.dto.ExpenseCreateRequest;
 import Hampouch.server.domain.expense.dto.ExpenseCreateResponse;
 import Hampouch.server.domain.expense.dto.NoSpendRecordRequest;
@@ -9,15 +12,19 @@ import Hampouch.server.domain.expense.repository.NoSpendDayRepository;
 import Hampouch.server.domain.expense.service.ExpenseService;
 import Hampouch.server.domain.user.entity.User;
 import Hampouch.server.domain.user.repository.UserRepository;
+import Hampouch.server.global.common.exception.CustomException;
+import Hampouch.server.global.common.exception.domain.ExpenseErrorCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 class ExpenseTransactionIntegrationTest {
@@ -30,6 +37,8 @@ class ExpenseTransactionIntegrationTest {
     NoSpendDayRepository noSpendDayRepository;
     @Autowired
     UserRepository userRepository;
+    @Autowired
+    ChallengeRepository challengeRepository;
 
     @Test
     @DisplayName("무지출 기록과 지출 생성·수정·삭제가 끝날 때마다 DB를 다시 조회해도 행 상태와 마지막 기록일이 유지된다")
@@ -72,6 +81,48 @@ class ExpenseTransactionIntegrationTest {
         assertThat(deleted.getStatus()).isEqualTo(ExpenseStatus.DELETED);
         assertThat(userRepository.findById(userId).orElseThrow().getLastUpdated())
                 .isEqualTo(previousNoSpendDate);
+    }
+
+    @Test
+    @DisplayName("최종 종료된 챌린지 기간의 지출은 수정·삭제와 무지출 기록이 모두 409로 막히고, 막힌 뒤 DB의 지출 행도 그대로다")
+    void closedChallengePeriodBlocksExpenseChanges() {
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        LocalDate lockedDate = today.minusDays(3);
+        User user = userRepository.save(User.createLocalUser(
+                "expense-closed-challenge@hampouch.test", "encoded", "종료잠금"));
+        Long userId = user.getId();
+        // 지출은 서비스가 아니라 리포지토리로 심는다 — 다른 통합 테스트가 숫자 유저 id를 직접 박아 심은
+        // 진행 중 챌린지와 이 유저의 발급 id가 겹칠 수 있어서, 생성 경로의 기간 검증에 결과가 좌우된다
+        Expense seeded = expenseRepository.save(Expense.of(
+                "점심", 8000, ExpenseCategory.CAFE, ExpenseEmotion.STRESS, lockedDate, user));
+
+        // 잠금은 지출을 넣은 뒤에 걸린다 — 기간 중에 기록하고 끝난 뒤 종료를 누르는 실제 순서
+        Challenge challenge = Challenge.builder()
+                .userId(userId).durationDays(7).startDate(today.minusDays(7))
+                .budgetTotal(70000).dailyLimit(10000).build();
+        challenge.applyResult(ChallengeStatus.SUCCESS);
+        challenge.close(LocalDateTime.now());
+        challengeRepository.save(challenge);
+
+        assertThatThrownBy(() -> expenseService.update(userId, seeded.getId(), request("저녁", 99000, lockedDate)))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ExpenseErrorCode.EXPENSE_CHALLENGE_CLOSED);
+        assertThatThrownBy(() -> expenseService.delete(userId, seeded.getId()))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ExpenseErrorCode.EXPENSE_CHALLENGE_CLOSED);
+        assertThatThrownBy(() -> expenseService.recordNoSpend(userId, new NoSpendRecordRequest(lockedDate)))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ExpenseErrorCode.EXPENSE_CHALLENGE_CLOSED);
+
+        Expense untouched = expenseRepository.findById(seeded.getId()).orElseThrow();
+        assertThat(untouched.getName()).isEqualTo("점심");
+        assertThat(untouched.getPrice()).isEqualTo(8000);
+        assertThat(untouched.getStatus()).isEqualTo(ExpenseStatus.ACTIVE);
+        assertThat(noSpendDayRepository.existsByUser_IdAndRecordDate(userId, lockedDate)).isFalse();
+
+        // 잠긴 것은 그 기간뿐이라 기간 밖 날짜의 무지출 기록은 그대로 저장된다
+        expenseService.recordNoSpend(userId, new NoSpendRecordRequest(today));
+        assertThat(noSpendDayRepository.existsByUser_IdAndRecordDate(userId, today)).isTrue();
     }
 
     private ExpenseCreateRequest request(String name, int price, LocalDate date) {

--- a/src/test/java/Hampouch/server/domain/expense/service/ExpenseServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/expense/service/ExpenseServiceTest.java
@@ -1,8 +1,5 @@
 package Hampouch.server.domain.expense.service;
 
-import Hampouch.server.domain.challenge.entity.Challenge;
-import Hampouch.server.domain.challenge.entity.ChallengeStatus;
-import Hampouch.server.domain.challenge.repository.ChallengeRepository;
 import Hampouch.server.domain.expense.dto.*;
 import Hampouch.server.domain.expense.entity.*;
 import Hampouch.server.domain.expense.repository.ExpenseDailyTotal;
@@ -47,7 +44,7 @@ class ExpenseServiceTest {
     @Mock
     NoSpendDayRepository noSpendDayRepository;
     @Mock
-    ChallengeRepository challengeRepository;
+    ExpenseDateLockQuery expenseDateLockQuery;
     @Mock
     UserRepository userRepository;
 
@@ -58,7 +55,7 @@ class ExpenseServiceTest {
     /** 오늘을 직접 고정해야 하는 케이스(주간/월간 요약의 dailyAverage 계산)용 */
     private ExpenseService serviceAt(LocalDate today) {
         Clock clock = Clock.fixed(today.atTime(12, 0).atZone(SEOUL).toInstant(), SEOUL);
-        return new ExpenseService(expenseRepository, noSpendDayRepository, challengeRepository, userRepository, clock);
+        return new ExpenseService(expenseRepository, noSpendDayRepository, expenseDateLockQuery, userRepository, clock);
     }
 
     // ---------- create ----------
@@ -101,36 +98,13 @@ class ExpenseServiceTest {
     }
 
     @Test
-    @DisplayName("진행 중 챌린지 기간 밖 날짜로 생성하면 400(EXPENSE_DATE_OUT_OF_CHALLENGE_PERIOD)을 던진다")
-    void create_rejectsDateOutsideChallengePeriod() {
-        Challenge ch = Challenge.builder()
-                .userId(OWNER)
-                .durationDays(14)
-                .startDate(LocalDate.of(2026, 6, 1))
-                .budgetTotal(280000)
-                .dailyLimit(20000)
-                .resetByPayday(false)
-                .paydayDay(null)
-                .build();
-        when(challengeRepository.findByUserIdAndStatus(OWNER, ChallengeStatus.IN_PROGRESS)).thenReturn(Optional.of(ch));
-
-        var req = new ExpenseCreateRequest("스타벅스", 5000, ExpenseCategory.CAFE, null,
-                ExpenseEmotion.STRESS, null, LocalDate.of(2026, 6, 20)); // 06-01~06-14 밖
-
-        assertThatThrownBy(() -> service().create(OWNER, req))
-                .isInstanceOf(CustomException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ExpenseErrorCode.EXPENSE_DATE_OUT_OF_CHALLENGE_PERIOD);
-    }
-
-    @Test
-    @DisplayName("진행 중인 챌린지가 없으면 날짜 범위 검증 없이 자유롭게 생성된다")
-    void create_allowsAnyDateWhenNoActiveChallenge() {
-        when(challengeRepository.findByUserIdAndStatus(OWNER, ChallengeStatus.IN_PROGRESS)).thenReturn(Optional.empty());
+    @DisplayName("최종 종료된 챌린지 기간이 아닌 과거 날짜에는 지출을 생성할 수 있다")
+    void create_allowsUnlockedPastDate() {
         when(userRepository.getReferenceById(OWNER)).thenReturn(user(OWNER));
         when(expenseRepository.save(any(Expense.class))).thenAnswer(inv -> inv.getArgument(0));
 
         var req = new ExpenseCreateRequest("스타벅스", 5000, ExpenseCategory.CAFE, null,
-                ExpenseEmotion.STRESS, null, LocalDate.of(2020, 1, 1)); // 챌린지가 있었다면 당연히 밖일 날짜, 없으면 막히지 않아야 함
+                ExpenseEmotion.STRESS, null, LocalDate.of(2020, 1, 1));
 
         assertThat(service().create(OWNER, req)).isNotNull();
     }
@@ -263,8 +237,6 @@ class ExpenseServiceTest {
         verify(noSpendDayRepository, never()).save(any());
         verifyNoInteractions(noSpendDayRepository);
         verifyNoInteractions(userRepository);
-        // 챌린지 조회는 최종 종료 잠금(#50) 하나만 나가고, 진행 중 기간 검증은 여전히 안 탄다
-        verify(challengeRepository, never()).findByUserIdAndStatus(any(), any());
     }
 
     @Test
@@ -278,12 +250,11 @@ class ExpenseServiceTest {
 
         verify(noSpendDayRepository, never()).save(any());
         verifyNoInteractions(userRepository);
-        verify(challengeRepository, never()).findByUserIdAndStatus(any(), any());
     }
 
     @Test
-    @DisplayName("챌린지 기간 검증 없이 빈 날짜에 '오늘은 안 썼어요' 기록을 저장한다")
-    void recordNoSpend_savesEmptyDateOutsideChallengePeriod() {
+    @DisplayName("최종 종료된 챌린지 기간이 아니고 지출도 없는 날짜에는 '오늘은 안 썼어요'를 저장할 수 있다")
+    void recordNoSpend_savesUnlockedEmptyDate() {
         LocalDate outside = LocalDate.of(2026, 6, 20);
         when(expenseRepository.existsByUser_IdAndExpenseDateAndStatus(OWNER, outside, ExpenseStatus.ACTIVE))
                 .thenReturn(false);
@@ -297,7 +268,6 @@ class ExpenseServiceTest {
         verify(noSpendDayRepository).save(captor.capture());
         assertThat(captor.getValue().getRecordDate()).isEqualTo(outside);
         assertThat(user.getLastUpdated()).isEqualTo(outside);
-        verify(challengeRepository, never()).findByUserIdAndStatus(any(), any());
     }
 
     // ---------- lastUpdated ----------
@@ -414,7 +384,7 @@ class ExpenseServiceTest {
     @DisplayName("최종 종료된 챌린지 기간의 날짜로 지출을 생성하면 409(EXPENSE_CHALLENGE_CLOSED)로 거절한다 — 수정·삭제만 막으면 새로 넣는 경로로 그 기간 기록이 바뀐다")
     void create_rejectsDateLockedByClosedChallenge() {
         LocalDate lockedDate = LocalDate.of(2026, 6, 3);
-        when(challengeRepository.isDateLockedByClosedChallenge(OWNER, lockedDate)).thenReturn(true);
+        when(expenseDateLockQuery.isExpenseChangeProhibited(OWNER, lockedDate)).thenReturn(true);
 
         var req = new ExpenseCreateRequest("스타벅스", 5000, ExpenseCategory.CAFE, null,
                 ExpenseEmotion.STRESS, null, lockedDate);
@@ -431,7 +401,7 @@ class ExpenseServiceTest {
         LocalDate lockedDate = LocalDate.of(2026, 6, 3);
         Expense expense = Expense.of("스타벅스", 5000, ExpenseCategory.CAFE, ExpenseEmotion.STRESS, lockedDate, user(OWNER));
         when(expenseRepository.findByIdAndStatus(1L, ExpenseStatus.ACTIVE)).thenReturn(Optional.of(expense));
-        when(challengeRepository.isDateLockedByClosedChallenge(OWNER, lockedDate)).thenReturn(true);
+        when(expenseDateLockQuery.isExpenseChangeProhibited(OWNER, lockedDate)).thenReturn(true);
 
         var req = new ExpenseCreateRequest("스타벅스", 99000, ExpenseCategory.CAFE, null,
                 ExpenseEmotion.STRESS, null, lockedDate);
@@ -449,8 +419,7 @@ class ExpenseServiceTest {
         LocalDate freeDate = LocalDate.of(2026, 7, 10);
         Expense expense = Expense.of("스타벅스", 5000, ExpenseCategory.CAFE, ExpenseEmotion.STRESS, lockedDate, user(OWNER));
         when(expenseRepository.findByIdAndStatus(1L, ExpenseStatus.ACTIVE)).thenReturn(Optional.of(expense));
-        when(challengeRepository.isDateLockedByClosedChallenge(OWNER, lockedDate)).thenReturn(true);
-        when(challengeRepository.isDateLockedByClosedChallenge(OWNER, freeDate)).thenReturn(false);
+        when(expenseDateLockQuery.isExpenseChangeProhibited(OWNER, lockedDate)).thenReturn(true);
 
         var req = new ExpenseCreateRequest("스타벅스", 5000, ExpenseCategory.CAFE, null,
                 ExpenseEmotion.STRESS, null, freeDate);
@@ -467,7 +436,7 @@ class ExpenseServiceTest {
         LocalDate lockedDate = LocalDate.of(2026, 6, 3);
         Expense expense = Expense.of("스타벅스", 5000, ExpenseCategory.CAFE, ExpenseEmotion.STRESS, lockedDate, user(OWNER));
         when(expenseRepository.findByIdAndStatus(1L, ExpenseStatus.ACTIVE)).thenReturn(Optional.of(expense));
-        when(challengeRepository.isDateLockedByClosedChallenge(OWNER, lockedDate)).thenReturn(true);
+        when(expenseDateLockQuery.isExpenseChangeProhibited(OWNER, lockedDate)).thenReturn(true);
 
         assertThatThrownBy(() -> service().delete(OWNER, 1L))
                 .isInstanceOf(CustomException.class)
@@ -479,7 +448,7 @@ class ExpenseServiceTest {
     @DisplayName("최종 종료된 챌린지 기간의 날짜에 '오늘은 안 썼어요'를 기록하려 해도 409로 거절한다 — 그 날짜에 기록이 있었는지가 바뀌기 때문")
     void recordNoSpend_rejectsWhenDateLocked() {
         LocalDate lockedDate = LocalDate.of(2026, 6, 3);
-        when(challengeRepository.isDateLockedByClosedChallenge(OWNER, lockedDate)).thenReturn(true);
+        when(expenseDateLockQuery.isExpenseChangeProhibited(OWNER, lockedDate)).thenReturn(true);
 
         assertThatThrownBy(() -> service().recordNoSpend(OWNER, new NoSpendRecordRequest(lockedDate)))
                 .isInstanceOf(CustomException.class)
@@ -601,35 +570,10 @@ class ExpenseServiceTest {
     }
 
     @Test
-    @DisplayName("진행 중 챌린지 기간 밖 날짜로 수정하면 400(EXPENSE_DATE_OUT_OF_CHALLENGE_PERIOD)을 던진다")
-    void update_rejectsDateOutsideChallengePeriod() {
+    @DisplayName("최종 종료된 챌린지 기간이 아닌 과거 날짜로 지출을 옮길 수 있다")
+    void update_allowsUnlockedPastDate() {
         Expense expense = expenseOf(OWNER, ExpenseCategory.CAFE, null, ExpenseEmotion.STRESS, null);
         when(expenseRepository.findByIdAndStatus(1L, ExpenseStatus.ACTIVE)).thenReturn(Optional.of(expense));
-        Challenge ch = Challenge.builder()
-                .userId(OWNER)
-                .durationDays(14)
-                .startDate(LocalDate.of(2026, 6, 1))
-                .budgetTotal(280000)
-                .dailyLimit(20000)
-                .resetByPayday(false)
-                .paydayDay(null)
-                .build();
-        when(challengeRepository.findByUserIdAndStatus(OWNER, ChallengeStatus.IN_PROGRESS)).thenReturn(Optional.of(ch));
-
-        var req = new ExpenseCreateRequest("스타벅스", 5000, ExpenseCategory.CAFE, null,
-                ExpenseEmotion.STRESS, null, LocalDate.of(2026, 6, 20)); // 06-01~06-14 밖
-
-        assertThatThrownBy(() -> service().update(OWNER, 1L, req))
-                .isInstanceOf(CustomException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ExpenseErrorCode.EXPENSE_DATE_OUT_OF_CHALLENGE_PERIOD);
-    }
-
-    @Test
-    @DisplayName("진행 중인 챌린지가 없으면 오늘/어제 범위 밖 날짜로 수정해도 막지 않는다 — create와 대칭 케이스")
-    void update_allowsAnyDateWhenNoActiveChallenge() {
-        Expense expense = expenseOf(OWNER, ExpenseCategory.CAFE, null, ExpenseEmotion.STRESS, null);
-        when(expenseRepository.findByIdAndStatus(1L, ExpenseStatus.ACTIVE)).thenReturn(Optional.of(expense));
-        when(challengeRepository.findByUserIdAndStatus(OWNER, ChallengeStatus.IN_PROGRESS)).thenReturn(Optional.empty());
 
         LocalDate today = LocalDate.of(2026, 6, 6);
         var req = new ExpenseCreateRequest("스타벅스", 5000, ExpenseCategory.CAFE, null,
@@ -639,17 +583,22 @@ class ExpenseServiceTest {
     }
 
     @Test
-    @DisplayName("날짜를 바꾸지 않고 다른 필드만 수정하면 챌린지 기간 검증을 아예 건너뛴다 (날짜가 실제로 바뀔 때만 검증)")
-    void update_skipsChallengePeriodValidationWhenDateUnchanged() {
-        Expense expense = expenseOf(OWNER, ExpenseCategory.CAFE, null, ExpenseEmotion.STRESS, null); // 날짜: 2026-06-05
+    @DisplayName("지출 날짜 변경 시 챌린지 행 락 획득 순서를 데드락 방지를 위해 날짜순으로 고정한다")
+    void update_acquiresChallengeRowLocksInDateOrder() {
+        LocalDate oldDate = LocalDate.of(2026, 7, 10);
+        LocalDate newDate = LocalDate.of(2026, 6, 3);
+        User user = user(OWNER);
+        user.updateLastUpdated(LocalDate.of(2026, 8, 1));
+        Expense expense = Expense.of("스타벅스", 5000, ExpenseCategory.CAFE, ExpenseEmotion.STRESS, oldDate, user);
         when(expenseRepository.findByIdAndStatus(1L, ExpenseStatus.ACTIVE)).thenReturn(Optional.of(expense));
 
-        var req = new ExpenseCreateRequest("스타벅스 아메리카노", 6000, ExpenseCategory.CAFE, null,
-                ExpenseEmotion.STRESS, null, LocalDate.of(2026, 6, 5));
+        service().update(OWNER, 1L, new ExpenseCreateRequest(
+                "스타벅스", 5000, ExpenseCategory.CAFE, null,
+                ExpenseEmotion.STRESS, null, newDate));
 
-        service().update(OWNER, 1L, req);
-
-        verify(challengeRepository, never()).findByUserIdAndStatus(any(), any());
+        var order = inOrder(expenseDateLockQuery);
+        order.verify(expenseDateLockQuery).isExpenseChangeProhibited(OWNER, newDate);
+        order.verify(expenseDateLockQuery).isExpenseChangeProhibited(OWNER, oldDate);
     }
 
     @Test

--- a/src/test/java/Hampouch/server/domain/expense/service/ExpenseServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/expense/service/ExpenseServiceTest.java
@@ -262,7 +262,9 @@ class ExpenseServiceTest {
 
         verify(noSpendDayRepository, never()).save(any());
         verifyNoInteractions(noSpendDayRepository);
-        verifyNoInteractions(challengeRepository, userRepository);
+        verifyNoInteractions(userRepository);
+        // 챌린지 조회는 최종 종료 잠금(#50) 하나만 나가고, 진행 중 기간 검증은 여전히 안 탄다
+        verify(challengeRepository, never()).findByUserIdAndStatus(any(), any());
     }
 
     @Test
@@ -275,7 +277,8 @@ class ExpenseServiceTest {
         service().recordNoSpend(OWNER, new NoSpendRecordRequest(TODAY));
 
         verify(noSpendDayRepository, never()).save(any());
-        verifyNoInteractions(challengeRepository, userRepository);
+        verifyNoInteractions(userRepository);
+        verify(challengeRepository, never()).findByUserIdAndStatus(any(), any());
     }
 
     @Test
@@ -294,7 +297,7 @@ class ExpenseServiceTest {
         verify(noSpendDayRepository).save(captor.capture());
         assertThat(captor.getValue().getRecordDate()).isEqualTo(outside);
         assertThat(user.getLastUpdated()).isEqualTo(outside);
-        verifyNoInteractions(challengeRepository);
+        verify(challengeRepository, never()).findByUserIdAndStatus(any(), any());
     }
 
     // ---------- lastUpdated ----------
@@ -403,6 +406,85 @@ class ExpenseServiceTest {
         service().delete(OWNER, 1L);
 
         assertThat(user.getLastUpdated()).isEqualTo(remainingExpenseDate);
+    }
+
+    // ---------- 최종 종료된 챌린지 기간 잠금 (#50) ----------
+
+    @Test
+    @DisplayName("최종 종료된 챌린지 기간의 날짜로 지출을 생성하면 409(EXPENSE_CHALLENGE_CLOSED)로 거절한다 — 수정·삭제만 막으면 새로 넣는 경로로 그 기간 기록이 바뀐다")
+    void create_rejectsDateLockedByClosedChallenge() {
+        LocalDate lockedDate = LocalDate.of(2026, 6, 3);
+        when(challengeRepository.isDateLockedByClosedChallenge(OWNER, lockedDate)).thenReturn(true);
+
+        var req = new ExpenseCreateRequest("스타벅스", 5000, ExpenseCategory.CAFE, null,
+                ExpenseEmotion.STRESS, null, lockedDate);
+
+        assertThatThrownBy(() -> service().create(OWNER, req))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ExpenseErrorCode.EXPENSE_CHALLENGE_CLOSED);
+        verify(expenseRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("최종 종료된 챌린지 기간의 지출을 금액만 고치려 해도 409(EXPENSE_CHALLENGE_CLOSED)로 거절하고 원래 금액을 유지한다")
+    void update_rejectsWhenDateLocked() {
+        LocalDate lockedDate = LocalDate.of(2026, 6, 3);
+        Expense expense = Expense.of("스타벅스", 5000, ExpenseCategory.CAFE, ExpenseEmotion.STRESS, lockedDate, user(OWNER));
+        when(expenseRepository.findByIdAndStatus(1L, ExpenseStatus.ACTIVE)).thenReturn(Optional.of(expense));
+        when(challengeRepository.isDateLockedByClosedChallenge(OWNER, lockedDate)).thenReturn(true);
+
+        var req = new ExpenseCreateRequest("스타벅스", 99000, ExpenseCategory.CAFE, null,
+                ExpenseEmotion.STRESS, null, lockedDate);
+
+        assertThatThrownBy(() -> service().update(OWNER, 1L, req))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ExpenseErrorCode.EXPENSE_CHALLENGE_CLOSED);
+        assertThat(expense.getPrice()).isEqualTo(5000);
+    }
+
+    @Test
+    @DisplayName("잠긴 기간의 지출을 기간 밖 날짜로 옮기는 것도 409로 거절한다 — 옮겨 가는 날짜만 보면 빼내기로 그 기간 합계가 바뀐다")
+    void update_rejectsWhenMovingExpenseOutOfLockedPeriod() {
+        LocalDate lockedDate = LocalDate.of(2026, 6, 3);
+        LocalDate freeDate = LocalDate.of(2026, 7, 10);
+        Expense expense = Expense.of("스타벅스", 5000, ExpenseCategory.CAFE, ExpenseEmotion.STRESS, lockedDate, user(OWNER));
+        when(expenseRepository.findByIdAndStatus(1L, ExpenseStatus.ACTIVE)).thenReturn(Optional.of(expense));
+        when(challengeRepository.isDateLockedByClosedChallenge(OWNER, lockedDate)).thenReturn(true);
+        when(challengeRepository.isDateLockedByClosedChallenge(OWNER, freeDate)).thenReturn(false);
+
+        var req = new ExpenseCreateRequest("스타벅스", 5000, ExpenseCategory.CAFE, null,
+                ExpenseEmotion.STRESS, null, freeDate);
+
+        assertThatThrownBy(() -> service().update(OWNER, 1L, req))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ExpenseErrorCode.EXPENSE_CHALLENGE_CLOSED);
+        assertThat(expense.getExpenseDate()).isEqualTo(lockedDate);
+    }
+
+    @Test
+    @DisplayName("최종 종료된 챌린지 기간의 지출은 삭제도 409로 거절한다 — 소프트 삭제라 행은 남지만 유저에겐 기록이 사라진 것과 같기 때문")
+    void delete_rejectsWhenDateLocked() {
+        LocalDate lockedDate = LocalDate.of(2026, 6, 3);
+        Expense expense = Expense.of("스타벅스", 5000, ExpenseCategory.CAFE, ExpenseEmotion.STRESS, lockedDate, user(OWNER));
+        when(expenseRepository.findByIdAndStatus(1L, ExpenseStatus.ACTIVE)).thenReturn(Optional.of(expense));
+        when(challengeRepository.isDateLockedByClosedChallenge(OWNER, lockedDate)).thenReturn(true);
+
+        assertThatThrownBy(() -> service().delete(OWNER, 1L))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ExpenseErrorCode.EXPENSE_CHALLENGE_CLOSED);
+        assertThat(expense.getStatus()).isEqualTo(ExpenseStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("최종 종료된 챌린지 기간의 날짜에 '오늘은 안 썼어요'를 기록하려 해도 409로 거절한다 — 그 날짜에 기록이 있었는지가 바뀌기 때문")
+    void recordNoSpend_rejectsWhenDateLocked() {
+        LocalDate lockedDate = LocalDate.of(2026, 6, 3);
+        when(challengeRepository.isDateLockedByClosedChallenge(OWNER, lockedDate)).thenReturn(true);
+
+        assertThatThrownBy(() -> service().recordNoSpend(OWNER, new NoSpendRecordRequest(lockedDate)))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ExpenseErrorCode.EXPENSE_CHALLENGE_CLOSED);
+        verify(noSpendDayRepository, never()).save(any());
     }
 
     // ---------- getDetail ----------


### PR DESCRIPTION
## 📎연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) closes #[issue number]

- close: #50

## 📄 작업 내용 요약
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.

- 최종 종료 엔드포인트 신설 — `POST /api/challenges/{id}/close`. 결과 팝업의 [챌린지 종료]에 대응하는 상태 전이라 200(새 리소스가 아니라 잠금 상태만 바뀜).
- `Challenge.closedAt`(LocalDateTime) 추가 — null이면 미종료. status(성패)와 다른 축이라, 기간이 끝나 SUCCESS로 확정된 뒤에도 이 값이 채워지기 전까지는 지출을 마저 고칠 수 있다. `ResultResponse`에 `closedAt` 필드 추가(클라가 이 값으로 종료 팝업 노출을 판단).
- 결과 화면을 한 번도 안 연 채 종료를 눌러도 되도록, `close`가 만료 미확정분을 그 자리에서 확정한다. 종료를 안 눌러도 다음 챌린지는 시작 가능(생성 경로가 만료분을 먼저 확정).
- 최종 종료 뒤 그 챌린지 기간의 기록 잠금 — `POST /{id}/days` 및 해당 기간 날짜의 지출 생성·수정·삭제·무지출 기록을 409로 거절.
- 에러 코드 신설: `CHALLENGE_ALREADY_CLOSED`·`CHALLENGE_NOT_CLOSABLE`(challenge) / `EXPENSE_CHALLENGE_CLOSED`(expense).
- 테스트: 엔티티·서비스·컨트롤러 단위 + 챌린지·지출 통합. 전체 603건 통과.

## 👀 중요 변경 사항
> API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요

- `ResultResponse`에 `closedAt` 필드가 추가됩니다(안드 계약 변경 — 안드에는 별도 공유 예정).
- 지출 잠금이 expense 도메인에도 걸립니다 — `ExpenseService`의 create·update·delete·recordNoSpend가 `ChallengeRepository.isDateLockedByClosedChallenge`로 최종 종료된 기간을 막습니다. 지출→챌린지 참조가 새로 생기는 지점.
- 종료 후 지출 잠금 "범위"(수정만 vs 생성·삭제도)는 PM 확인 중입니다 — 현재는 생성·삭제·무지출까지 막아 뒀고, "수정만"으로 확정되면 expense 쪽 create·delete 가드를 걷어냅니다.

## 🔖 Uncompleted Tasks
> 후속 작업 예정인 사항이 있다면 작성해주세요.

- 노션 API 명세 challenge 11(close) 행 추가 및 challenge 4·5·무지출 블록 갱신 — 원고 준비됨, 붙여넣기 예정.

## 📢 To Reviewers
> Reviewer가 주로 확인해주었으면 하는 부분을 적어주세요.

- 지출 도메인 잠금(`ExpenseService`)이 챌린지 최종 종료 상태를 조회하는 방향의 결합이 괜찮은지 봐 주세요(#64 도메인 경계 논의와 맞닿음).
- 포기·자동 취소(VOID) 챌린지를 close 대상에서 제외(`CHALLENGE_NOT_CLOSABLE`)한 판단이 맞는지 — 재계산되지 않는 결과라 얼릴 대상이 없다고 봤습니다.
