### PR TITLE
chore(test): Testcontainers 기반 실 MySQL 검증 계층 추가 (#119) [base: develop]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test-report
-          path: build/reports/tests/test/
+          path: |
+            build/reports/tests/test/
+            build/reports/tests/mysqlTest/
 
       #Dockerfile이 정상적으로 이미지 빌드되는지 확인
       - name: Build Docker image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,15 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      - name: Verify Docker daemon
+        run: docker info
+
       #gradle 빌드 및 테스트 실행
       - name: Build and test
         run: ./gradlew clean build
+
+      - name: Test with MySQL container
+        run: ./gradlew mysqlTest
 
       - name: Upload test report
         if: failure()

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 ## Hampouch
+
+### 테스트 실행
+
+```bash
+./gradlew test
+```
+
+대부분은 H2로 돌고, MySQL 고유 동작을 보는 일부만 Testcontainers로 MySQL 8.0 컨테이너를 띄운다.
+컨테이너의 문자셋·콜레이션과 JDBC 시간대·인코딩은 운영 MySQL 설정에 맞춘다.
+기본 `test`에서는 MySQL 테스트를 제외한다. 스키마·제약을 실 MySQL로 검증할 때는 전용 명령을 실행한다.
+
+```bash
+./gradlew mysqlTest
+```
+
+`mysqlTest`는 Docker 데몬을 먼저 확인하며, 사용할 수 없으면 실패한다.
+
+colima는 소켓이 기본 경로에 없어 자동 검출이 안 된다. 지정해서 실행한다.
+
+```bash
+DOCKER_HOST="unix://$HOME/.colima/default/docker.sock" TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock ./gradlew mysqlTest
+```

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,12 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
+	// Testcontainers — 실 MySQL 8.0 컨테이너 계층. H2(MODE=MySQL)가 통과시키는 MySQL 고유 거부를 잡는다.
+	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+	// 2.x에서 모듈 좌표가 testcontainers-* 로 바뀌었다(1.x의 org.testcontainers:mysql 은 BOM에 없어 버전 해석 실패).
+	testImplementation 'org.testcontainers:testcontainers-junit-jupiter'
+	testImplementation 'org.testcontainers:testcontainers-mysql'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-validation-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
@@ -61,10 +67,29 @@ dependencies {
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+	useJUnitPlatform {
+		excludeTags 'mysql'
+	}
 	systemProperty 'user.timezone', 'Asia/Seoul'
 }
 
-tasks.withType(JavaCompile) {
+def verifyDocker = tasks.register('verifyDocker', Exec) {
+	commandLine 'docker', 'info'
+}
+
+tasks.register('mysqlTest', Test) {
+	description = 'Runs tests against a real MySQL container.'
+	group = 'verification'
+	testClassesDirs = sourceSets.test.output.classesDirs
+	classpath = sourceSets.test.runtimeClasspath
+	dependsOn verifyDocker
+	shouldRunAfter tasks.named('test')
+	useJUnitPlatform {
+		includeTags 'mysql'
+	}
+	systemProperty 'user.timezone', 'Asia/Seoul'
+}
+
+tasks.withType(JavaCompile).configureEach {
 	options.compilerArgs << '-parameters'
 }

--- a/src/main/java/Hampouch/server/domain/challenge/entity/Challenge.java
+++ b/src/main/java/Hampouch/server/domain/challenge/entity/Challenge.java
@@ -13,27 +13,19 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * 챌린지 1건 (온보딩 STEP2 목표 설정으로 생성).
- *
- * dailyLimit은 계산만 하지 않고 저장한다 — 판정 기준을 매번 나눗셈으로 다시 유도하지 않기 위함.
- * 단 이 값은 "지금의 한도"라 조정(#7)이 덮어쓴다. 지난 날의 판정 기준을 지키는 건 여기가 아니라
- * ChallengeDay 행마다의 dailyLimit 스냅샷이다.
- */
-@Getter // 필드별 getter 자동 생성(나연 common과 동일한 팀 스타일) — boolean은 isResetByPayday() 형태
-@NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA 필수 빈 생성자(Hibernate가 행→객체 복원·프록시 생성에 사용). protected = 반쪽짜리 new 차단, 정식 생성은 create()
+/** dailyLimit은 현재 한도이며, 지난 날짜의 한도는 ChallengeDay에 스냅샷으로 보존한다. */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "challenge",
         uniqueConstraints = @UniqueConstraint(name = "uq_challenge_active_user", columnNames = "active_user_id"))
-@EntityListeners(AuditingEntityListener.class) // 저장 직전에 끼어들어 @CreatedDate(createdAt)를 자동으로 채우는 감시자.
-// 기능은 JpaAuditingConfig가 켜고, 시각은 컴퓨터 시계가 아니라 공용 Clock(Asia/Seoul, ClockConfig)에서 얻음 — 테스트에선 고정 시계로 교체 가능
+@EntityListeners(AuditingEntityListener.class)
 public class Challenge {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY) // 번호 발급은 DB(auto_increment) 몫 — 대체로 1씩 증가하지만 롤백 시 구멍 가능. 고유 식별자로만 쓰고 순서 논리엔 쓰지 말 것
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    /** JWT principal에서 오는 유저 id. TODO: @ManyToOne User 연관 전환은 별도 결정 대기 — 로그인 연동 후에도 id 보관을 유지 중. */
     @Column(nullable = false)
     private Long userId;
 
@@ -43,7 +35,6 @@ public class Challenge {
     @Column(nullable = false)
     private LocalDate startDate;
 
-    /** startDate + durationDays - 1 */
     @Column(nullable = false)
     private LocalDate endDate;
 
@@ -51,39 +42,28 @@ public class Challenge {
     @Column(nullable = false)
     private int budgetTotal;
 
-    /** 지금의 하루 한도. 생성 시 budgetTotal / durationDays(버림)이고, 조정(#7)을 거치면 그 결과로 바뀐다. */
+    /** 현재 하루 한도(원). */
     @Column(nullable = false)
     private int dailyLimit;
 
-    /**
-     * 온보딩의 "월급날 기준 리셋" 옵션. 0714 답변: 켜면 챌린지 주기가 월급날~월급날로 맞춰짐(첫 주기는 부분 기간 가능),
-     * 기간형(durationDays) 챌린지는 일회성이라 월급날과 무관. 예산 리필·반복 종료 등 잔여 정의(PM_질문목록 1번)가 나올 때까지 저장만.
-     */
     @Column(nullable = false)
     private boolean resetByPayday;
 
-    /** 월급날(1~31), 옵션이라 nullable. */
     private Integer paydayDay;
 
-    @Enumerated(EnumType.STRING) // 이름 그대로 저장. 기본값 ORDINAL(순서 번호)은 enum 중간에 상수가 끼면 기존 데이터가 통째로 오염됨
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     private ChallengeStatus status;
 
     /**
-     * DB가 status를 보고 스스로 채우는 생성 컬럼 — 진행 중이면 userId, 아니면 NULL(NULL끼리는 유니크에 안 걸림).
-     * 위의 uq_challenge_active_user 제약과 한 쌍으로 "유저당 진행 중 챌린지 1개"를 DB가 강제한다(동시 생성 경쟁의
-     * 마지막 방어선 — MySQL은 조건부 유니크가 없어 이 우회를 쓴다). 값 계산은 전적으로 DB 몫이라 읽기 전용 매핑.
-     * 문자열 끝에 STORED/VIRTUAL 키워드를 생략한 건 의도 — 테스트 H2가 그 키워드를 거부하고,
-     * MySQL은 생략 시 VIRTUAL로 만들며 그 위 유니크 인덱스를 허용한다.
+     * MySQL 조건부 유니크 우회용 생성 컬럼. 진행 중일 때만 userId를 노출해 유저당 진행 중 챌린지 1개를 강제한다.
+     * STORED/VIRTUAL은 H2 호환을 위해 생략하며 MySQL에서는 VIRTUAL로 생성된다.
      */
     @Column(name = "active_user_id", insertable = false, updatable = false,
             columnDefinition = "bigint generated always as (case when status = 'IN_PROGRESS' then user_id end)")
     private Long activeUserId;
 
-    /**
-     * 종료 사유 표식 — null = 기록에서 계산된 판정(종료 후 지출 수정 시 재계산 대상),
-     * 값이 있으면 선언 또는 자동 취소로 끝난 상태라 재계산에서 제외한다.
-     */
+    /** null이면 기록 기반 판정이라 재계산할 수 있고, 값이 있으면 선언 또는 자동 취소라 재계산하지 않는다. */
     @Enumerated(EnumType.STRING)
     @Column(length = 20)
     private EndReason endReason;
@@ -92,30 +72,13 @@ public class Challenge {
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
-    // 집중 카테고리는 챌린지 전속 부품(생명주기 공유) — 저장·삭제가 챌린지와 함께 전파(cascade)되고, 리스트에서 빠지면 행도 삭제(orphanRemoval)
     @OneToMany(mappedBy = "challenge", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ChallengeWeakCategory> weakCategories = new ArrayList<>();
 
-    /**
-     * 챌린지 생성 통로 — Challenge.builder()...build(). dailyLimit은 호출부(서비스)에서 계산해 넘긴다
-     * (한도 계산 규칙은 ChallengeCalculator가 단일 출처).
-     *
-     * 원래 7개 파라미터 정적 팩토리 create()였는데, 같은 int 타입이 연달아 있어(durationDays·
-     * budgetTotal·dailyLimit) 호출부에서 인자 순서가 한 칸 밀려도 컴파일러가 못 잡는 위험이 커서
-     * 이름 붙은 빌더로 교체(0717). @Builder를 클래스가 아니라 이 private 생성자에 붙인 이유 —
-     * build()가 반드시 이 생성자를 지나므로 endDate 계산·status 초기값(IN_PROGRESS) 세팅을
-     * 우회한 객체가 못 생긴다(클래스에 붙이면 필드 전체를 그대로 받는 빌더가 생겨 불변식이 뚫림).
-     * 필수 필드(userId·startDate·기간·예산)를 빠뜨리면 아래 생성자 검사가 막는다 — 옵션 필드는
-     * 타입 기본값(resetByPayday는 false, paydayDay는 null)이라 안 채워도 자연스럽다.
-     */
+    /** 필수값 검증과 endDate·status 초기화를 우회하지 못하도록 생성자에만 빌더를 노출한다. */
     @Builder
     private Challenge(Long userId, int durationDays, LocalDate startDate, int budgetTotal,
                       int dailyLimit, boolean resetByPayday, Integer paydayDay) {
-        // 빌더는 필수 필드를 빠뜨려도 build()가 컴파일된다(누락 시 참조형 null·정수형 0). 그래서 여기서 불변식을 지킨다.
-        // 요청 값 자체는 CreateChallengeRequest의 @Valid가 이미 거르므로, 이 검사가 실제로 잡는 건
-        // 서비스가 인자를 잘못 넘기는 서버 코드 실수 — 특히 durationDays·budgetTotal·dailyLimit처럼
-        // 같은 int가 연달아 한 칸 밀리는 사고다. 클라 오류가 아니라 서버 버그라 4xx CustomException이
-        // 아니라 IllegalArgumentException으로 즉시 터뜨린다(applyResult와 같은 원칙).
         if (userId == null) {
             throw new IllegalArgumentException("userId는 필수입니다.");
         }
@@ -142,16 +105,8 @@ public class Challenge {
         this.status = ChallengeStatus.IN_PROGRESS;
     }
 
-    /**
-     * 집중 카테고리 전체 교체 — 보낸 목록이 곧 최종 상태(생성·수정 공용 통로).
-     * 중복을 접어 저장하는 이유는 uq_weak_category 위반이 곧 500이라서.
-     *
-     * 겹치는 카테고리의 기존 행을 재사용하는 건 함정 회피다(실측) — 하이버네이트가 한 번의 반영에서
-     * INSERT를 고아 삭제 DELETE보다 먼저 실행해, 지웠다 같은 값을 다시 넣으면 유니크 제약에 걸린다.
-     * 필드에 새 리스트를 대입하는 것도 금지 — 변경 추적이 끊긴다.
-     */
+    /** 기존 행을 재사용해 Hibernate의 INSERT-before-orphan-DELETE 순서에서 유니크 충돌을 피한다. */
     public void replaceWeakCategories(List<String> categories) {
-        // 재사용할 행 찾기가 clear()보다 먼저 끝나야 한다
         List<ChallengeWeakCategory> next = categories.stream()
                 .distinct()
                 .map(this::reuseOrCreateWeakCategory)
@@ -167,12 +122,7 @@ public class Challenge {
                 .orElseGet(() -> new ChallengeWeakCategory(this, category));
     }
 
-    /**
-     * 판정 결과(SUCCESS/FAIL)를 반영 — 기간 경과 후 최초 확정(getResult)과,
-     * 종료 후 지출 수정에 따른 재계산 갱신(upsertDay) 양쪽에서 쓴다(그래서 finish가 아니라 applyResult).
-     * 결과가 아닌 값(IN_PROGRESS)이 오는 건 클라 요청 오류가 아니라 서버 코드 버그라,
-     * 4xx용 CustomException 대신 IllegalArgumentException으로 즉시 터뜨려 잘못 호출한 코드를 드러낸다.
-     */
+    /** 기록 기반 SUCCESS/FAIL 판정만 반영하며 endReason은 설정하지 않는다. */
     public void applyResult(ChallengeStatus result) {
         if (result != ChallengeStatus.SUCCESS && result != ChallengeStatus.FAIL) {
             throw new IllegalArgumentException("판정 결과는 SUCCESS/FAIL만 가능: " + result);
@@ -180,15 +130,7 @@ public class Challenge {
         this.status = result;
     }
 
-    /**
-     * 중도 포기 — 유저 선언으로 즉시 FAIL 확정(0707 전체회의: 도중 중단·일시정지 없음, 그만두면 실패).
-     * applyResult(계산 판정 반영)와 분리한 이유: 포기는 기록에서 나온 결과가 아니라 선언이라,
-     * endReason 표식을 함께 남겨 이후 지출 수정 재계산(upsertDay)이 이 FAIL을 SUCCESS로
-     * 되살리지 못하게 해야 한다(API명세_중도포기.md "재계산 부활 버그 방지").
-     * endDate는 원래 목표 기간 그대로 보존(자체 결정 — 기록 유지, 필요 시 PM 확인).
-     * IN_PROGRESS 검사(클라 오류 409)는 서비스 몫 — 여기까지 왔는데 아니면 서버 코드 버그라
-     * 즉시 터뜨린다(applyResult가 잘못된 값에 IllegalArgumentException을 던지는 것과 같은 원칙).
-     */
+    /** 포기 표식을 남겨 이후 지출 수정 재계산이 결과를 바꾸지 못하게 하며, 목표 종료일은 보존한다. */
     public void giveUp() {
         if (!isInProgress()) {
             throw new IllegalStateException("진행 중 챌린지만 포기할 수 있다: " + status);
@@ -197,7 +139,7 @@ public class Challenge {
         this.endReason = EndReason.GIVEN_UP;
     }
 
-    /** 3일 연속 지출 미입력으로 자동 취소한다. 사용자 중도 포기(FAIL)와 달리 지난 챌린지에는 남지 않는다. */
+    /** 미입력 자동 취소로 표시해 히스토리와 재계산 대상에서 제외한다. */
     public void cancelForMissingInput() {
         if (!isInProgress()) {
             throw new IllegalStateException("진행 중 챌린지만 자동 취소할 수 있다: " + status);
@@ -206,13 +148,7 @@ public class Challenge {
         this.endReason = EndReason.MISSING_DAILY_INPUT;
     }
 
-    /**
-     * 목표 금액 조정(#7) 반영 — 유저가 고르는 건 목표 금액이고 하루 한도는 거기서 파생된 값이라 둘이 함께 움직인다.
-     * 파생 계산은 호출부(서비스)가 ChallengeCalculator로 하고 여기선 결과만 받는다(생성 때와 같은 구조).
-     * 두 값은 조정한 날부터의 것이고, 지난 날의 판정은 각 ChallengeDay의 스냅샷이 지키므로 여기서 되돌아보지 않는다.
-     * 진행 중 여부·횟수 소진(409)은 서비스가 거르고, 여기 검사는 서버 코드 버그용이라
-     * CustomException이 아니라 IllegalArgumentException/IllegalStateException으로 터뜨린다(giveUp과 같은 원칙).
-     */
+    /** 현재 목표와 한도만 바꾸며 지난 날짜의 한도는 ChallengeDay 스냅샷을 유지한다. */
     public void adjustGoal(int newBudgetTotal, int newDailyLimit) {
         if (!isInProgress()) {
             throw new IllegalStateException("진행 중 챌린지만 목표를 조정할 수 있다: " + status);

--- a/src/main/java/Hampouch/server/domain/challenge/repository/ChallengeRepository.java
+++ b/src/main/java/Hampouch/server/domain/challenge/repository/ChallengeRepository.java
@@ -8,85 +8,25 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
-/**
- * 챌린지 저장소. findById·save 같은 CRUD 기본기는 이 파일에 선언이 없어도 쓸 수 있다 —
- * 부모 인터페이스 사슬(JpaRepository ← ListCrudRepository ← CrudRepository)에 이미 선언돼
- * 있어 상속으로 물려받기 때문. 구현 클래스도 우리가 안 만든다 — 스프링 데이터가 부팅 때
- * 이 인터페이스의 프록시 구현체를 만들어 빈으로 등록한다(CRUD 기본기는 SimpleJpaRepository 구현).
- * 아래 파생 쿼리들도 선언만 하면 구현은 스프링이 메서드 이름을 해석해 만든다 —
- * 기본기와 파생 쿼리는 선언 출처만 다를 뿐(부모 vs 이 파일) 구현 주체는 둘 다 스프링이다.
- *
- * findById가 0 또는 1건인 근거는 DB 기본 키 제약(같은 id 두 행은 존재 불가) —
- * 도메인 규칙(코드 게이트)에 기대는 findInProgress의 "0 또는 1"보다 강한 보장이다.
- */
 public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
 
-    /**
-     * 동시 진행 1개 가정 — 생성 시 중복 체크용 파생 쿼리.
-     * status(IN_PROGRESS)까지 보는 이유: 유저의 끝난 챌린지(SUCCESS/FAIL)도 DB에 남으므로,
-     * userId만 보면 과거에 챌린지 한 유저는 새로 못 만듦. "진행 중"만 세야 함.
-     * 직접 호출하지 말고 아래 existsInProgress(상태 고정판)를 쓸 것.
-     */
     boolean existsByUserIdAndStatus(Long userId, ChallengeStatus status);
 
-    /**
-     * 진행 중 챌린지 1건 조회용 파생 쿼리 (홈/현황, 만료 lazy 확정).
-     *
-     * userId+status 조합이 "딱 1건"인 건 쿼리가 보장하는 게 아니라 도메인 규칙이 보장한다 —
-     * 동시 진행은 1개뿐(create의 existsInProgress 게이트가 409로 차단)이라 IN_PROGRESS는
-     * 유저당 최대 1행. 반환 타입 Optional은 그 규칙을 믿고 "0 아니면 1"을 기대한다는 선언이고,
-     * 실제 2행 이상이 걸리면 Spring Data가 IncorrectResultSizeDataAccessException을 던진다(500).
-     * 그래서 이 쿼리는 IN_PROGRESS 전용 — SUCCESS/FAIL은 유저당 여러 개 쌓이는 게 정상이라
-     * 그런 조회는 List를 반환하는 아래 히스토리 쿼리 몫이다.
-     * 직접 호출하지 말고 아래 findInProgress(상태 고정판)를 쓸 것.
-     */
     Optional<Challenge> findByUserIdAndStatus(Long userId, ChallengeStatus status);
 
-    /**
-     * 진행 중 챌린지 존재 여부 — create의 동시 진행 1개 게이트 전용.
-     * 파생 쿼리 이름 문법에는 값(IN_PROGRESS)을 박을 자리가 없어(이름은 속성만 정하고 값은 파라미터)
-     * default 메서드로 감싸 상태를 고정했다 — 호출부가 다른 상태를 넘길 통로를 구조로 막는다.
-     */
     default boolean existsInProgress(Long userId) {
         return existsByUserIdAndStatus(userId, ChallengeStatus.IN_PROGRESS);
     }
 
-    /**
-     * 진행 중 챌린지 조회 — 동시 진행 1개 규칙 위에서 0 또는 1건(규칙 근거는 위 파생 쿼리 주석).
-     * IN_PROGRESS 전용이라는 계약을 주석이 아니라 시그니처로 지키기 위한 상태 고정판 —
-     * 서비스는 이것만 호출한다.
-     */
     default Optional<Challenge> findInProgress(Long userId) {
         return findByUserIdAndStatus(userId, ChallengeStatus.IN_PROGRESS);
     }
 
-    /**
-     * 지난 챌린지 리스트(#4) — 종료된 것만, 최근 종료(endDate 내림차순)가 먼저.
-     * "IN_PROGRESS가 아닌 전부"가 아니라 보여줄 상태를 In(SUCCESS, FAIL)으로 명시하는 이유:
-     * VOID 같은 상태가 추가됐을 때 Not 조건은 그 상태를 자동으로 리스트에 흘려보낸다.
-     * 미입력 자동 취소 VOID는 지난 기록에서 제외하므로 보여줄 상태만 명시한다.
-     * endDate가 같으면 id 내림차순(나중에 만든 것 먼저) — 정렬이 매번 같도록 붙인 보조 기준(자체 결정).
-     *
-     * 이름 읽는 법(조건부): findBy 뒤 UserId(키워드 없음 = 같음 비교) And StatusIn(컬렉션 안의 값 중 하나, SQL IN)
-     * → WHERE user_id = ? AND status IN (...). 메서드 파라미터는 이 조건 순서대로 대응 — In 조건이라
-     * 두 번째 파라미터가 단일 값이 아닌 Collection이다. OrderBy 키워드를 만나는 지점에서 조건부가 끝난다.
-     * 이름 읽는 법(정렬부): OrderBy 뒤는 "속성+방향" 쌍의 나열 — EndDateDesc, IdDesc
-     * → SQL의 ORDER BY end_date DESC, id DESC. 방향을 생략하면 Asc가 기본이라 Desc는 매번 붙여야 한다.
-     * 두 키가 각각 따로 전체를 정렬하는 게 아니라, 둘째 키(id)는 첫 키(endDate)가 같은 행들 사이에서만 순서를 정한다.
-     */
     List<Challenge> findByUserIdAndStatusInOrderByEndDateDescIdDesc(Long userId, Collection<ChallengeStatus> statuses);
 
     /**
-     * 직전 종료 챌린지 1건 — 휴식기 홈의 keptRecords(#8) 재료.
-     * findFirst = 정렬 결과의 맨 앞 1건만(SQL LIMIT 1) — List로 다 가져와 첫 원소를 집는 게 아니라 쿼리가 1건으로 끝난다.
-     *
-     * "직전"의 정렬이 히스토리의 endDate가 아니라 생성 시각(createdAt)인 이유: 중도 포기 챌린지는 endDate가
-     * 원래 목표 기간 그대로 보존돼 미래일 수 있어서, endDate 내림차순은 "예전에 포기한 긴 챌린지"를
-     * 나중에 실제로 끝낸 챌린지보다 최근으로 오판한다(예: 30일짜리 이틀 만에 포기 → 그 뒤 7일짜리 완주).
-     * 동시 진행 1개 규칙이라 챌린지는 순차로만 생기고, 종료된 것들 중에선 마지막에 만든 것이 곧
-     * 마지막에 끝난 것 — 생성순이 종료순을 정확히 대신한다. 생성순은 의미 그대로인 createdAt이 지고
-     * id는 같은 시각일 때의 보조 기준만 맡는다(id 필드 주석의 "순서 논리에 쓰지 말 것" 규칙 + 히스토리
-     * 보조 정렬과 동일한 역할 분담).
+     * 포기한 챌린지는 목표 endDate를 보존하므로 직전 종료 건은 createdAt으로 고른다.
+     * id는 createdAt이 같은 경우의 보조 정렬이다.
      */
     Optional<Challenge> findFirstByUserIdAndStatusInOrderByCreatedAtDescIdDesc(Long userId, Collection<ChallengeStatus> statuses);
 }

--- a/src/test/java/Hampouch/server/domain/challenge/repository/ChallengeRepositoryMySqlTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/repository/ChallengeRepositoryMySqlTest.java
@@ -1,0 +1,62 @@
+package Hampouch.server.domain.challenge.repository;
+
+import Hampouch.server.domain.challenge.entity.Challenge;
+import Hampouch.server.domain.challenge.entity.ChallengeStatus;
+import Hampouch.server.global.mysql.MySqlContainerTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * 유저당 진행 중 챌린지 1개 제약을 실 MySQL에서 확인한다 — 같은 검증이 ChallengeRepositoryTest에 H2로도 있지만,
+ * 이 제약은 DB가 status를 보고 채우는 계산 컬럼 active_user_id 위에 서 있고 H2는 그 정의를 흉내만 낸다.
+ * 동시 생성 경쟁의 마지막 방어선이라 운영 엔진에서 실제로 서는지를 따로 못 박아 둔다.
+ */
+@MySqlContainerTest
+@Transactional
+class ChallengeRepositoryMySqlTest {
+
+    @Autowired
+    ChallengeRepository challengeRepository;
+
+    /** userId의 챌린지를 저장하고, result가 있으면 그 상태로 종료시킨다(null이면 IN_PROGRESS 유지). */
+    private Challenge persist(Long userId, LocalDate start, ChallengeStatus result) {
+        Challenge challenge = Challenge.builder()
+                .userId(userId).durationDays(7).startDate(start)
+                .budgetTotal(70000).dailyLimit(10000).build();
+        if (result != null) {
+            challenge.applyResult(result);
+        }
+        return challengeRepository.save(challenge);
+    }
+
+    @Test
+    @DisplayName("같은 유저의 진행 중 챌린지가 이미 있으면 두 번째 저장을 MySQL 유니크 제약이 거절한다")
+    void rejectsSecondInProgressForSameUser() {
+        persist(1L, LocalDate.of(2026, 6, 1), null);
+
+        assertThatThrownBy(() -> persist(1L, LocalDate.of(2026, 6, 8), null))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    @DisplayName("진행 중 챌린지를 종료 상태로 바꾸면 MySQL이 계산 컬럼을 비워 같은 유저의 새 챌린지를 받아들인다")
+    void freesSlotAfterFinish() {
+        Challenge first = persist(2L, LocalDate.of(2026, 6, 1), null);
+        first.applyResult(ChallengeStatus.SUCCESS);
+        // 상태 변경 UPDATE를 먼저 내보낸다 — id가 IDENTITY라 아래 INSERT는 즉시 나가고, UPDATE가 그보다 늦으면
+        // DB엔 아직 진행 중 행이 남아 있어 제약에 걸린다
+        challengeRepository.flush();
+
+        persist(2L, LocalDate.of(2026, 6, 8), null);
+
+        assertThat(challengeRepository.existsInProgress(2L)).isTrue();
+    }
+}

--- a/src/test/java/Hampouch/server/global/mysql/MySqlContainerConfig.java
+++ b/src/test/java/Hampouch/server/global/mysql/MySqlContainerConfig.java
@@ -1,0 +1,34 @@
+package Hampouch.server.global.mysql;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.mysql.MySQLContainer;
+
+/**
+ * 실 MySQL 컨테이너를 데이터소스로 물리는 테스트 설정. @ServiceConnection이 접속 정보를 만들어
+ * 테스트 기본 설정(src/test/resources/application.yml)의 H2 url·드라이버보다 우선한다.
+ * DB 동작에 영향을 주는 이미지 태그와 문자 설정은 운영 docker-compose.prod.yml에 맞춘다.
+ */
+@TestConfiguration(proxyBeanMethods = false)
+public class MySqlContainerConfig {
+
+    static final String MYSQL_IMAGE = "mysql:8.0";
+    static final String MYSQL_CHARACTER_SET = "utf8mb4";
+    static final String MYSQL_COLLATION = "utf8mb4_unicode_ci";
+    static final String JDBC_TIME_ZONE = "Asia/Seoul";
+    static final String JDBC_CHARACTER_ENCODING = "utf8";
+
+    @Bean
+    @ServiceConnection
+    MySQLContainer mysqlContainer() {
+        return new MySQLContainer(MYSQL_IMAGE)
+                .withCommand(
+                        "--character-set-server=" + MYSQL_CHARACTER_SET,
+                        "--collation-server=" + MYSQL_COLLATION)
+                .withUrlParam("useSSL", "false")
+                .withUrlParam("allowPublicKeyRetrieval", "true")
+                .withUrlParam("serverTimezone", JDBC_TIME_ZONE)
+                .withUrlParam("characterEncoding", JDBC_CHARACTER_ENCODING);
+    }
+}

--- a/src/test/java/Hampouch/server/global/mysql/MySqlContainerTest.java
+++ b/src/test/java/Hampouch/server/global/mysql/MySqlContainerTest.java
@@ -1,0 +1,26 @@
+package Hampouch.server.global.mysql;
+
+import org.junit.jupiter.api.Tag;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+import java.lang.annotation.*;
+
+/**
+ * H2 대신 실 MySQL 컨테이너 위에서 도는 테스트에 붙인다.
+ * 설정을 이 한 곳에 모아 두는 이유는 스프링이 설정 조합을 키로 컨텍스트를 캐시하기 때문이다 —
+ * 클래스마다 프로퍼티를 따로 적으면 키가 갈려 컨테이너가 클래스 수만큼 뜬다.
+ * 기본 test에서는 제외되고 mysqlTest와 CI에서 실행한다. Docker 데몬이 없으면 실행 전에 실패한다.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@Tag("mysql")
+@SpringBootTest(properties = {
+        // 테스트 기본 설정이 H2Dialect로 못 박아 둔 것을 여기서만 되돌린다. 남겨 두면 MySQL에 H2 문법을 보낸다.
+        "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect"
+})
+@Import(MySqlContainerConfig.class)
+public @interface MySqlContainerTest {
+}

--- a/src/test/java/Hampouch/server/global/mysql/MySqlSchemaCreationTest.java
+++ b/src/test/java/Hampouch/server/global/mysql/MySqlSchemaCreationTest.java
@@ -1,0 +1,101 @@
+package Hampouch.server.global.mysql;
+
+import jakarta.persistence.EntityManagerFactory;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.ConnectionCallback;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static Hampouch.server.global.mysql.MySqlContainerConfig.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 엔티티 매핑이 실 MySQL에서 실제로 테이블이 되는지 확인한다.
+ * ddl-auto는 CREATE TABLE이 거부돼도 경고만 남기고 부팅을 계속하므로 "컨텍스트가 떴다"로는 판정이 안 되고,
+ * H2는 MySQL이 거부하는 예약어 컬럼을 통과시켜 기존 테스트가 전건 초록인 채로 배포까지 간 적이 있다.
+ */
+@MySqlContainerTest
+class MySqlSchemaCreationTest {
+
+    /**
+     * 예약어 컬럼 때문에 실 MySQL이 아직 만들지 못하는 테이블 — 원인이 고쳐지면 이 목록에서 뺀다.
+     * challenge_adjustment는 option 컬럼(수정본이 리뷰 대기), battle_participant는 rank 컬럼(배틀 담당)이다.
+     * 목록에 없는 테이블이 빠지면 새로 생긴 결함이므로 이 테스트가 실패한다.
+     */
+    private static final Set<String> KNOWN_MISSING_TABLES = Set.of("challenge_adjustment", "battle_participant");
+
+    @Autowired
+    EntityManagerFactory entityManagerFactory;
+    @Autowired
+    JdbcTemplate jdbc;
+
+    @Test
+    @DisplayName("운영과 같은 버전·문자 설정의 MySQL 컨테이너에 붙는다")
+    void connectsToRealMySql() {
+        String product = jdbc.execute((ConnectionCallback<String>) connection ->
+                connection.getMetaData().getDatabaseProductName());
+        String version = jdbc.execute((ConnectionCallback<String>) connection ->
+                connection.getMetaData().getDatabaseProductVersion());
+        String characterSet = jdbc.queryForObject("select @@character_set_server", String.class);
+        String collation = jdbc.queryForObject("select @@collation_server", String.class);
+
+        assertThat(product).isEqualTo("MySQL");
+        assertThat(version).startsWith(MYSQL_IMAGE.substring(MYSQL_IMAGE.indexOf(':') + 1));
+        assertThat(characterSet).isEqualTo(MYSQL_CHARACTER_SET);
+        assertThat(collation).isEqualTo(MYSQL_COLLATION);
+    }
+
+    @Test
+    @DisplayName("Testcontainers의 DB 설정이 운영 Compose 선언과 일치한다")
+    void matchesProductionCompose() throws IOException {
+        String compose = Files.readString(Path.of("docker-compose.prod.yml"));
+
+        assertThat(compose).contains(
+                "image: " + MYSQL_IMAGE,
+                "--character-set-server=" + MYSQL_CHARACTER_SET,
+                "--collation-server=" + MYSQL_COLLATION,
+                "serverTimezone=" + JDBC_TIME_ZONE,
+                "characterEncoding=" + JDBC_CHARACTER_ENCODING);
+    }
+
+    @Test
+    @DisplayName("엔티티 매핑에 있는 테이블이 실 MySQL에도 전부 만들어진다")
+    void everyMappedTableIsCreated() {
+        Set<String> mapped = mappedTableNames();
+        Set<String> created = createdTableNames();
+        Set<String> missing = new TreeSet<>(mapped);
+        missing.removeAll(created);
+
+        // 매핑을 못 읽으면 기대 집합이 비어 아래 검사가 무조건 통과한다
+        assertThat(mapped).as("엔티티 매핑에서 읽은 테이블 이름").isNotEmpty();
+        assertThat(missing).as("실 MySQL이 생성을 거부한 테이블").isSubsetOf(KNOWN_MISSING_TABLES);
+    }
+
+    private Set<String> mappedTableNames() {
+        Set<String> names = new TreeSet<>();
+        entityManagerFactory.unwrap(SessionFactoryImplementor.class)
+                .getMappingMetamodel()
+                .forEachEntityDescriptor(entity -> entity.forEachTableDetails(
+                        table -> names.add(table.getTableName().toLowerCase(Locale.ROOT))));
+        return names;
+    }
+
+    private Set<String> createdTableNames() {
+        // 컨테이너가 만든 DB 하나만 본다 — information_schema에는 mysql·sys 같은 시스템 스키마의 테이블도 들어 있다
+        List<String> names = jdbc.queryForList(
+                "select table_name from information_schema.tables where table_schema = database()", String.class);
+        Set<String> lowerCased = new TreeSet<>();
+        names.forEach(name -> lowerCased.add(name.toLowerCase(Locale.ROOT)));
+        return lowerCased;
+    }
+}


### PR DESCRIPTION
## 📎연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) closes #[issue number]

- close: #119

## 📄 작업 내용 요약
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.

- Testcontainers MySQL 8.0 설정과 `@MySqlContainerTest` 공통 테스트 어노테이션을 추가했습니다.
- 기본 `test`에서는 MySQL 태그를 제외하고, 전용 `mysqlTest`에서 Docker 데몬을 필수로 확인한 뒤 실행하도록 분리했습니다.
- 계산 컬럼 기반 유저당 진행 중 챌린지 1개 제약과 엔티티 스키마 생성을 실 MySQL에서 검증합니다.
- CI에서 `mysqlTest`를 실행하고 실패 시 기본·MySQL 테스트 리포트를 함께 업로드합니다.
- 실행 방법을 README에 추가하고, `Challenge`·`ChallengeRepository`의 주석을 현재 코드 기준으로 정리했습니다.

## 👀 중요 변경 사항
> API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요

- 로컬 기본 테스트는 `./gradlew test`, 실 MySQL 검증은 Docker를 켠 뒤 `./gradlew mysqlTest`로 실행합니다.
- 현재 MySQL이 생성하지 못하는 `challenge_adjustment`, `battle_participant`만 기존 예약어 컬럼 문제로 허용하며, 그 밖의 매핑 테이블 누락은 테스트가 실패합니다.
- `./gradlew test mysqlTest --no-daemon`과 Docker 이미지 빌드는 통과했습니다. MySQL 8.0에 앱을 연결해 부팅·health 요청 도달도 확인했으며, 실측용 더미 SMTP 때문에 mail health만 `DOWN`이었습니다.

## 🔖 Uncompleted Tasks
> 후속 작업 예정인 사항이 있다면 작성해주세요.

- 예약어 컬럼 수정 PR이 반영되면 스키마 검사의 기존 누락 허용 목록을 제거합니다.

## 📢 To Reviewers
> Reviewer가 주로 확인해주었으면 하는 부분을 적어주세요.

- 기본 H2 테스트와 전용 MySQL 테스트의 분리, CI에서 Docker 미사용 상태가 조용히 건너뛰어지지 않는지 확인 부탁드립니다.