### PR TITLE
chore(test): 변경 감지 상태 전이의 실제 커밋을 통합 테스트로 검증 (#83) [base: develop]

### DIFF
--- a/src/test/java/Hampouch/server/domain/challenge/ChallengeFlowIntegrationTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/ChallengeFlowIntegrationTest.java
@@ -361,4 +361,100 @@ class ChallengeFlowIntegrationTest {
                 .andExpect(jsonPath("$.data.items[0].challengeId").value(id))
                 .andExpect(jsonPath("$.data.items[0].status").value("FAIL"));
     }
+
+    @Test
+    @DisplayName("만료 챌린지의 결과 조회가 총지출이 목표를 넘으면 FAIL로, 넘지 않으면 SUCCESS로 확정하고 그 상태가 요청 종료 후 새 DB 조회에서도 남아 있다")
+    void resultFinalizationCommitsAfterRequest() throws Exception {
+        Long user = 83_001L;
+
+        // 6/1~6/7 목표 70,000 — 6/3 하루 80,000 지출로 총지출이 목표를 넘어 FAIL감
+        Challenge fail = challengeRepository.save(Challenge.builder()
+                .userId(user).durationDays(7).startDate(LocalDate.of(2026, 6, 1))
+                .budgetTotal(70000).dailyLimit(10000).build());
+        challengeDayRepository.save(ChallengeDay.of(fail, LocalDate.of(2026, 6, 3), 80000, DayStatus.OVER, 10000));
+
+        mvc.perform(get("/api/challenges/" + fail.getId() + "/result").header("Authorization", bearer(user)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("FAIL"));
+        // 확정은 save 없는 더티 체킹 UPDATE라 응답이 맞아도 커밋이 빠질 수 있다 — 새 조회로 저장 상태를 본다
+        assertThat(challengeRepository.findById(fail.getId()).orElseThrow().getStatus())
+                .isEqualTo(ChallengeStatus.FAIL);
+
+        // 앞 챌린지가 FAIL로 굳어 진행 중 유니크 자리가 비었으니 같은 유저에게 두 번째를 심을 수 있다
+        Challenge success = challengeRepository.save(Challenge.builder()
+                .userId(user).durationDays(7).startDate(LocalDate.of(2026, 7, 1))
+                .budgetTotal(70000).dailyLimit(10000).build());
+
+        mvc.perform(get("/api/challenges/" + success.getId() + "/result").header("Authorization", bearer(user)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("SUCCESS"));
+        assertThat(challengeRepository.findById(success.getId()).orElseThrow().getStatus())
+                .isEqualTo(ChallengeStatus.SUCCESS);
+    }
+
+    @Test
+    @DisplayName("같은 날짜로 일별 지출을 다시 보내면 새 행 없이 기존 기록이 고쳐지고, 바뀐 금액과 판정이 요청 종료 후 새 DB 조회에서도 남아 있다")
+    void upsertDayUpdateCommitsAfterRequest() throws Exception {
+        Long user = 83_002L;
+        LocalDate start = LocalDate.now(ZoneId.of("Asia/Seoul")); // 서버의 "오늘"(Asia/Seoul) — 위 테스트들과 동일 처리
+
+        String created = mvc.perform(post("/api/challenges")
+                        .header("Authorization", bearer(user))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"durationDays\":7,\"budgetTotal\":70000,\"startDate\":\"" + start + "\"}"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        long id = om.readTree(created).path("data").path("challengeId").asLong();
+
+        mvc.perform(post("/api/challenges/" + id + "/days")
+                        .header("Authorization", bearer(user))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"date\":\"" + start + "\",\"spentAmount\":8000}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("SUCCESS"));
+        Long rowId = challengeDayRepository.findByChallenge_IdAndDayDate(id, start).orElseThrow().getId();
+
+        mvc.perform(post("/api/challenges/" + id + "/days")
+                        .header("Authorization", bearer(user))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"date\":\"" + start + "\",\"spentAmount\":15000}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("OVER"));
+
+        // 두 번째 보내기는 INSERT가 아니라 save 없는 더티 체킹 UPDATE — 커밋 여부는 새 조회로만 보인다
+        ChallengeDay reloaded = challengeDayRepository.findByChallenge_IdAndDayDate(id, start).orElseThrow();
+        assertThat(reloaded.getId()).isEqualTo(rowId); // 새 행이 생긴 게 아니라 기존 행이 고쳐졌다
+        assertThat(reloaded.getSpentAmount()).isEqualTo(15000);
+        assertThat(reloaded.getStatus()).isEqualTo(DayStatus.OVER);
+    }
+
+    @Test
+    @DisplayName("만료로 FAIL 확정된 챌린지의 지출을 고쳐 총지출이 목표 안으로 들어오면 결과가 SUCCESS로 재계산되고, 그 재계산이 요청 종료 후 새 DB 조회에서도 남아 있다")
+    void dayEditRecalculationCommitsAfterRequest() throws Exception {
+        Long user = 83_003L;
+        LocalDate overDay = LocalDate.of(2026, 6, 3);
+
+        // 6/1~6/7 목표 70,000에 6/3 80,000 지출 → 만료 FAIL로 확정된 상태를 심는다.
+        // applyResult로 굳힌 FAIL은 endReason이 없어 재계산 대상이다 — 선언으로 남는 포기·자동취소와 갈라지는 지점.
+        Challenge ch = challengeRepository.save(Challenge.builder()
+                .userId(user).durationDays(7).startDate(LocalDate.of(2026, 6, 1))
+                .budgetTotal(70000).dailyLimit(10000).build());
+        challengeDayRepository.save(ChallengeDay.of(ch, overDay, 80000, DayStatus.OVER, 10000));
+        ch.applyResult(ChallengeStatus.FAIL);
+        challengeRepository.save(ch);
+
+        // 종료 후 지출 수정(0711 확정 경로) — 80,000을 5,000으로 고치면 총지출이 목표 아래로 내려간다
+        mvc.perform(post("/api/challenges/" + ch.getId() + "/days")
+                        .header("Authorization", bearer(user))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"date\":\"" + overDay + "\",\"spentAmount\":5000}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("SUCCESS"));
+
+        // 기록 수정과 결과 뒤집기 둘 다 더티 체킹 UPDATE — 커밋 여부는 새 조회로만 보인다
+        assertThat(challengeRepository.findById(ch.getId()).orElseThrow().getStatus())
+                .isEqualTo(ChallengeStatus.SUCCESS);
+        assertThat(challengeDayRepository.findByChallenge_IdAndDayDate(ch.getId(), overDay).orElseThrow()
+                .getSpentAmount()).isEqualTo(5000);
+    }
 }

--- a/src/test/java/Hampouch/server/domain/rest/RestFlowIntegrationTest.java
+++ b/src/test/java/Hampouch/server/domain/rest/RestFlowIntegrationTest.java
@@ -204,6 +204,46 @@ class RestFlowIntegrationTest {
     }
 
     @Test
+    @DisplayName("지금 바로 복귀를 고르면 실제 복귀일이 오늘로 응답되고, 요청 종료 후 새 DB 조회에서도 오늘로 남아 활성 휴식에서 빠진다")
+    void resumeNowCommitsActualResumeDate() throws Exception {
+        Long user = 83_010L;
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        UserRest rest = userRestRepository.save(UserRest.start(user, today.minusDays(2), 7));
+
+        mvc.perform(post("/api/rests/resume")
+                        .header("Authorization", bearer(user))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"when\":\"NOW\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.resumeDate").value(today.toString()));
+
+        // 복귀 기록은 save 없는 더티 체킹 UPDATE라 응답이 맞아도 커밋이 빠질 수 있다 — 새 조회로 저장 상태를 본다
+        UserRest reloaded = userRestRepository.findById(rest.getId()).orElseThrow();
+        assertThat(reloaded.getActualResumeDate()).isEqualTo(today);
+        assertThat(userRestRepository.findActiveOn(user, today)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("내일 복귀를 고르면 실제 복귀일이 내일로 저장되고, 오늘은 아직 휴식 중이라 활성 휴식으로 계속 잡힌다")
+    void resumeTomorrowCommitsActualResumeDate() throws Exception {
+        Long user = 83_011L;
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        UserRest rest = userRestRepository.save(UserRest.start(user, today.minusDays(2), 7));
+
+        mvc.perform(post("/api/rests/resume")
+                        .header("Authorization", bearer(user))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"when\":\"TOMORROW\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.resumeDate").value(today.plusDays(1).toString()));
+
+        UserRest reloaded = userRestRepository.findById(rest.getId()).orElseThrow();
+        assertThat(reloaded.getActualResumeDate()).isEqualTo(today.plusDays(1));
+        // 내일 복귀 예약은 오늘까지 휴식이다 — 활성으로 남아 있어야 오늘 다시 골라 바꿀 수 있다
+        assertThat(userRestRepository.findActiveOn(user, today)).isPresent();
+    }
+
+    @Test
     @DisplayName("액세스 토큰 없이 휴식 시작을 부르면 401과 인증 필요 에러 본문으로 거절된다")
     void restRejectsRequestWithoutToken() throws Exception {
         // 401이 나오는 자리는 둘이다. 여기서 보는 건 시큐리티 필터가 거절하는 쪽(AuthEntryPoint)이고,


### PR DESCRIPTION
## 📎연관된 이슈

- close: #83

## 📄 작업 내용 요약

save 없는 변경 감지(더티 체킹) 갱신이 요청 종료 후 DB에 실제로 커밋되는지를 새 조회로 확인하는 통합 테스트 5건을 추가했습니다. 프로덕션 코드 변경은 없습니다.

- `ChallengeFlowIntegrationTest` 3건
  - 만료 챌린지의 결과 조회가 확정한 FAIL·SUCCESS가 요청 종료 후 새 DB 조회에서도 남는다
  - 같은 날짜로 일별 지출을 다시 보내면 새 행 없이 기존 기록이 고쳐지고(행 id 동일), 바뀐 금액·판정이 커밋된다
  - 만료 FAIL 챌린지의 지출을 고쳐 총지출이 목표 안으로 들어오면 SUCCESS 재계산이 커밋된다
- `RestFlowIntegrationTest` 2건
  - 복귀 NOW: actualResumeDate가 오늘로 저장되고 활성 휴식에서 빠진다
  - 복귀 TOMORROW: actualResumeDate가 내일로 저장되고 오늘은 아직 활성 휴식으로 잡힌다

## 👀 중요 변경 사항

없습니다 — 테스트만 추가라 API·로직·응답은 그대로입니다.

## 🔖 Uncompleted Tasks

없습니다.

## 📢 To Reviewers

새 테스트의 단정이 응답 본문이 아니라 요청 종료 후 리포지토리 재조회로 되어 있는 것이 의도입니다 — 두 클래스 모두 클래스 레벨 @Transactional이 없어서, 서비스 메서드 자신의 트랜잭션이 커밋한 결과만 보입니다. 데이터 격리는 전용 유저 id(83001~83011)로 했습니다.
