### PR TITLE
chore(infra): 스키마 DDL 오류를 부팅 실패로 승격 (hibernate.hbm2ddl.halt_on_error) (#114) [base: develop]

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,9 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        # 스키마 DDL 오류를 WARN으로 넘기지 않고 부팅 실패로 — 예약어 컬럼처럼 테이블이 조용히 안 만들어지는 부류 차단(#114)
+        hbm2ddl:
+          halt_on_error: true
   mail:
     host: smtp.gmail.com
     port: 587


### PR DESCRIPTION
## 📎연관된 이슈

- close: #114

## 📄 작업 내용 요약

- `application.yml`에 `hibernate.hbm2ddl.halt_on_error: true` 한 줄 추가 — ddl-auto가 스키마 DDL 실행 오류를 WARN으로만 남기고 부팅을 계속하던 것을 **부팅 실패**로 바꿉니다. #113(challenge_adjustment)·battle_participant(rank)가 CREATE 거부를 조용히 넘겨 테이블 없는 서버가 떠 있던 부류의 재발 방지입니다.
- 동작 실측: H2 테스트 580건 무변(H2엔 스키마 오류가 없음) / 예약어 미수정 상태로 실 MySQL 부팅 시 `SchemaManagementException: Halting on error`로 부팅이 중단되는 것 확인(스위치가 실제로 잡는다는 증명).

## 👀 중요 변경 사항

- ⚠️ **머지 게이트: 예약어 수정 2건(#115의 `adjust_option`, 배틀 `rank`)이 develop에 먼저 들어간 뒤 머지해야 합니다.** 이 설정이 먼저 배포되면 기존 DDL 오류 때문에 서버가 부팅되지 않습니다(이슈 Relationships에도 걸어 둠).
- 켜진 뒤에는 스키마 오류 = 부팅 실패입니다(가용성↓·조기 발각↑). 개발 단계 + ddl-auto=update 유지 상황에선 조기 발각이 낫다는 판단이며, 이 판단 자체가 리뷰 확인 대상입니다.

## 🔖 Uncompleted Tasks

- Flyway 도입(#117)이 진행되면 ddl-auto가 validate로 내려가 이 설정의 역할이 줄어듭니다 — 전환 PR에서 이 줄의 정리 여부를 같이 판단합니다.

## 📢 To Reviewers

- 변경은 yml 한 줄 + 주석입니다. 설정 키 정의: Hibernate 7.4 `SchemaToolingSettings.HBM2DDL_HALT_ON_ERROR`(기본 false) — https://docs.hibernate.org/orm/7.4/javadocs/org/hibernate/cfg/SchemaToolingSettings.html
