### PR TITLE
fix(challenge): 조정 이력 컬럼명을 adjust_option으로 변경 (MySQL 예약어 충돌) (#113) [base: develop]

### DIFF
--- a/src/main/java/Hampouch/server/domain/challenge/entity/ChallengeAdjustment.java
+++ b/src/main/java/Hampouch/server/domain/challenge/entity/ChallengeAdjustment.java
@@ -50,9 +50,13 @@ public class ChallengeAdjustment {
     @Column(nullable = false)
     private LocalDate effectiveDate;
 
-    /** 고른 프리셋. 직접 입력으로 조정하면 배율이 없어 null이다. */
+    /**
+     * 고른 프리셋. 직접 입력으로 조정하면 배율이 없어 null이다.
+     * 컬럼명을 필드명과 다르게 둔 이유: OPTION은 MySQL 예약어라 그대로 쓰면 실 DB에서
+     * CREATE TABLE부터 거부된다(H2는 허용해서 테스트로는 안 잡히는 함정).
+     */
     @Enumerated(EnumType.STRING)
-    @Column(length = 20)
+    @Column(name = "adjust_option", length = 20)
     private AdjustOption option;
 
     /** 조정 직전 목표. 첫 조정 행의 이전 값들이 "기간 시작 시점"이라 타임라인 복원의 기준점이 된다. */


### PR DESCRIPTION
## 📎연관된 이슈

- close: #113

## 📄 작업 내용 요약

- `ChallengeAdjustment.option` 컬럼명을 `adjust_option`으로 명시 (`@Column(name = "adjust_option")`) — OPTION이 MySQL 예약어라 실 MySQL에서 `challenge_adjustment` CREATE TABLE이 부팅마다 거부되고, 테이블 부재로 조정 이력을 읽는 챌린지 조회 전부(`/current`·`/{id}/result`·`/history`·`/recommendation`)가 500이 나던 문제의 수정입니다. 재현·영향 실측 로그는 #113에 있습니다.
- 필드에 예약어 함정 주석 보강. 자바 필드명·호출부는 무변이고 DB 컬럼 이름표만 바뀝니다.

## 👀 중요 변경 사항

- 실 테이블이 어느 환경(로컬 도커·EC2)에도 만들어진 적이 없어(CREATE 자체가 실패해 왔음) **데이터 이전 없음** — 머지 후 첫 부팅에서 ddl-auto가 새 이름으로 생성합니다.
- H2는 `option`을 예약어로 안 봐서 테스트로는 안 잡히는 부류입니다 — 수정 후 실 MySQL 부팅 실측으로 DDL 거부 0건·`adjust_option` 컬럼 생성을 확인했습니다. 같은 부류가 `battle_participant.rank`에도 있어 담당께 별도 전달했습니다.

## 🔖 Uncompleted Tasks

- #114(스키마 DDL 오류를 부팅 실패로 승격)가 이 PR과 배틀 `rank` 수정이 develop에 들어간 뒤 머지되도록 걸려 있습니다(Relationships).

## 📢 To Reviewers

- 전체 테스트 통과(동작 무변 — 컬럼 리네임뿐). 컬럼 이름(`adjust_option`)이 어색하면 다른 비예약어 이름으로 바꿔도 무방합니다.
