### PR TITLE
chore(infra): Sentry 예외 추적 연동 (스타터 + logback 이벤트 수집) (#106) [base: develop]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,10 @@ dependencies {
 
 	//actuator - 운영 health check용
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+	//sentry - 운영 미처리 예외 추적. Boot 4 전용 스타터이고, sentry-logback 은 스타터에 안 딸려 와서 명시(log.error 를 이벤트로 수집)
+	implementation 'io.sentry:sentry-spring-boot-4-starter:8.52.0'
+	implementation 'io.sentry:sentry-logback:8.52.0'
 }
 
 tasks.named('test') {

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -20,3 +20,7 @@ jwt:
   secret: ${JWT_SECRET}
   access-token-expires-in-ms: ${JWT_ACCESS_TOKEN_EXPIRES_IN_MS}
   refresh-token-expires-in-ms: ${JWT_REFRESH_TOKEN_EXPIRES_IN_MS}
+
+sentry:
+  # DSN 미주입이면 SDK가 스스로 비활성 — 이 값 없이도 부팅은 정상 (실값은 EC2 .env 의 SENTRY_DSN)
+  dsn: ${SENTRY_DSN:}


### PR DESCRIPTION
## 📎연관된 이슈

- close: #106

## 📄 작업 내용 요약

- `build.gradle`에 `io.sentry:sentry-spring-boot-4-starter:8.52.0`(Boot 4 전용 스타터)과 `io.sentry:sentry-logback:8.52.0` 추가
- `application-prod.yml`에 `sentry.dsn: ${SENTRY_DSN:}` 추가 — 기본값이 빈 문자열이라 DSN 미주입이면 SDK가 스스로 비활성, 로컬·CI·현행 배포 모두 그대로 부팅됩니다
- 자바 코드 변경 없음. 테스트 580건 전건 통과

## 👀 중요 변경 사항

- **수집 경로가 logback입니다.** `GlobalExceptionHandler`의 `@ExceptionHandler(Exception.class)` catch-all이 모든 예외를 처리해 버려서, Sentry 기본 수집 경로(미처리 예외 resolver)에는 아무것도 안 닿습니다. 대신 sentry-logback이 있으면 스타터가 `SentryAppender`를 자동 구성해 **`log.error` 호출(스로어블 포함)이 이벤트로 올라갑니다** — catch-all의 `log.error`가 그 진입점입니다. `CustomException` 경로는 `log.warn`이라 이벤트가 안 되고 브레드크럼만 남아, 비즈니스 4xx 소음 없이 500 경로만 수집됩니다. (`sentry.exception-resolver-order`를 최상위로 올리는 대안은 4xx까지 전부 수집돼 채택하지 않았습니다)
- 현재 `log.error`는 5곳 전부 이벤트감입니다: catch-all 500 · SMTP 발송 실패 · 구글/카카오 토큰 검증 실패 · presigned URL 발급 실패
- 배포 반영은 EC2 `.env`에 `SENTRY_DSN` 한 줄 추가 + 컨테이너 재기동(up)이 필요합니다 — CD가 `.env`를 안 건드리므로 머지 후 별도 요청드릴 예정입니다. 그 전까지는 운영에서도 지금과 동일하게 동작합니다.

## 🔖 Uncompleted Tasks

- Sentry 프로젝트 생성·DSN 발급(일혁) → EC2 `.env` 반영 요청(나연)

## 📢 To Reviewers

- 의존성 2줄·설정 3줄이 전부입니다. `application-prod.yml`은 #105와 같은 파일을 건드리지만 서로 다른 키 추가라 충돌은 없습니다.
