### PR TITLE
feat(infra): springdoc-openapi(Swagger UI) 도입 (#116) [base: develop]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,9 @@ dependencies {
 
 	//actuator - 운영 health check용
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+	//springdoc-openapi(Swagger UI) — 3.x가 Boot 4 계열, 2.x는 Boot 3.5까지다
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.1.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/Hampouch/server/global/security/SecurityConfig.java
+++ b/src/main/java/Hampouch/server/global/security/SecurityConfig.java
@@ -39,7 +39,10 @@ public class SecurityConfig {
                                 "/api/auth/social",
                                 "/api/auth/refresh",
                                 "/api/auth/password/reset",
-                                "/actuator/health"
+                                "/actuator/health",
+                                "/swagger-ui.html",
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/test/java/Hampouch/server/global/openapi/OpenApiDocsIntegrationTest.java
+++ b/src/test/java/Hampouch/server/global/openapi/OpenApiDocsIntegrationTest.java
@@ -1,0 +1,40 @@
+package Hampouch.server.global.openapi;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 다른 컨트롤러 테스트와 달리 시큐리티 필터를 켠 채로 돈다 — 문서 경로가 인증 없이 열리는지가
+ * 검증 대상이라 addFilters = false로 끄면 SecurityConfig의 permitAll이 검증되지 않는다.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+class OpenApiDocsIntegrationTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    @DisplayName("Authorization 헤더 없이 /v3/api-docs를 열면 200과 함께 컨트롤러에서 수집한 경로가 담긴 문서가 내려온다")
+    void apiDocsAreServedWithoutAuthorizationHeader() throws Exception {
+        mockMvc.perform(get("/v3/api-docs"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.openapi").exists())
+                .andExpect(jsonPath("$.paths['/api/auth/login']").exists());
+    }
+
+    @Test
+    @DisplayName("Authorization 헤더 없이 Swagger UI 경로를 열면 401이 아니라 200이 내려온다")
+    void swaggerUiIsServedWithoutAuthorizationHeader() throws Exception {
+        mockMvc.perform(get("/swagger-ui/index.html"))
+                .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
## 📎연관된 이슈

- close: #116

## 📄 작업 내용 요약

- `springdoc-openapi-starter-webmvc-ui:3.1.0` 의존성 추가. 3.x 계열이 Spring Boot 4 를 겨냥합니다 — 3.1.0 의 parent 가 `spring-boot-starter-parent:4.1.0` 이고, 2.x 최신인 2.9.0 은 `3.5.16` 이라 우리 버전과 맞지 않습니다.
- `SecurityConfig` 의 permitAll 에 문서 경로 3개(`/swagger-ui.html` · `/swagger-ui/**` · `/v3/api-docs/**`)를 추가했습니다.
- 문서가 인증 없이 열리는지 검증하는 통합 테스트 1개(2건)를 추가했습니다.

이슈 체크리스트 중 엔드포인트별 상세 어노테이션(`@Operation` 등)은 이슈 본문대로 범위 밖입니다. 기본 자동 스캔 노출까지가 이 PR 입니다.

**실 MySQL 8.0 으로 띄워 확인했습니다**(H2 테스트와 별개로 도커 컨테이너 기동 후 실측).

| 요청 (Authorization 헤더 없음) | 결과 |
|---|---|
| `GET /v3/api-docs` | 200, openapi 3.1.0, 경로 39개 수집 |
| `GET /swagger-ui/index.html` | 200 `text/html` |
| `GET /swagger-ui.html` | 302 → `/swagger-ui/index.html` |
| `GET /api/users/me` | 401 (인증 정책 그대로) |

자동 테스트는 582건 전부 통과합니다(추가 전 580 → +2).

## 👀 중요 변경 사항

**문서 경로는 토큰 없이 열립니다.** permitAll 이므로 `Authorization` 헤더가 없어도 200 이 나갑니다. 문서에 드러나는 것은 API 모양(경로·필드·검증 규칙)이고, 나머지 엔드포인트의 인증은 그대로라 문서를 봐도 토큰 없이는 호출되지 않습니다.

**운영(EC2)에도 노출됩니다 — 잠정 결정입니다.** 이슈의 목적이 안드 연동 중 실물 대조인데 안드가 붙어 있는 곳이 EC2 라서 프로파일로 막지 않았습니다. 배포되면 `https://api.hampouch.com/swagger-ui/index.html` 에서 열립니다. 공개 서버에 API 표면이 드러나는 것이 대가이고, 막아야 한다고 보시면 `application-prod.yml` 에 두 줄로 끕니다.

```yaml
springdoc:
  api-docs.enabled: false
  swagger-ui.enabled: false
```

인증 없이 열려 있는 `/api/auth/email/send` 가 문서 화면에서 바로 호출될 수 있다는 점은 확인했는데, `AuthService` 에 이메일·용도별 30초 재발송 쿨다운이 이미 걸려 있어 이 PR 로 새로 생기는 구멍은 없습니다.

## 🔖 Uncompleted Tasks

- 노션 "서버 개발 컨벤션 & 룰" 의 Swagger 미도입 문구 갱신 — 머지 후 반영합니다.

## 📢 To Reviewers

- `SecurityConfig` 가 인프라 관할이라 permitAll 3줄 추가가 이 PR 의 확인 지점입니다. 문서 경로만 열고 나머지 정책은 건드리지 않았습니다.
- 운영 노출 여부(위 중요 변경 사항)는 자체 결정이라 판단을 받고 싶습니다. 끄는 쪽이면 이 PR 에 반영하겠습니다.
