### PR TITLE
fix(battle): 참가자 순위 컬럼명을 final_rank로 변경 (MySQL 예약어 충돌) (#124) [base: develop]

### DIFF
--- a/src/main/java/Hampouch/server/domain/battle/entity/BattleParticipant.java
+++ b/src/main/java/Hampouch/server/domain/battle/entity/BattleParticipant.java
@@ -2,6 +2,7 @@ package Hampouch.server.domain.battle.entity;
 
 import Hampouch.server.domain.user.entity.User;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Max;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -36,7 +37,11 @@ public class BattleParticipant {
     @Column(name = "is_valid", nullable = false)
     private boolean isValid;
 
-    /** 배틀 종료 시점 순위 — TERMINATED 스냅샷 전엔 null(Battle.penaltyUser와 동일 원칙) */
+    /** 배틀 종료 시점 순위 — TERMINATED 스냅샷 전엔 null(Battle.penaltyUser와 동일 원칙)
+     * rank가 Mysql 8.0 예약어이므로 columnName 수정이 필요하다
+     * */
+    @Column(name = "final_rank")
+    @Max(10)
     private Integer rank;
 
     /** 배틀 기간 동안 사용한 금액 — 위와 동일하게 스냅샷 전엔 null */


### PR DESCRIPTION
## 📎연관된 이슈

- close: #124 

## 📄 작업 내용 요약

- `BattleParticipant.rank` 필드에 `@Column(name = "final_rank")` 지정 — `RANK`가 MySQL 8.0.2+ 예약어(윈도우 함수)라 컬럼명이 `rank`인 채로는 `battle_participant` 테이블 생성 자체가 거부됨
- 컬럼명을 필드명과 다르게 둔 사유를 필드 Javadoc에 명시
- 클래스 Javadoc의 `rank/totalAmount` 언급을 변경된 컬럼명 기준으로 정리

## 👀 중요 변경 사항

- 자바 필드명은 `rank`를 그대로 유지했습니다. 바뀌는 건 DB 컬럼명뿐이라 `getRank()`, `finalizeResult(int rank, int totalAmount)`를 쓰는 코드와 기존 `BattleParticipantTest`는 수정 없이 그대로 동작합니다.
- JPQL·네이티브 쿼리에서 이 컬럼을 직접 참조하는 곳이 없어(`BattleParticipantRepository`의 `findMyParticipations`는 `Battle`의 필드로만 정렬) 변경 범위는 엔티티 한 파일입니다.
- 운영 DB에 `battle_participant` 테이블이 애초에 생성되지 못한 상태라 기존 데이터 마이그레이션은 필요하지 않습니다. 이 PR 배포 후 `ddl-auto=update`가 `final_rank`로 테이블을 새로 만들게 됩니다.
- PR #118 가 이 수정과 #113 을 선행 조건으로 대기 중입니다. 이 PR이 develop에 들어가면 남은 선행 조건은 PR #115 뿐입니다.

## 🔖 Uncompleted Tasks

- ERD의 `battle_participant` 순위 컬럼명 반영
- #99 에서 이 컬럼을 실제로 읽게 되므로, 해당 작업 시 정렬 쿼리가 `final_rank` 기준으로 작성되는지 확인 필요

## 📢 To Reviewers

- 컬럼명을 `final_rank`로 정했습니다. "종료 시점에 확정되는 스냅샷"이라는 필드 성격을 드러내는 쪽을 골랐는데, `battle_rank`나 `participant_rank`처럼 테이블명을 따르는 방식이 팀 컨벤션에 더 맞다면 말씀해주세요. 지금 바꾸는 게 나중보다 훨씬 쌉니다.
- 예약어 여부를 필드 단위로 눈으로 확인하는 방식이 이번으로 두 번째라, #119 (Testcontainers)가 들어오기 전까지 남은 엔티티를 한 번 훑어보는 게 좋을지 의견 부탁드립니다.