### PR TITLE
feat: 햄배틀 상세 조회 및 랭킹 API 구현

### DIFF
--- a/src/main/java/Hampouch/server/domain/battle/controller/BattleController.java
+++ b/src/main/java/Hampouch/server/domain/battle/controller/BattleController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import java.net.URI;
 
 /**
- * 햄배틀 생성/목록 조회/참가 링크 조회/참가 API. 상세조회+랭킹은 이후 이슈.
+ * 햄배틀 생성/목록 조회/상세 조회/참가 링크 조회/참가 API.
  */
 @RestController
 @RequestMapping(BattleController.BASE_PATH)
@@ -45,6 +45,18 @@ public class BattleController {
             @LoginUserId Long userId,
             @RequestParam(required = false) BattleStatus status) {
         return ApiResponse.success(battleService.getMyBattles(userId, status));
+    }
+
+    /**
+     * GET /api/battles/{battleId} — 배틀 상세 + 참가자 랭킹. 참가자만 조회 가능하며 아니면
+     * FORBIDDEN_NOT_PARTICIPANT. 경로 순서상 /invitations/{battleCode}보다 뒤에 둬야 하는 제약은
+     * 없음 — Spring MVC가 정적 세그먼트(/invitations)를 가변 세그먼트({battleId})보다 우선 매칭한다.
+     */
+    @GetMapping("/{battleId}")
+    public ApiResponse<BattleDetailResponse> getBattleDetail(
+            @LoginUserId Long userId,
+            @PathVariable Long battleId) {
+        return ApiResponse.success(battleService.getBattleDetail(userId, battleId));
     }
 
     /**

--- a/src/main/java/Hampouch/server/domain/battle/dto/BattleDetailResponse.java
+++ b/src/main/java/Hampouch/server/domain/battle/dto/BattleDetailResponse.java
@@ -36,8 +36,8 @@ public record BattleDetailResponse(
             String nickname,
             String avatarUrl,
             Integer rank,
-            int todayAmount,
-            int totalAmount,
+            long todayAmount,
+            long totalAmount,
             boolean isValid
     ) {
     }

--- a/src/main/java/Hampouch/server/domain/battle/dto/BattleDetailResponse.java
+++ b/src/main/java/Hampouch/server/domain/battle/dto/BattleDetailResponse.java
@@ -7,27 +7,29 @@ import java.time.LocalDate;
 import java.util.List;
 
 /**
- * GET /battles/{battleId} 응답 — 배틀 메타데이터와 참가자 랭킹을 하나로 합침
- * 26.05.01 - 26.05.07 (7일)와 같이 날짜범위와 기간을 같이 보여줌.
- * battleCode는 READY 상세 화면의 링크 다시 복사하기 버튼을 근거로 포함
+ * GET /battles/{battleId} 응답 — 배틀 메타데이터와 참가자 랭킹을 하나로 합침.
+ * penaltyTargetNickname: ONGOING 상세엔 "현재 꼴찌 : {닉네임}"이,
+ * TERMINATED 결과 화면엔 "{닉네임} 님이 벌칙을 수행해요"가 각각 노출됨
+ * 진행 중/종료 둘 다 벌칙 대상자가 필요해서 상태 무관하게 필드 하나로 통일.
+ * READY/CANCELLED의 경우 null.
  */
 public record BattleDetailResponse(
         Long battleId,
         String battleCode,
         String title,
         String penalty,
-        int capacity,
         LocalDate startDate,
         LocalDate endDate,
-        int durationDays,
         BattleStatus status,
-        List<ParticipantRanking> participants
+        List<ParticipantRanking> participants,
+        String penaltyTargetNickname
 ) {
 
     /**
-     * rank는 READY에서 null, ONGOING/TERMINATED에서만 값이 참 - BattleService가 상태별로 판단
-     * todayAmount는 TERMINATED에서 0 고정 — 배틀 종료 후엔
-     * 오늘 개념이 무의미(확정된 디자인 근거는 아직 없음, ③ 착수 시 임시 결정).
+     * rank는 READY에서 null, ONGOING/TERMINATED에서만 값이 참 - BattleService가 상태별로 판단.
+     * todayAmount는 TERMINATED에서 0 고정
+     * isValid는 BattleParticipant.isValid 그대로 노출 — 3일 연속 미기록 무효화 배치(④, 아직 미구현)
+     * 반영 시 바로 응답에 실리도록 지금 필드부터 추가해둠.
      */
     public record ParticipantRanking(
             Long userId,
@@ -35,22 +37,23 @@ public record BattleDetailResponse(
             String avatarUrl,
             Integer rank,
             int todayAmount,
-            int totalAmount
+            int totalAmount,
+            boolean isValid
     ) {
     }
 
-    public static BattleDetailResponse from(Battle battle, List<ParticipantRanking> participants) {
+    public static BattleDetailResponse from(Battle battle, List<ParticipantRanking> participants,
+                                             String penaltyTargetNickname) {
         return new BattleDetailResponse(
                 battle.getId(),
                 battle.getBattleCode(),
                 battle.getTitle(),
                 battle.getPenalty(),
-                battle.getCapacity(),
                 battle.getStartDate(),
                 battle.getEndDate(),
-                battle.getDurationDays(),
                 battle.getStatus(),
-                participants
+                participants,
+                penaltyTargetNickname
         );
     }
 }

--- a/src/main/java/Hampouch/server/domain/battle/dto/BattleDetailResponse.java
+++ b/src/main/java/Hampouch/server/domain/battle/dto/BattleDetailResponse.java
@@ -1,0 +1,56 @@
+package Hampouch.server.domain.battle.dto;
+
+import Hampouch.server.domain.battle.entity.Battle;
+import Hampouch.server.domain.battle.entity.BattleStatus;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * GET /battles/{battleId} 응답 — 배틀 메타데이터와 참가자 랭킹을 하나로 합침
+ * 26.05.01 - 26.05.07 (7일)와 같이 날짜범위와 기간을 같이 보여줌.
+ * battleCode는 READY 상세 화면의 링크 다시 복사하기 버튼을 근거로 포함
+ */
+public record BattleDetailResponse(
+        Long battleId,
+        String battleCode,
+        String title,
+        String penalty,
+        int capacity,
+        LocalDate startDate,
+        LocalDate endDate,
+        int durationDays,
+        BattleStatus status,
+        List<ParticipantRanking> participants
+) {
+
+    /**
+     * rank는 READY에서 null, ONGOING/TERMINATED에서만 값이 참 - BattleService가 상태별로 판단
+     * todayAmount는 TERMINATED에서 0 고정 — 배틀 종료 후엔
+     * 오늘 개념이 무의미(확정된 디자인 근거는 아직 없음, ③ 착수 시 임시 결정).
+     */
+    public record ParticipantRanking(
+            Long userId,
+            String nickname,
+            String avatarUrl,
+            Integer rank,
+            int todayAmount,
+            int totalAmount
+    ) {
+    }
+
+    public static BattleDetailResponse from(Battle battle, List<ParticipantRanking> participants) {
+        return new BattleDetailResponse(
+                battle.getId(),
+                battle.getBattleCode(),
+                battle.getTitle(),
+                battle.getPenalty(),
+                battle.getCapacity(),
+                battle.getStartDate(),
+                battle.getEndDate(),
+                battle.getDurationDays(),
+                battle.getStatus(),
+                participants
+        );
+    }
+}

--- a/src/main/java/Hampouch/server/domain/battle/dto/BattleSummary.java
+++ b/src/main/java/Hampouch/server/domain/battle/dto/BattleSummary.java
@@ -34,7 +34,7 @@ public sealed interface BattleSummary
             List<ParticipantAmount> participants
     ) implements BattleSummary {
         public record ParticipantAmount(
-                Long userId, String nickname, String avatarUrl, int todayAmount, int totalAmount
+                Long userId, String nickname, String avatarUrl, long todayAmount, long totalAmount
         ) {
         }
     }

--- a/src/main/java/Hampouch/server/domain/battle/repository/BattleParticipantRepository.java
+++ b/src/main/java/Hampouch/server/domain/battle/repository/BattleParticipantRepository.java
@@ -44,4 +44,15 @@ public interface BattleParticipantRepository extends JpaRepository<BattlePartici
             "WHERE p.battle.id = :battleId " +
             "ORDER BY p.joinedAt")
     List<BattleParticipant> findByBattle_IdWithUser(@Param("battleId") Long battleId);
+
+    /**
+     * GET /battles — ONGOING 카드 여러 개의 참가자를 배틀 ID 목록 기준으로 한 번에 가져온다
+     * (N+1 방지, PR #128 리뷰 반영 2026-08-11). findByBattle_IdWithUser의 배치 버전 —
+     * 정렬에 battle.id를 먼저 두는 이유: 호출부(BattleService)가 결과를 battle.id로
+     * groupingBy할 때 같은 배틀 안에서는 참가순(joinedAt)이 그대로 유지돼야 하기 때문.
+     */
+    @Query("SELECT p FROM BattleParticipant p JOIN FETCH p.user " +
+            "WHERE p.battle.id IN :battleIds " +
+            "ORDER BY p.battle.id, p.joinedAt")
+    List<BattleParticipant> findByBattle_IdInWithUser(@Param("battleIds") List<Long> battleIds);
 }

--- a/src/main/java/Hampouch/server/domain/battle/repository/BattleParticipantRepository.java
+++ b/src/main/java/Hampouch/server/domain/battle/repository/BattleParticipantRepository.java
@@ -31,4 +31,17 @@ public interface BattleParticipantRepository extends JpaRepository<BattlePartici
             "AND (:status IS NULL OR b.status = :status) " +
             "ORDER BY b.startDate DESC, b.id DESC")
     List<BattleParticipant> findMyParticipations(@Param("userId") Long userId, @Param("status") BattleStatus status);
+
+    /**
+     * GET /battles/{battleId} — 배틀 하나의 참가자 전원을 User와 함께 가져온다(N+1 방지).
+     * findMyParticipations가 p.battle을 JOIN FETCH하는 것과 반대 방향으로 p.user를 JOIN FETCH하는
+     * 이유: 여기선 battle 자체는 호출부(BattleService)가 findById로 이미 따로 들고 있고, 대신
+     * 참가자마다 user.nickname/avatarUrl/status(탈퇴 마스킹 판단용)를 화면에 그대로 노출해야 한다.
+     * 정렬은 참가순(joinedAt) 고정 — 랭킹 순서(등수)는 여기서 정하지 않고 서비스 계층의
+     * RankAssigner가 집계된 totalAmount 기준으로 별도 정렬한다
+     */
+    @Query("SELECT p FROM BattleParticipant p JOIN FETCH p.user " +
+            "WHERE p.battle.id = :battleId " +
+            "ORDER BY p.joinedAt")
+    List<BattleParticipant> findByBattle_IdWithUser(@Param("battleId") Long battleId);
 }

--- a/src/main/java/Hampouch/server/domain/battle/service/BattleService.java
+++ b/src/main/java/Hampouch/server/domain/battle/service/BattleService.java
@@ -230,8 +230,17 @@ public class BattleService {
                             ranked.item().todayAmount(), ranked.item().totalAmount()))
                     .toList();
             case TERMINATED -> participants.stream()
-                    // todayAmount=0 고정: 종료된 배틀엔 오늘 지출 X
-                    .map(p -> toRanking(p, p.getRank(), 0, p.getTotalAmount()))
+                    // todayAmount=0 고정: 종료된 배틀엔 오늘 지출 X, rank/totalAmount가 null이면
+                    // toRanking()의 int 언박싱에서 의미 불명확한 NPE를 원인을 바로 알 수 있는 예외로 바꾼다
+                    // 종료 배치가 finalizeResult()를 못 채운 데이터 정합성 문제이지 정상 동작 X
+                    .map(p -> {
+                        if (p.getRank() == null || p.getTotalAmount() == null) {
+                            throw new IllegalStateException(
+                                    "TERMINATED 참가자에 rank/totalAmount 스냅샷이 없음(userId=" +
+                                            p.getUser().getId() + ") — 종료 배치의 finalizeResult() 반영 여부 확인 필요");
+                        }
+                        return toRanking(p, p.getRank(), 0, p.getTotalAmount());
+                    })
                     .toList();
         };
     }

--- a/src/main/java/Hampouch/server/domain/battle/service/BattleService.java
+++ b/src/main/java/Hampouch/server/domain/battle/service/BattleService.java
@@ -261,7 +261,7 @@ public class BattleService {
     private List<BattleSummary.Ongoing.ParticipantAmount> toOngoingParticipantAmounts(Battle battle) {
         List<BattleParticipant> participants = battleParticipantRepository.findByBattle_IdWithUser(battle.getId());
         return computeOngoingSpends(battle, participants).stream()
-                .sorted(Comparator.comparingInt(ParticipantSpend::totalAmount))
+                .sorted(Comparator.comparingLong(ParticipantSpend::totalAmount))
                 .map(spend -> {
                     User user = spend.participant().getUser();
                     String avatarUrl = user.isDeleted() ? null : user.getProfileImageUrl();
@@ -306,8 +306,9 @@ public class BattleService {
         return participants.stream()
                 .map(p -> {
                     BattleParticipantSpending spending = spendingByUser.get(p.getUser().getId());
-                    int todayAmount = spending == null ? 0 : (int) spending.todayAmount();
-                    int totalAmount = spending == null ? 0 : (int) spending.totalAmount();
+                    // SUM()은 JPQL에서 Long으로 집계되는데 여기서 int로 좁히면 아주 큰 합계에서 조용히 오버플로가 날 수 있었다.
+                    long todayAmount = spending == null ? 0 : spending.todayAmount();
+                    long totalAmount = spending == null ? 0 : spending.totalAmount();
                     return new ParticipantSpend(p, todayAmount, totalAmount);
                 })
                 .toList();
@@ -348,7 +349,7 @@ public class BattleService {
      * 대체한다고 가정, 확정된 디자인 근거는 아직 없음, 임시 결정).
      * isValid는 BattleParticipant를 그대로 받아서 노출(무효화 배치 ④ 구현 전이라 지금은 항상 true).
      */
-    private BattleDetailResponse.ParticipantRanking toRanking(BattleParticipant participant, Integer rank, int todayAmount, int totalAmount) {
+    private BattleDetailResponse.ParticipantRanking toRanking(BattleParticipant participant, Integer rank, long todayAmount, long totalAmount) {
         User user = participant.getUser();
         String avatarUrl = user.isDeleted() ? null : user.getProfileImageUrl();
         return new BattleDetailResponse.ParticipantRanking(
@@ -360,6 +361,6 @@ public class BattleService {
     }
 
     /** computeOngoingSpends()의 결과 형태 — BattleParticipant와 today/total 집계값을 함께 들고 다닌다. */
-    private record ParticipantSpend(BattleParticipant participant, int todayAmount, int totalAmount) {
+    private record ParticipantSpend(BattleParticipant participant, long todayAmount, long totalAmount) {
     }
 }

--- a/src/main/java/Hampouch/server/domain/battle/service/BattleService.java
+++ b/src/main/java/Hampouch/server/domain/battle/service/BattleService.java
@@ -291,15 +291,19 @@ public class BattleService {
     /**
      * 참가자 전원의 today/total 지출을 실시간 집계 — battleId를 안 가진 Expense를 유저 + 기간
      * 교집합으로 묶는 유일한 지점(sumTodayAndTotalByUsers).
-     * 상한선을 battle.getEndDate()가 아닌 오늘로 잡는 이유: 미래 날짜엔 애초에 Expense row가 존재할 수 없어 결과는 같지만,
-     * 지금까지의 누적이라는 의도를 쿼리 파라미터로도 명확히 하기 위함.
+     * 집계 상한은 min(오늘, endDate)로 clamp — endDate가
+     * 지났는데 종료 배치가 아직 안 돌아서 여전히 ONGOING인 배틀이 실제로 있을 수 있다
+     * 그 창구에서 상한을 그냥 오늘로 두면 배틀 종료일 다음 날 지출까지 조용히 합계에 섞여 들어간다.
+     * today parameter 도입 시, 오늘이 endDate 이후라면 clamp된 end로 인해 BETWEEN 조건 자체에서
+     * 걸러지므로 todayAmount도 자연히 0이 된다 — today까지 따로 clamp할 필요는 없다.
      */
     private List<ParticipantSpend> computeOngoingSpends(Battle battle, List<BattleParticipant> participants) {
         LocalDate today = LocalDate.now(clock);
+        LocalDate aggregationEnd = today.isAfter(battle.getEndDate()) ? battle.getEndDate() : today;
         List<Long> userIds = participants.stream().map(p -> p.getUser().getId()).toList();
 
         Map<Long, BattleParticipantSpending> spendingByUser = expenseRepository
-                .sumTodayAndTotalByUsers(userIds, battle.getStartDate(), today, today, ExpenseStatus.ACTIVE)
+                .sumTodayAndTotalByUsers(userIds, battle.getStartDate(), aggregationEnd, today, ExpenseStatus.ACTIVE)
                 .stream()
                 .collect(Collectors.toMap(BattleParticipantSpending::userId, s -> s));
 

--- a/src/main/java/Hampouch/server/domain/battle/service/BattleService.java
+++ b/src/main/java/Hampouch/server/domain/battle/service/BattleService.java
@@ -229,20 +229,32 @@ public class BattleService {
                     .map(ranked -> toRanking(ranked.item().participant(), ranked.rank(),
                             ranked.item().todayAmount(), ranked.item().totalAmount()))
                     .toList();
-            case TERMINATED -> participants.stream()
-                    // todayAmount=0 고정: 종료된 배틀엔 오늘 지출 X, rank/totalAmount가 null이면
-                    // toRanking()의 int 언박싱에서 의미 불명확한 NPE를 원인을 바로 알 수 있는 예외로 바꾼다
-                    // 종료 배치가 finalizeResult()를 못 채운 데이터 정합성 문제이지 정상 동작 X
-                    .map(p -> {
-                        if (p.getRank() == null || p.getTotalAmount() == null) {
-                            throw new IllegalStateException(
-                                    "TERMINATED 참가자에 rank/totalAmount 스냅샷이 없음(userId=" +
-                                            p.getUser().getId() + ") — 종료 배치의 finalizeResult() 반영 여부 확인 필요");
-                        }
-                        return toRanking(p, p.getRank(), 0, p.getTotalAmount());
-                    })
-                    .toList();
+            case TERMINATED -> {
+                // rank/totalAmount 스냅샷 검증을 정렬보다 먼저 한다 — sorted()가 null rank를
+                // 만나면 의미 불명확한 NPE로 죽어버려서, 검증 없이 정렬부터 하면 안 된다.
+                participants.forEach(this::validateTerminatedSnapshot);
+                // findByBattle_IdWithUser()는 참가순(joinedAt)으로 오므로, rank 오름차순으로 다시 정렬해야
+                // 응답이 실제 순위 순서(1등부터)로 나간다 — todayAmount=0 고정(종료된 배틀엔 오늘 지출 X)
+                yield participants.stream()
+                        .sorted(Comparator.comparing(BattleParticipant::getRank))
+                        .map(p -> toRanking(p, p.getRank(), 0, p.getTotalAmount()))
+                        .toList();
+            }
         };
+    }
+
+    /**
+     * TERMINATED 참가자에 종료 배치가 남겨야 할 rank/totalAmount 스냅샷이 있는지 검증.
+     * 없으면 toRanking()의 int 언박싱에서 의미 불명확한 NPE가 나는 대신, 원인(종료 배치의
+     * finalizeResult() 미반영)을 바로 알 수 있는 예외로 막는다 — 종료 배치가 아직 없는 지금은
+     * 도달 불가능하지만, 배치 구현 후 버그를 조기에 잡기 위한 안전장치.
+     */
+    private void validateTerminatedSnapshot(BattleParticipant p) {
+        if (p.getRank() == null || p.getTotalAmount() == null) {
+            throw new IllegalStateException(
+                    "TERMINATED 참가자에 rank/totalAmount 스냅샷이 없음(userId=" +
+                            p.getUser().getId() + ") — 종료 배치의 finalizeResult() 반영 여부 확인 필요");
+        }
     }
 
     /** toSummary()의 ONGOING 카드용 — rank 없이 today/total만 필요해서 정렬만 하고 등수는 안 매긴다. */

--- a/src/main/java/Hampouch/server/domain/battle/service/BattleService.java
+++ b/src/main/java/Hampouch/server/domain/battle/service/BattleService.java
@@ -6,6 +6,9 @@ import Hampouch.server.domain.battle.entity.BattleParticipant;
 import Hampouch.server.domain.battle.entity.BattleStatus;
 import Hampouch.server.domain.battle.repository.BattleParticipantRepository;
 import Hampouch.server.domain.battle.repository.BattleRepository;
+import Hampouch.server.domain.expense.entity.ExpenseStatus;
+import Hampouch.server.domain.expense.repository.BattleParticipantSpending;
+import Hampouch.server.domain.expense.repository.ExpenseRepository;
 import Hampouch.server.domain.user.entity.User;
 import Hampouch.server.domain.user.repository.UserRepository;
 import Hampouch.server.global.common.exception.CustomException;
@@ -18,11 +21,14 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
- * 배틀 생성/목록/참가 링크 조회/참가의 서비스 계층. 상세조회·랭킹·배치는 이후 구현 예정.
+ * 배틀 생성/목록/상세/참가 링크 조회/참가의 서비스 계층. 무효화·종료 배치는 이후 구현 예정.
  */
 @Service
 @RequiredArgsConstructor
@@ -30,9 +36,11 @@ import java.util.Set;
 public class BattleService {
 
     private static final Set<Integer> ALLOWED_DURATIONS = Set.of(3, 7, 14, 31);
+    private static final String DELETED_USER_NICKNAME = "탈퇴한 사용자";
 
     private final BattleRepository battleRepository;
     private final BattleParticipantRepository battleParticipantRepository;
+    private final ExpenseRepository expenseRepository;
     private final UserRepository userRepository;
     private final BattleCodeGenerator battleCodeGenerator;
     private final Clock clock;
@@ -112,6 +120,26 @@ public class BattleService {
         return JoinBattleResponse.from(battle);
     }
 
+    /**
+     * GET /battles/{battleId}. 참가자 전원을 User와 함께 한 번에 가져온 뒤, 그 리스트로 요청자 참가 여부 판단
+     * 별도 exists 쿼리를 안 태우는 이유: 참가자가 최대 10명이라 리스트 순회 비용이 쿼리 하나보다 싸기 때문.
+     */
+    public BattleDetailResponse getBattleDetail(Long userId, Long battleId) {
+        Battle battle = battleRepository.findById(battleId)
+                .orElseThrow(() -> new CustomException(BattleErrorCode.BATTLE_NOT_FOUND));
+
+        List<BattleParticipant> participants = battleParticipantRepository.findByBattle_IdWithUser(battleId);
+        boolean isParticipant = participants.stream()
+                .anyMatch(p -> p.getUser().getId().equals(userId));
+        if (!isParticipant) {
+            throw new CustomException(BattleErrorCode.FORBIDDEN_NOT_PARTICIPANT);
+        }
+
+        List<BattleDetailResponse.ParticipantRanking> rankings = toRankings(battle, participants);
+        String penaltyTargetNickname = findPenaltyTargetNickname(battle, participants, rankings);
+        return BattleDetailResponse.from(battle, rankings, penaltyTargetNickname);
+    }
+
     private void validateCapacity(int capacity) {
         if (capacity < 2 || capacity > 10) {
             throw new CustomException(BattleErrorCode.INVALID_CAPACITY_RANGE);
@@ -155,9 +183,9 @@ public class BattleService {
     }
 
     /**
-     * status별 카드 shape 분기. ONGOING의 todayAmount/totalAmount, TERMINATED의 winnerNickname은
-     * 실시간 집계/랭킹 쿼리가 아직 없어 빈 값으로 스텁 — 시작일·종료일 배치가 없는 지금은
-     * 어떤 배틀도 실제로 이 상태에 도달하지 않아 당장 잘못된 값이 나갈 일은 없음.
+     * status별 카드 shape 분기. ONGOING/TERMINATED는 getBattleDetail()과 같은 집계 헬퍼
+     * (computeOngoingSpends/toRanking)를 재사용 — 이 배틀이 내가 참가 중인 배틀 목록에서
+     * 나온 것이므로 별도 FORBIDDEN 체크는 필요 없다
      */
     private BattleSummary toSummary(Battle battle) {
         return switch (battle.getStatus()) {
@@ -169,12 +197,12 @@ public class BattleService {
             case ONGOING -> new BattleSummary.Ongoing(
                     battle.getId(), battle.getBattleCode(), battle.getTitle(), battle.getPenalty(),
                     battle.getStartDate(), battle.getEndDate(), battle.getStatus(),
-                    List.of() // TODO(③): 참가자별 today/total 실시간 집계로 교체
+                    toOngoingParticipantAmounts(battle)
             );
             case TERMINATED -> new BattleSummary.Terminated(
                     battle.getId(), battle.getBattleCode(), battle.getTitle(), battle.getPenalty(),
                     battle.getStartDate(), battle.getEndDate(), battle.getStatus(),
-                    null // TODO(③): rank=1 참가자 닉네임으로 교체
+                    findWinnerNickname(battle)
             );
             // 도달 불가 — getMyBattles()의 필터 거절과 findMyParticipations()의 WHERE 제외로
             // 이미 두 겹 막혀 있다. sealed switch의 완전성 때문에 남기는 방어선이라, 여기 닿았다면
@@ -182,5 +210,135 @@ public class BattleService {
             case CANCELLED -> throw new IllegalStateException(
                     "CANCELLED 배틀이 목록 조회에 도달함 — 필터/쿼리 제외 로직 확인 필요");
         };
+    }
+
+    /**
+     * GET /battles/{battleId} 랭킹 리스트 — 상태별로 소스가 다르다.
+     * READY/CANCELLED: 아무도 지출을 집계할 시점이 아니므로 전부 0/null.
+     * ONGOING: 실시간 집계 + RankAssigner로 매 조회마다 다시 계산
+     * TERMINATED: 종료 배치가 BattleParticipant.finalizeResult()로 이미 박아둔 rank/totalAmount
+     * 스냅샷을 그대로 읽는다 — 햄배틀은 일괄 입력 기능이 없고 배틀 기간이 끝나면 산정되는 방식
+     */
+    private List<BattleDetailResponse.ParticipantRanking> toRankings(Battle battle, List<BattleParticipant> participants) {
+        return switch (battle.getStatus()) {
+            case READY, CANCELLED -> participants.stream()
+                    .map(p -> toRanking(p, null, 0, 0))
+                    .toList();
+            case ONGOING -> RankAssigner.assign(computeOngoingSpends(battle, participants), ParticipantSpend::totalAmount)
+                    .stream()
+                    .map(ranked -> toRanking(ranked.item().participant(), ranked.rank(),
+                            ranked.item().todayAmount(), ranked.item().totalAmount()))
+                    .toList();
+            case TERMINATED -> participants.stream()
+                    // todayAmount=0 고정: 종료된 배틀엔 오늘 지출 X
+                    .map(p -> toRanking(p, p.getRank(), 0, p.getTotalAmount()))
+                    .toList();
+        };
+    }
+
+    /** toSummary()의 ONGOING 카드용 — rank 없이 today/total만 필요해서 정렬만 하고 등수는 안 매긴다. */
+    private List<BattleSummary.Ongoing.ParticipantAmount> toOngoingParticipantAmounts(Battle battle) {
+        List<BattleParticipant> participants = battleParticipantRepository.findByBattle_IdWithUser(battle.getId());
+        return computeOngoingSpends(battle, participants).stream()
+                .sorted(Comparator.comparingInt(ParticipantSpend::totalAmount))
+                .map(spend -> {
+                    User user = spend.participant().getUser();
+                    String avatarUrl = user.isDeleted() ? null : user.getProfileImageUrl();
+                    return new BattleSummary.Ongoing.ParticipantAmount(
+                            user.getId(), maskedNickname(user), avatarUrl, spend.todayAmount(), spend.totalAmount());
+                })
+                .toList();
+    }
+
+    /**
+     * toSummary()의 TERMINATED 카드용 — rank=1 스냅샷을 가진 참가자의 닉네임. 동점 공동 1위인
+     * 경우 DTO가 String 하나만 받을 수 있어 참가 순서)상 먼저인 쪽을 대표로 노출
+     * (공동 우승 UI 표현은 이 DTO 범위 밖 — 확정된 디자인 근거 없음).
+     * rank=1인 참가자가 없으면 종료 배치가 finalizeResult()를 아직 못 채운 데이터 정합성 문제라
+     * 조용히 null을 주지 않고 터뜨린다.
+     */
+    private String findWinnerNickname(Battle battle) {
+        List<BattleParticipant> participants = battleParticipantRepository.findByBattle_IdWithUser(battle.getId());
+        BattleParticipant winner = participants.stream()
+                .filter(p -> p.getRank() != null && p.getRank() == 1)
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException(
+                        "TERMINATED 배틀에 rank=1 참가자가 없음 — 종료 배치의 finalizeResult() 반영 여부 확인 필요"));
+        return maskedNickname(winner.getUser());
+    }
+
+    /**
+     * 참가자 전원의 today/total 지출을 실시간 집계 — battleId를 안 가진 Expense를 유저 + 기간
+     * 교집합으로 묶는 유일한 지점(sumTodayAndTotalByUsers).
+     * 상한선을 battle.getEndDate()가 아닌 오늘로 잡는 이유: 미래 날짜엔 애초에 Expense row가 존재할 수 없어 결과는 같지만,
+     * 지금까지의 누적이라는 의도를 쿼리 파라미터로도 명확히 하기 위함.
+     */
+    private List<ParticipantSpend> computeOngoingSpends(Battle battle, List<BattleParticipant> participants) {
+        LocalDate today = LocalDate.now(clock);
+        List<Long> userIds = participants.stream().map(p -> p.getUser().getId()).toList();
+
+        Map<Long, BattleParticipantSpending> spendingByUser = expenseRepository
+                .sumTodayAndTotalByUsers(userIds, battle.getStartDate(), today, today, ExpenseStatus.ACTIVE)
+                .stream()
+                .collect(Collectors.toMap(BattleParticipantSpending::userId, s -> s));
+
+        return participants.stream()
+                .map(p -> {
+                    BattleParticipantSpending spending = spendingByUser.get(p.getUser().getId());
+                    int todayAmount = spending == null ? 0 : (int) spending.todayAmount();
+                    int totalAmount = spending == null ? 0 : (int) spending.totalAmount();
+                    return new ParticipantSpend(p, todayAmount, totalAmount);
+                })
+                .toList();
+    }
+
+    /**
+     * GET /battles/{battleId}용 벌칙 대상자
+     * ONGOING: 방금 계산한 rankings에서 등수가 가장 낮은 참가자를 그때그때 조회
+     * TERMINATED: Battle.penaltyUser 스냅샷이 이미 있으므로 재계산하지 않고 그 유저를 participants에서 찾아 적용
+     * READY/CANCELLED는 대상이 없어 null.
+     */
+    private String findPenaltyTargetNickname(Battle battle, List<BattleParticipant> participants,
+                                              List<BattleDetailResponse.ParticipantRanking> rankings) {
+        return switch (battle.getStatus()) {
+            case READY, CANCELLED -> null;
+            case ONGOING -> rankings.stream()
+                    .max(Comparator.comparingInt(BattleDetailResponse.ParticipantRanking::rank))
+                    .map(BattleDetailResponse.ParticipantRanking::nickname)
+                    .orElse(null);
+            case TERMINATED -> {
+                User penaltyUser = battle.getPenaltyUser();
+                if (penaltyUser == null) {
+                    throw new IllegalStateException(
+                            "TERMINATED 배틀에 penaltyUser가 없음 — 종료 배치의 terminate() 호출 여부 확인 필요");
+                }
+                yield participants.stream()
+                        .filter(p -> p.getUser().getId().equals(penaltyUser.getId()))
+                        .map(p -> maskedNickname(p.getUser()))
+                        .findFirst()
+                        .orElseThrow(() -> new IllegalStateException(
+                                "TERMINATED 배틀의 penaltyUser가 참가자 목록에 없음 — 데이터 정합성 확인 필요"));
+            }
+        };
+    }
+
+    /**
+     * 탈퇴 유저 마스킹 — 닉네임은 고정 문구로 가리고 avatarUrl은 null(프론트가 기본 아바타로
+     * 대체한다고 가정, 확정된 디자인 근거는 아직 없음, 임시 결정).
+     * isValid는 BattleParticipant를 그대로 받아서 노출(무효화 배치 ④ 구현 전이라 지금은 항상 true).
+     */
+    private BattleDetailResponse.ParticipantRanking toRanking(BattleParticipant participant, Integer rank, int todayAmount, int totalAmount) {
+        User user = participant.getUser();
+        String avatarUrl = user.isDeleted() ? null : user.getProfileImageUrl();
+        return new BattleDetailResponse.ParticipantRanking(
+                user.getId(), maskedNickname(user), avatarUrl, rank, todayAmount, totalAmount, participant.isValid());
+    }
+
+    private String maskedNickname(User user) {
+        return user.isDeleted() ? DELETED_USER_NICKNAME : user.getNickname();
+    }
+
+    /** computeOngoingSpends()의 결과 형태 — BattleParticipant와 today/total 집계값을 함께 들고 다닌다. */
+    private record ParticipantSpend(BattleParticipant participant, int todayAmount, int totalAmount) {
     }
 }

--- a/src/main/java/Hampouch/server/domain/battle/service/BattleService.java
+++ b/src/main/java/Hampouch/server/domain/battle/service/BattleService.java
@@ -7,6 +7,7 @@ import Hampouch.server.domain.battle.entity.BattleStatus;
 import Hampouch.server.domain.battle.repository.BattleParticipantRepository;
 import Hampouch.server.domain.battle.repository.BattleRepository;
 import Hampouch.server.domain.expense.entity.ExpenseStatus;
+import Hampouch.server.domain.expense.repository.BattleParticipantBattleSpending;
 import Hampouch.server.domain.expense.repository.BattleParticipantSpending;
 import Hampouch.server.domain.expense.repository.ExpenseRepository;
 import Hampouch.server.domain.user.entity.User;
@@ -22,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -80,8 +82,18 @@ public class BattleService {
 
         List<BattleParticipant> participation = battleParticipantRepository.findMyParticipations(userId, statusFilter);
 
+        // ONGOING 카드만 참가자+지출 집계가 필요하다 — 배틀마다 쿼리 2개씩 추가되던 N+1을
+        // 배틀 ID 목록 기준 일괄 조회 2번으로 줄인다
+        List<Long> ongoingBattleIds = participation.stream()
+                .map(BattleParticipant::getBattle)
+                .filter(battle -> battle.getStatus() == BattleStatus.ONGOING)
+                .map(Battle::getId)
+                .toList();
+        Map<Long, List<BattleSummary.Ongoing.ParticipantAmount>> ongoingParticipantsByBattle =
+                batchOngoingParticipantAmounts(ongoingBattleIds);
+
         List<BattleSummary> summaries = participation.stream()
-                .map(p -> toSummary(p.getBattle()))
+                .map(p -> toSummary(p.getBattle(), ongoingParticipantsByBattle))
                 .toList();
 
         return new BattleListResponse(summaries);
@@ -183,11 +195,11 @@ public class BattleService {
     }
 
     /**
-     * status별 카드 shape 분기. ONGOING/TERMINATED는 getBattleDetail()과 같은 집계 헬퍼
-     * (computeOngoingSpends/toRanking)를 재사용 — 이 배틀이 내가 참가 중인 배틀 목록에서
-     * 나온 것이므로 별도 FORBIDDEN 체크는 필요 없다
+     * status별 카드 shape 분기. TERMINATED는 getBattleDetail()과 같은 집계 헬퍼(findWinnerNickname)를
+     * 재사용 — 이 배틀이 내가 참가 중인 배틀 목록에서 나온 것이므로 별도 FORBIDDEN 체크는 필요 없다.
+     * ONGOING은 getMyBattles()가 배틀 ID 목록 기준으로 미리 일괄 조회해둔 맵에서 꺼내 쓴다
      */
-    private BattleSummary toSummary(Battle battle) {
+    private BattleSummary toSummary(Battle battle, Map<Long, List<BattleSummary.Ongoing.ParticipantAmount>> ongoingParticipantsByBattle) {
         return switch (battle.getStatus()) {
             case READY -> new BattleSummary.Ready(
                     battle.getId(), battle.getBattleCode(), battle.getTitle(), battle.getPenalty(),
@@ -197,7 +209,7 @@ public class BattleService {
             case ONGOING -> new BattleSummary.Ongoing(
                     battle.getId(), battle.getBattleCode(), battle.getTitle(), battle.getPenalty(),
                     battle.getStartDate(), battle.getEndDate(), battle.getStatus(),
-                    toOngoingParticipantAmounts(battle)
+                    ongoingParticipantsByBattle.getOrDefault(battle.getId(), List.of())
             );
             case TERMINATED -> new BattleSummary.Terminated(
                     battle.getId(), battle.getBattleCode(), battle.getTitle(), battle.getPenalty(),
@@ -257,18 +269,47 @@ public class BattleService {
         }
     }
 
-    /** toSummary()의 ONGOING 카드용 — rank 없이 today/total만 필요해서 정렬만 하고 등수는 안 매긴다. */
-    private List<BattleSummary.Ongoing.ParticipantAmount> toOngoingParticipantAmounts(Battle battle) {
-        List<BattleParticipant> participants = battleParticipantRepository.findByBattle_IdWithUser(battle.getId());
-        return computeOngoingSpends(battle, participants).stream()
-                .sorted(Comparator.comparingLong(ParticipantSpend::totalAmount))
-                .map(spend -> {
-                    User user = spend.participant().getUser();
-                    String avatarUrl = user.isDeleted() ? null : user.getProfileImageUrl();
-                    return new BattleSummary.Ongoing.ParticipantAmount(
-                            user.getId(), maskedNickname(user), avatarUrl, spend.todayAmount(), spend.totalAmount());
-                })
-                .toList();
+    /**
+     * toSummary()의 ONGOING 카드용 — getBattleDetail()의 computeOngoingSpends()(단일 배틀)와 달리
+     * 여기는 참가 목록 전체의 ONGOING 배틀들을 배틀 ID 목록 기준으로 한 번에 조회·집계한 뒤 배틀별로
+     * 묶는다. rank 없이 today/total만 필요해서 정렬만 하고 등수는 안 매긴다.
+     */
+    private Map<Long, List<BattleSummary.Ongoing.ParticipantAmount>> batchOngoingParticipantAmounts(List<Long> battleIds) {
+        if (battleIds.isEmpty()) {
+            return Map.of();
+        }
+
+        Map<Long, List<BattleParticipant>> participantsByBattle = battleParticipantRepository
+                .findByBattle_IdInWithUser(battleIds).stream()
+                .collect(Collectors.groupingBy(p -> p.getBattle().getId()));
+
+        LocalDate today = LocalDate.now(clock);
+        Map<Long, List<BattleParticipantBattleSpending>> spendingByBattle = expenseRepository
+                .sumTodayAndTotalByBattleIds(battleIds, today, ExpenseStatus.ACTIVE).stream()
+                .collect(Collectors.groupingBy(BattleParticipantBattleSpending::battleId));
+
+        Map<Long, List<BattleSummary.Ongoing.ParticipantAmount>> result = new HashMap<>();
+        for (Long battleId : battleIds) {
+            List<BattleParticipant> participants = participantsByBattle.getOrDefault(battleId, List.of());
+            Map<Long, BattleParticipantBattleSpending> spendingByUser = spendingByBattle
+                    .getOrDefault(battleId, List.of()).stream()
+                    .collect(Collectors.toMap(BattleParticipantBattleSpending::userId, s -> s));
+
+            List<BattleSummary.Ongoing.ParticipantAmount> amounts = participants.stream()
+                    .map(p -> {
+                        BattleParticipantBattleSpending spending = spendingByUser.get(p.getUser().getId());
+                        long todayAmount = spending == null ? 0 : spending.todayAmount();
+                        long totalAmount = spending == null ? 0 : spending.totalAmount();
+                        User user = p.getUser();
+                        String avatarUrl = user.isDeleted() ? null : user.getProfileImageUrl();
+                        return new BattleSummary.Ongoing.ParticipantAmount(
+                                user.getId(), maskedNickname(user), avatarUrl, todayAmount, totalAmount);
+                    })
+                    .sorted(Comparator.comparingLong(BattleSummary.Ongoing.ParticipantAmount::totalAmount))
+                    .toList();
+            result.put(battleId, amounts);
+        }
+        return result;
     }
 
     /**

--- a/src/main/java/Hampouch/server/domain/battle/service/RankAssigner.java
+++ b/src/main/java/Hampouch/server/domain/battle/service/RankAssigner.java
@@ -3,7 +3,7 @@ package Hampouch.server.domain.battle.service;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.function.ToIntFunction;
+import java.util.function.ToLongFunction;
 
 /**
  * 배틀 랭킹 계산 전용 순수 함수 클래스 — Repository/Entity에 의존하지 않아 BattleService의
@@ -21,21 +21,23 @@ public class RankAssigner {
     }
 
     /**
-     * amountExtractor로 뽑은 값이 작을수록 높은 등수(1위)를 받는다.
+     * amountExtractor로 뽑은 값이 작을수록 높은 등수(1위)를 받는다. long을 쓰는 이유(PR #128 리뷰
+     * 반영, 2026-08-11): 지출 합계는 DB에서 SUM()으로 집계되는 순간 JPQL 규약상 Long이 되므로,
+     * 여기서 int로 좁히면 아주 큰 합계에서 조용히 오버플로가 날 수 있다.
      * 반환 리스트는 입력 순서가 아니라 등수 오름차순으로 정렬되어 있다 — 호출부가 곧바로
      * 응답 리스트 순서로 써도 되게 하기 위함(BattleDetailResponse.participants는 랭킹 순으로 노출).
      */
-    public static <T> List<Ranked<T>> assign(List<T> items, ToIntFunction<T> amountExtractor) {
+    public static <T> List<Ranked<T>> assign(List<T> items, ToLongFunction<T> amountExtractor) {
         List<T> sorted = items.stream()
-                .sorted(Comparator.comparingInt(amountExtractor))
+                .sorted(Comparator.comparingLong(amountExtractor))
                 .toList();
 
         List<Ranked<T>> result = new ArrayList<>(sorted.size());
         int rank = 0;
-        int previousAmount = 0;
+        long previousAmount = 0;
         for (int i = 0; i < sorted.size(); i++) {
             T item = sorted.get(i);
-            int amount = amountExtractor.applyAsInt(item);
+            long amount = amountExtractor.applyAsLong(item);
             if (i == 0 || amount != previousAmount) {
                 rank = i + 1;
             }

--- a/src/main/java/Hampouch/server/domain/battle/service/RankAssigner.java
+++ b/src/main/java/Hampouch/server/domain/battle/service/RankAssigner.java
@@ -1,0 +1,47 @@
+package Hampouch.server.domain.battle.service;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.ToIntFunction;
+
+/**
+ * 배틀 랭킹 계산 전용 순수 함수 클래스 — Repository/Entity에 의존하지 않아 BattleService의
+ * getBattleDetail()과 toSummary()의 TERMINATED 분기(winnerNickname) 양쪽에서 재사용하고,
+ * RankAssignerTest로 리포지토리/DB 없이 독립 단위 테스트가 가능하다.
+ * battle domain 특성상 total_amount가 작을수록 좋은 등수 — 오름차순 고정.
+ * 동점자는 같은 등수를 공유하고 다음 등수는 그만큼 건너뛴다(경쟁 순위, 예: 1,1,3,4)
+ */
+public class RankAssigner {
+
+    private RankAssigner() {
+    }
+
+    public record Ranked<T>(T item, int rank) {
+    }
+
+    /**
+     * amountExtractor로 뽑은 값이 작을수록 높은 등수(1위)를 받는다.
+     * 반환 리스트는 입력 순서가 아니라 등수 오름차순으로 정렬되어 있다 — 호출부가 곧바로
+     * 응답 리스트 순서로 써도 되게 하기 위함(BattleDetailResponse.participants는 랭킹 순으로 노출).
+     */
+    public static <T> List<Ranked<T>> assign(List<T> items, ToIntFunction<T> amountExtractor) {
+        List<T> sorted = items.stream()
+                .sorted(Comparator.comparingInt(amountExtractor))
+                .toList();
+
+        List<Ranked<T>> result = new ArrayList<>(sorted.size());
+        int rank = 0;
+        int previousAmount = 0;
+        for (int i = 0; i < sorted.size(); i++) {
+            T item = sorted.get(i);
+            int amount = amountExtractor.applyAsInt(item);
+            if (i == 0 || amount != previousAmount) {
+                rank = i + 1;
+            }
+            result.add(new Ranked<>(item, rank));
+            previousAmount = amount;
+        }
+        return result;
+    }
+}

--- a/src/main/java/Hampouch/server/domain/expense/repository/BattleParticipantBattleSpending.java
+++ b/src/main/java/Hampouch/server/domain/expense/repository/BattleParticipantBattleSpending.java
@@ -1,0 +1,10 @@
+package Hampouch.server.domain.expense.repository;
+
+/**
+ * ExpenseRepository.sumTodayAndTotalByBattleIds() 전용 JPQL 생성자 표현식 DTO.
+ * BattleParticipantSpending과 다른 점은 battleId를 함께 들고 다닌다는 것 — 여러 배틀을 한 번에
+ * 집계할 때(GET /battles의 ONGOING 카드들) 어느 배틀의 today/total인지 구분할 유일한 방법이라
+ * 필드로 얹었다
+ */
+public record BattleParticipantBattleSpending(Long battleId, Long userId, long todayAmount, long totalAmount) {
+}

--- a/src/main/java/Hampouch/server/domain/expense/repository/BattleParticipantSpending.java
+++ b/src/main/java/Hampouch/server/domain/expense/repository/BattleParticipantSpending.java
@@ -1,0 +1,11 @@
+package Hampouch.server.domain.expense.repository;
+
+/**
+ * ExpenseRepository.sumTodayAndTotalByUsers() 전용 JPQL 생성자 표현식 DTO.
+ * battle 도메인이 소비하지만 Expense가 홈인 쿼리라 ExpenseDailyTotal과 같은 패키지에 둔다
+ * (Battle은 battle_id를 안 갖고 있어 battle→expense 연결은 참가자 user + 기간 교집합으로만
+ * 가능 — 그 연결을 만드는 쪽은 항상 Expense 리포지토리여야 한다는 원칙).
+ * SUM()은 JPQL에서 Long으로 집계되므로 필드 타입도 long(ExpenseDailyTotal과 동일 컨벤션).
+ */
+public record BattleParticipantSpending(Long userId, long todayAmount, long totalAmount) {
+}

--- a/src/main/java/Hampouch/server/domain/expense/repository/ExpenseRepository.java
+++ b/src/main/java/Hampouch/server/domain/expense/repository/ExpenseRepository.java
@@ -1,5 +1,6 @@
 package Hampouch.server.domain.expense.repository;
 
+import Hampouch.server.domain.battle.entity.BattleParticipant;
 import Hampouch.server.domain.expense.entity.Expense;
 import Hampouch.server.domain.expense.entity.ExpenseStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -112,4 +113,27 @@ public interface ExpenseRepository extends JpaRepository<Expense, Long> {
                                                               @Param("end") LocalDate end,
                                                               @Param("today") LocalDate today,
                                                               @Param("status") ExpenseStatus status);
+
+    /**
+     * GET /battles — ONGOING 카드 여러 개의 today/total을 배틀 ID 목록 기준으로 한 번에 집계
+     * sumTodayAndTotalByUsers처럼 바깥에서 단일 start/end를 주는 방식으로는 배틀마다 startDate가 다르고 한 유저가 여러 배틀에 동시 참가할
+     * 수도 있어 배틀별로 올바르게 못 나눈다 — 그래서 각 배틀 자신의 startDate/endDate를 쿼리
+     * 안에서 직접 참조하는 명시적 ON 조인으로 묶는다
+     * end는 min(오늘, endDate)로 clamp — computeOngoingSpends()와 동일 원칙
+     */
+    @Query("""
+            SELECT new Hampouch.server.domain.expense.repository.BattleParticipantBattleSpending(
+                p.battle.id, e.user.id,
+                SUM(CASE WHEN e.expenseDate = :today THEN e.price ELSE 0 END),
+                SUM(e.price))
+            FROM BattleParticipant p
+            JOIN Expense e ON e.user.id = p.user.id AND e.status = :status
+                AND e.expenseDate BETWEEN p.battle.startDate
+                    AND (CASE WHEN :today < p.battle.endDate THEN :today ELSE p.battle.endDate END)
+            WHERE p.battle.id IN :battleIds
+            GROUP BY p.battle.id, e.user.id
+            """)
+    List<BattleParticipantBattleSpending> sumTodayAndTotalByBattleIds(@Param("battleIds") List<Long> battleIds,
+                                                                       @Param("today") LocalDate today,
+                                                                       @Param("status") ExpenseStatus status);
 }

--- a/src/main/java/Hampouch/server/domain/expense/repository/ExpenseRepository.java
+++ b/src/main/java/Hampouch/server/domain/expense/repository/ExpenseRepository.java
@@ -49,8 +49,8 @@ public interface ExpenseRepository extends JpaRepository<Expense, Long> {
     int sumPriceByUserIdAndExpenseDateAndStatus(@Param("userId") Long userId, @Param("date") LocalDate date, @Param("status") ExpenseStatus status);
 
     /**
-     * 합계(sum)만으로는 그 날짜에 기록 자체가 없음과 그 날짜 기록의 합계가 0원임을 구분할 수 없어
-     * 별도 존재 확인 쿼리로 둔다.
+     * ExpenseService.getDaySpending()에서 DaySpending.hasRecord를 채우는 용도 — 합계(sum)만으로는
+     * 그 날짜에 기록 자체가 없음과 그 날짜 기록의 합계가 0원임을 구분할 수 없어 별도 존재 확인 쿼리로 둔다.
      */
     boolean existsByUser_IdAndExpenseDateAndStatus(Long userId, LocalDate expenseDate, ExpenseStatus status);
 
@@ -88,4 +88,28 @@ public interface ExpenseRepository extends JpaRepository<Expense, Long> {
             """)
     List<Expense> findPeriodExpenses(@Param("userId") Long userId, @Param("status") ExpenseStatus status,
                                      @Param("start") LocalDate start, @Param("end") LocalDate end);
+
+    /**
+     * BattleService.getBattleDetail()/toSummary() 공용 — 배틀 참가자 전원의 today/total 지출 합계를
+     * 유저당 한 행으로 한 번에 집계(참가자 최대 10명 — hampouch_battle_api_review 확정 "쿼리 타임 실시간
+     * 집계, 참가자 최대 10명이라 비용 부담 없음"). CASE WHEN으로 today 조건부 합계를 total 합계와 같은
+     * GROUP BY에 얹어 쿼리 1번으로 두 값을 동시에 반환(Today/Total 토글 응답에 둘 다 필요하다는 요구사항 반영).
+     * 지출이 하나도 없는 참가자는 이 결과 자체에 행이 안 생긴다 — 호출부(BattleService)가 userId 기준
+     * 맵으로 변환한 뒤 없는 유저는 0으로 채워야 한다(coalesce로 쿼리 안에서 0 채우면 GROUP BY 대상이 아예
+     * 없는 유저는 여전히 행 자체가 안 나와서 의미 없음).
+     */
+    @Query("""
+            SELECT new Hampouch.server.domain.expense.repository.BattleParticipantSpending(
+                e.user.id,
+                SUM(CASE WHEN e.expenseDate = :today THEN e.price ELSE 0 END),
+                SUM(e.price))
+            FROM Expense e
+            WHERE e.user.id IN :userIds AND e.status = :status AND e.expenseDate BETWEEN :start AND :end
+            GROUP BY e.user.id
+            """)
+    List<BattleParticipantSpending> sumTodayAndTotalByUsers(@Param("userIds") List<Long> userIds,
+                                                              @Param("start") LocalDate start,
+                                                              @Param("end") LocalDate end,
+                                                              @Param("today") LocalDate today,
+                                                              @Param("status") ExpenseStatus status);
 }

--- a/src/test/java/Hampouch/server/domain/battle/BattleTransactionIntegrationTest.java
+++ b/src/test/java/Hampouch/server/domain/battle/BattleTransactionIntegrationTest.java
@@ -1,0 +1,189 @@
+package Hampouch.server.domain.battle;
+
+import Hampouch.server.domain.battle.dto.BattleDetailResponse;
+import Hampouch.server.domain.battle.dto.CreateBattleRequest;
+import Hampouch.server.domain.battle.dto.CreateBattleResponse;
+import Hampouch.server.domain.battle.entity.Battle;
+import Hampouch.server.domain.battle.entity.BattleParticipant;
+import Hampouch.server.domain.battle.repository.BattleParticipantRepository;
+import Hampouch.server.domain.battle.repository.BattleRepository;
+import Hampouch.server.domain.battle.service.BattleService;
+import Hampouch.server.domain.expense.entity.Expense;
+import Hampouch.server.domain.expense.entity.ExpenseCategory;
+import Hampouch.server.domain.expense.entity.ExpenseEmotion;
+import Hampouch.server.domain.expense.repository.ExpenseRepository;
+import Hampouch.server.domain.user.entity.User;
+import Hampouch.server.domain.user.repository.UserRepository;
+import Hampouch.server.global.common.exception.CustomException;
+import Hampouch.server.global.common.exception.domain.BattleErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * H2 test DB에 실제로 커밋되는지 검증 — 테스트 레벨 @Transactional을 일부러 안 붙인다(롤백되면
+ * "커밋됐다"는 걸 증명 못 함, ExpenseTransactionIntegrationTest와 동일 원칙).
+ * Mockito 목으로는 실행된 적 없는 실제 JPQL(findByBattle_IdWithUser의 JOIN FETCH,
+ * sumTodayAndTotalByUsers의 CASE WHEN GROUP BY 집계)이 H2(MODE=MySQL)에서 진짜로 동작하는지
+ * 확인하는 게 이 테스트의 핵심 목적 — 네트워크 문제로 로컬 컴파일 확인을 못 했던 부분이라 더 중요.
+ */
+@SpringBootTest
+class BattleTransactionIntegrationTest {
+
+    private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
+
+    @Autowired
+    BattleService battleService;
+    @Autowired
+    BattleRepository battleRepository;
+    @Autowired
+    BattleParticipantRepository battleParticipantRepository;
+    @Autowired
+    ExpenseRepository expenseRepository;
+    @Autowired
+    UserRepository userRepository;
+
+    @Test
+    @DisplayName("배틀 생성은 Battle과 생성자 참가자 행을 커밋하고, 참가는 새 참가자 행을 커밋한다 " +
+            "— 서비스 호출이 끝날 때마다 별도 리포지토리 조회로 다시 읽어도 반영돼 있어야 한다")
+    void createAndJoinCommitRowsAfterServiceCall() {
+        LocalDate today = LocalDate.now(SEOUL);
+        User creator = userRepository.save(User.createLocalUser(
+                "battle-tx-creator@hampouch.test", "encoded", "배틀생성자"));
+        User joiner = userRepository.save(User.createLocalUser(
+                "battle-tx-joiner@hampouch.test", "encoded", "배틀참가자"));
+
+        CreateBattleResponse created = battleService.create(creator.getId(),
+                new CreateBattleRequest("트랜잭션 생성 배틀", 3, 7, today, "치킨 사주기"));
+
+        Battle persistedBattle = battleRepository.findByBattleCode(created.battleCode()).orElseThrow();
+        assertThat(persistedBattle.getId()).isEqualTo(created.battleId());
+        assertThat(battleParticipantRepository.existsByBattle_IdAndUser_Id(created.battleId(), creator.getId()))
+                .isTrue();
+        assertThat(battleParticipantRepository.countByBattle_Id(created.battleId())).isEqualTo(1);
+
+        battleService.join(joiner.getId(), created.battleCode());
+
+        assertThat(battleParticipantRepository.existsByBattle_IdAndUser_Id(created.battleId(), joiner.getId()))
+                .isTrue();
+        assertThat(battleParticipantRepository.countByBattle_Id(created.battleId())).isEqualTo(2);
+
+        // 커밋된 참가 행을 별도 서비스 호출(재조회)이 그대로 봐야 함 — ALREADY_JOINED는
+        // 서비스 계층 existsBy 체크가 방금 커밋된 행을 실제로 읽어야만 나올 수 있는 에러
+        assertThatThrownBy(() -> battleService.join(joiner.getId(), created.battleCode()))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", BattleErrorCode.ALREADY_JOINED);
+    }
+
+    @Test
+    @DisplayName("ONGOING 상세 조회는 실제 Expense 행을 CASE WHEN 집계 쿼리로 today/total 반영해서 " +
+            "경쟁 순위를 매기고, 지출 없는 참가자는 0원으로 랭킹 1위가 된다")
+    void getBattleDetail_ongoing_aggregatesRealExpensesAndRanks() {
+        LocalDate today = LocalDate.now(SEOUL);
+        LocalDate battleStart = today.minusDays(2);
+
+        User owner = userRepository.save(User.createLocalUser(
+                "battle-tx-owner@hampouch.test", "encoded", "배틀오너"));
+        User bigSpender = userRepository.save(User.createLocalUser(
+                "battle-tx-spender@hampouch.test", "encoded", "많이쓴사람"));
+        User noSpend = userRepository.save(User.createLocalUser(
+                "battle-tx-nospend@hampouch.test", "encoded", "안쓴사람"));
+
+        Battle battle = Battle.of("TXBT0001", "트랜잭션 집계 배틀", 3, 7, battleStart, "커피 사기", owner);
+        battle.start();
+        battle = battleRepository.save(battle);
+
+        battleParticipantRepository.save(BattleParticipant.of(owner, battle));
+        battleParticipantRepository.save(BattleParticipant.of(bigSpender, battle));
+        battleParticipantRepository.save(BattleParticipant.of(noSpend, battle));
+
+        // owner: 과거 2000원 + 오늘 1000원 = 총 3000원(today=1000)
+        expenseRepository.save(Expense.of("어제 커피", 2000, ExpenseCategory.CAFE, ExpenseEmotion.STRESS,
+                battleStart.plusDays(1), owner));
+        expenseRepository.save(Expense.of("오늘 커피", 1000, ExpenseCategory.CAFE, ExpenseEmotion.STRESS,
+                today, owner));
+        // bigSpender: 과거 8000원(오늘 지출 없음) = 총 8000원(today=0)
+        expenseRepository.save(Expense.of("과거 지출", 8000, ExpenseCategory.CAFE, ExpenseEmotion.STRESS,
+                battleStart.plusDays(1), bigSpender));
+        // noSpend: 지출 행 자체가 없음 → 0원으로 채워져야 함
+
+        BattleDetailResponse res = battleService.getBattleDetail(owner.getId(), battle.getId());
+
+        BattleDetailResponse.ParticipantRanking ownerRanking = participant(res, owner.getId());
+        BattleDetailResponse.ParticipantRanking spenderRanking = participant(res, bigSpender.getId());
+        BattleDetailResponse.ParticipantRanking noSpendRanking = participant(res, noSpend.getId());
+
+        assertThat(ownerRanking.todayAmount()).isEqualTo(1000);
+        assertThat(ownerRanking.totalAmount()).isEqualTo(3000);
+        assertThat(spenderRanking.todayAmount()).isZero();
+        assertThat(spenderRanking.totalAmount()).isEqualTo(8000);
+        assertThat(noSpendRanking.todayAmount()).isZero();
+        assertThat(noSpendRanking.totalAmount()).isZero();
+
+        // 오름차순 랭킹: 안 쓴 사람(0원) 1위 → 오너(3000원) 2위 → 많이 쓴 사람(8000원) 3위(벌칙 대상)
+        assertThat(noSpendRanking.rank()).isEqualTo(1);
+        assertThat(ownerRanking.rank()).isEqualTo(2);
+        assertThat(spenderRanking.rank()).isEqualTo(3);
+        assertThat(res.penaltyTargetNickname()).isEqualTo(bigSpender.getNickname());
+        assertThat(res.participants()).allSatisfy(p -> assertThat(p.isValid()).isTrue());
+    }
+
+    @Test
+    @DisplayName("TERMINATED 상세 조회는 재집계하지 않고 참가자 스냅샷을 그대로 읽는다 " +
+            "— 종료 후 추가된 Expense가 있어도 totalAmount가 스냅샷 값에서 안 바뀌어야 한다")
+    void getBattleDetail_terminated_readsSnapshotNotLiveExpenses() {
+        LocalDate today = LocalDate.now(SEOUL);
+        LocalDate battleStart = today.minusDays(10);
+
+        User winner = userRepository.save(User.createLocalUser(
+                "battle-tx-winner@hampouch.test", "encoded", "우승자"));
+        User loser = userRepository.save(User.createLocalUser(
+                "battle-tx-loser@hampouch.test", "encoded", "꼴찌"));
+
+        Battle battle = Battle.of("TXBT0002", "트랜잭션 종료 배틀", 2, 14, battleStart, "삼겹살 쏘기", winner);
+        battle.start();
+        battle = battleRepository.save(battle);
+
+        BattleParticipant winnerParticipant = battleParticipantRepository.save(BattleParticipant.of(winner, battle));
+        BattleParticipant loserParticipant = battleParticipantRepository.save(BattleParticipant.of(loser, battle));
+        // save()가 반환한 엔티티는 그 save() 호출의 트랜잭션이 끝나며 detach된다 — finalizeResult()로
+        // 메모리 값만 바꾸고 다시 save()하지 않으면 DB엔 반영이 안 된다(커밋 검증이 핵심인 테스트라 특히 중요).
+        winnerParticipant.finalizeResult(1, 5000);
+        loserParticipant.finalizeResult(2, 90000);
+        battleParticipantRepository.save(winnerParticipant);
+        battleParticipantRepository.save(loserParticipant);
+        battle.terminate(loser);
+        battleRepository.save(battle);
+
+        // 종료 이후에 생긴 지출 — 재집계된다면 winner의 totalAmount가 크게 튀어야 정상
+        expenseRepository.save(Expense.of("종료 후 지출", 99999, ExpenseCategory.CAFE, ExpenseEmotion.STRESS,
+                today, winner));
+
+        BattleDetailResponse res = battleService.getBattleDetail(winner.getId(), battle.getId());
+
+        BattleDetailResponse.ParticipantRanking winnerRanking = participant(res, winner.getId());
+        BattleDetailResponse.ParticipantRanking loserRanking = participant(res, loser.getId());
+
+        assertThat(winnerRanking.totalAmount()).isEqualTo(5000); // 스냅샷 값 그대로 — 99999 안 섞임
+        assertThat(winnerRanking.todayAmount()).isZero();
+        assertThat(loserRanking.totalAmount()).isEqualTo(90000);
+        assertThat(loserRanking.todayAmount()).isZero();
+        assertThat(winnerRanking.rank()).isEqualTo(1);
+        assertThat(loserRanking.rank()).isEqualTo(2);
+        assertThat(res.penaltyTargetNickname()).isEqualTo(loser.getNickname());
+    }
+
+    private BattleDetailResponse.ParticipantRanking participant(BattleDetailResponse res, Long userId) {
+        return res.participants().stream()
+                .filter(p -> p.userId().equals(userId))
+                .findFirst()
+                .orElseThrow();
+    }
+}

--- a/src/test/java/Hampouch/server/domain/battle/BattleTransactionIntegrationTest.java
+++ b/src/test/java/Hampouch/server/domain/battle/BattleTransactionIntegrationTest.java
@@ -1,6 +1,8 @@
 package Hampouch.server.domain.battle;
 
 import Hampouch.server.domain.battle.dto.BattleDetailResponse;
+import Hampouch.server.domain.battle.dto.BattleListResponse;
+import Hampouch.server.domain.battle.dto.BattleSummary;
 import Hampouch.server.domain.battle.dto.CreateBattleRequest;
 import Hampouch.server.domain.battle.dto.CreateBattleResponse;
 import Hampouch.server.domain.battle.entity.Battle;
@@ -210,6 +212,50 @@ class BattleTransactionIntegrationTest {
 
         BattleDetailResponse.ParticipantRanking ownerRanking = participant(res, owner.getId());
         assertThat(ownerRanking.totalAmount()).isEqualTo(5000); // 3000 + 2000, 99999(종료일 다음날)는 안 섞임
+    }
+
+    @Test
+    @DisplayName("getMyBattles는 ONGOING 배틀 여러 개의 today/total을 배틀별 기간으로 정확히 나눠 집계한다 " +
+            "— 같은 유저가 시작일이 다른 배틀 두 개에 동시 참가해도 지출이 서로 섞이지 않아야 한다 " +
+            "(2026-08-11, PR #128 리뷰로 N+1 방지 위해 신설한 배치 쿼리의 배틀별 기간 분리를 실제 H2로 검증)")
+    void getMyBattles_ongoing_separatesSpendByEachBattlesOwnDateWindow() {
+        LocalDate today = LocalDate.now(SEOUL);
+        User owner = userRepository.save(User.createLocalUser(
+                "battle-tx-multiongoing@hampouch.test", "encoded", "동시참가자"));
+
+        // battleNear: 5일 전 시작 — 창구는 [오늘-5, 오늘]
+        Battle battleNear = Battle.of("TXBT0004", "최근 시작 배틀", 3, 31, today.minusDays(5), "젤리 사기", owner);
+        battleNear.start();
+        battleNear = battleRepository.save(battleNear);
+        // battleFar: 15일 전 시작 — 창구는 [오늘-15, 오늘]
+        Battle battleFar = Battle.of("TXBT0005", "오래 전 시작 배틀", 3, 31, today.minusDays(15), "아이스크림 사기", owner);
+        battleFar.start();
+        battleFar = battleRepository.save(battleFar);
+
+        battleParticipantRepository.save(BattleParticipant.of(owner, battleNear));
+        battleParticipantRepository.save(BattleParticipant.of(owner, battleFar));
+
+        // 오늘-3일 지출 — battleNear([오늘-5,오늘])·battleFar([오늘-15,오늘]) 둘 다의 기간 안 → 양쪽 다 집계돼야 함
+        expenseRepository.save(Expense.of("두 배틀 다 겹치는 지출", 1000, ExpenseCategory.CAFE, ExpenseEmotion.STRESS,
+                today.minusDays(3), owner));
+        // 오늘-10일 지출 — battleFar 기간 안이지만 battleNear 시작(오늘-5) 이전 → battleFar에만 집계돼야 함
+        expenseRepository.save(Expense.of("오래 전 배틀에만 속하는 지출", 2000, ExpenseCategory.CAFE, ExpenseEmotion.STRESS,
+                today.minusDays(10), owner));
+
+        BattleListResponse res = battleService.getMyBattles(owner.getId(), null);
+
+        BattleSummary.Ongoing near = ongoingSummary(res, battleNear.getId());
+        BattleSummary.Ongoing far = ongoingSummary(res, battleFar.getId());
+        assertThat(near.participants().getFirst().totalAmount()).isEqualTo(1000L); // 겹치는 지출만
+        assertThat(far.participants().getFirst().totalAmount()).isEqualTo(3000L); // 겹치는 지출 + 오래 전 지출
+    }
+
+    private BattleSummary.Ongoing ongoingSummary(BattleListResponse res, Long battleId) {
+        return res.battles().stream()
+                .filter(b -> b.battleId().equals(battleId))
+                .map(BattleSummary.Ongoing.class::cast)
+                .findFirst()
+                .orElseThrow();
     }
 
     private BattleDetailResponse.ParticipantRanking participant(BattleDetailResponse res, Long userId) {

--- a/src/test/java/Hampouch/server/domain/battle/BattleTransactionIntegrationTest.java
+++ b/src/test/java/Hampouch/server/domain/battle/BattleTransactionIntegrationTest.java
@@ -180,6 +180,38 @@ class BattleTransactionIntegrationTest {
         assertThat(res.penaltyTargetNickname()).isEqualTo(loser.getNickname());
     }
 
+    @Test
+    @DisplayName("배틀 종료일이 지났는데 아직 ONGOING이면(④ 종료 배치 실행 전 창구) 종료일 다음 날 " +
+            "지출은 집계에서 빠진다 — 실제 H2에 종료일 당일/다음날 지출을 함께 심어서 경계값까지 확인 " +
+            "(2026-08-11, PR #128 리뷰로 발견: endDate가 아니라 오늘을 상한으로 쓰면 조용히 섞여 들어갔음)")
+    void getBattleDetail_ongoing_excludesExpensesAfterBattleEndDateWhenTerminationBatchHasNotRunYet() {
+        LocalDate today = LocalDate.now(SEOUL);
+        LocalDate battleStart = today.minusDays(10);
+
+        User owner = userRepository.save(User.createLocalUser(
+                "battle-tx-lateowner@hampouch.test", "encoded", "늦은오너"));
+
+        Battle battle = Battle.of("TXBT0003", "종료일 경계 배틀", 2, 7, battleStart, "아이스크림 사기", owner);
+        battle.start(); // ONGOING — endDate가 지났어도 ④ 종료 배치가 없어 여전히 이 상태로 남을 수 있음
+        battle = battleRepository.save(battle);
+        LocalDate endDate = battle.getEndDate(); // battleStart + 6 = 오늘보다 4일 전
+        assertThat(endDate).isBefore(today); // 이 테스트가 겨냥하는 창구(종료일 < 오늘)를 전제로 함
+
+        battleParticipantRepository.save(BattleParticipant.of(owner, battle));
+
+        expenseRepository.save(Expense.of("배틀 기간 안 지출", 3000, ExpenseCategory.CAFE, ExpenseEmotion.STRESS,
+                battleStart.plusDays(1), owner));
+        expenseRepository.save(Expense.of("종료일 당일 지출", 2000, ExpenseCategory.CAFE, ExpenseEmotion.STRESS,
+                endDate, owner)); // 경계값 — endDate 포함은 그대로 유지돼야 함
+        expenseRepository.save(Expense.of("종료일 다음날 지출", 99999, ExpenseCategory.CAFE, ExpenseEmotion.STRESS,
+                endDate.plusDays(1), owner)); // 종료 배치가 아직 안 돈 창구에서 새던 지출 — 집계에서 빠져야 함
+
+        BattleDetailResponse res = battleService.getBattleDetail(owner.getId(), battle.getId());
+
+        BattleDetailResponse.ParticipantRanking ownerRanking = participant(res, owner.getId());
+        assertThat(ownerRanking.totalAmount()).isEqualTo(5000); // 3000 + 2000, 99999(종료일 다음날)는 안 섞임
+    }
+
     private BattleDetailResponse.ParticipantRanking participant(BattleDetailResponse res, Long userId) {
         return res.participants().stream()
                 .filter(p -> p.userId().equals(userId))

--- a/src/test/java/Hampouch/server/domain/battle/controller/BattleControllerTest.java
+++ b/src/test/java/Hampouch/server/domain/battle/controller/BattleControllerTest.java
@@ -244,4 +244,50 @@ class BattleControllerTest {
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.code").value("ALREADY_JOINED"));
     }
+
+    // ---------- getBattleDetail ----------
+
+    @Test
+    @DisplayName("상세 조회가 정상이면 200과 배틀 상세 + 참가자 랭킹을 돌려준다 " +
+            "(capacity/durationDays는 응답에 없음 — Notion 명세서 확인, 2026-08-09)")
+    void getBattleDetail_200() throws Exception {
+        when(service.getBattleDetail(OWNER, 1L)).thenReturn(new BattleDetailResponse(
+                1L, "ABCD1234", "짠테크 배틀", "치킨 사주기",
+                LocalDate.of(2026, 8, 1), LocalDate.of(2026, 8, 7), BattleStatus.ONGOING,
+                List.of(new BattleDetailResponse.ParticipantRanking(
+                        OWNER, "나", "https://avatar", 1, 1000, 5000, true)),
+                "나"));
+
+        mvc.perform(get("/api/battles/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.battleId").value(1))
+                .andExpect(jsonPath("$.data.participants[0].rank").value(1))
+                .andExpect(jsonPath("$.data.participants[0].isValid").value(true))
+                .andExpect(jsonPath("$.data.penaltyTargetNickname").value("나"))
+                .andExpect(jsonPath("$.data.capacity").doesNotExist())
+                .andExpect(jsonPath("$.data.durationDays").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("참가자가 아니면 403(FORBIDDEN_NOT_PARTICIPANT)을 돌려준다")
+    void getBattleDetail_403_whenNotParticipant() throws Exception {
+        when(service.getBattleDetail(OWNER, 1L))
+                .thenThrow(new CustomException(BattleErrorCode.FORBIDDEN_NOT_PARTICIPANT));
+
+        mvc.perform(get("/api/battles/1"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("FORBIDDEN_NOT_PARTICIPANT"));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 battleId면 404(BATTLE_NOT_FOUND)를 돌려준다")
+    void getBattleDetail_404_whenNotFound() throws Exception {
+        when(service.getBattleDetail(OWNER, 999L))
+                .thenThrow(new CustomException(BattleErrorCode.BATTLE_NOT_FOUND));
+
+        mvc.perform(get("/api/battles/999"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("BATTLE_NOT_FOUND"));
+    }
 }

--- a/src/test/java/Hampouch/server/domain/battle/repository/BattleParticipantRepositoryTest.java
+++ b/src/test/java/Hampouch/server/domain/battle/repository/BattleParticipantRepositoryTest.java
@@ -7,6 +7,7 @@ import Hampouch.server.domain.user.entity.User;
 import Hampouch.server.domain.user.repository.UserRepository;
 import Hampouch.server.global.config.ClockConfig;
 import Hampouch.server.global.config.JpaAuditingConfig;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -35,6 +36,8 @@ class BattleParticipantRepositoryTest {
     BattleRepository battleRepository;
     @Autowired
     BattleParticipantRepository battleParticipantRepository;
+    @Autowired
+    EntityManager em; // JOIN FETCH가 실제로 User를 채워왔는지 1차 캐시 비우고 확인하려면 필요
 
     private User me;
     private User other;
@@ -125,5 +128,22 @@ class BattleParticipantRepositoryTest {
         List<BattleParticipant> result = battleParticipantRepository.findMyParticipations(me.getId(), null);
 
         assertThat(result).extracting(p -> p.getBattle().getId()).containsExactly(ready.getId());
+    }
+
+    @Test
+    @DisplayName("findByBattle_IdWithUser는 그 배틀의 참가자만 참가순(joinedAt)으로, User를 함께 가져온다(JOIN FETCH)")
+    void findByBattleIdWithUser_returnsThatBattleParticipantsWithUserOrderedByJoinedAt() {
+        Battle battle = battle("ABCD1234", LocalDate.of(2026, 8, 1));
+        Battle otherBattle = battle("ZZZZ9999", LocalDate.of(2026, 8, 1));
+        battleParticipantRepository.saveAndFlush(BattleParticipant.of(other, battle));
+        battleParticipantRepository.saveAndFlush(BattleParticipant.of(me, battle));
+        battleParticipantRepository.save(BattleParticipant.of(me, otherBattle)); // 다른 배틀 참가자 — 섞이면 안 됨
+        em.flush();
+        em.clear(); // 1차 캐시를 비워 JOIN FETCH가 실제로 User를 채워왔는지(지연 로딩 예외 없이) 확인
+
+        List<BattleParticipant> result = battleParticipantRepository.findByBattle_IdWithUser(battle.getId());
+
+        assertThat(result).extracting(p -> p.getUser().getNickname())
+                .containsExactly(other.getNickname(), me.getNickname()); // 먼저 참가한 other가 먼저(joinedAt ASC)
     }
 }

--- a/src/test/java/Hampouch/server/domain/battle/service/BattleServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/battle/service/BattleServiceTest.java
@@ -6,6 +6,7 @@ import Hampouch.server.domain.battle.entity.BattleParticipant;
 import Hampouch.server.domain.battle.entity.BattleStatus;
 import Hampouch.server.domain.battle.repository.BattleParticipantRepository;
 import Hampouch.server.domain.battle.repository.BattleRepository;
+import Hampouch.server.domain.expense.entity.ExpenseStatus;
 import Hampouch.server.domain.expense.repository.BattleParticipantSpending;
 import Hampouch.server.domain.expense.repository.ExpenseRepository;
 import Hampouch.server.domain.user.entity.User;
@@ -32,6 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 /**
@@ -493,6 +495,24 @@ class BattleServiceTest {
 
         assertThat(res.participants().getFirst().todayAmount()).isEqualTo(hugeTodayAmount);
         assertThat(res.participants().getFirst().totalAmount()).isEqualTo(hugeTotalAmount);
+    }
+
+    @Test
+    @DisplayName("배틀 종료일이 지났는데 아직 ONGOING이면(④ 종료 배치 실행 전 창구) 집계 상한을 " +
+            "오늘이 아니라 종료일로 clamp해서 리포지토리를 호출한다 — 종료일 다음 지출이 안 섞이도록 " +
+            "(2026-08-11, PR #128 리뷰 반영: endDate로 today를 주면 종료일 이후 지출까지 포함될 수 있었음)")
+    void getBattleDetail_ongoingClampsAggregationEndToBattleEndDateWhenTodayIsAfter() {
+        Battle battle = battleWithStatus(BattleStatus.ONGOING, 4); // startDate 2026-08-01, durationDays 7 -> endDate 2026-08-07
+        BattleParticipant me = BattleParticipant.of(user(OWNER), battle);
+        when(battleRepository.findById(BATTLE_ID)).thenReturn(Optional.of(battle));
+        when(battleParticipantRepository.findByBattle_IdWithUser(BATTLE_ID)).thenReturn(List.of(me));
+        when(expenseRepository.sumTodayAndTotalByUsers(anyList(), any(), any(), any(), any())).thenReturn(List.of());
+        LocalDate today = LocalDate.of(2026, 8, 10); // endDate(8/7)보다 3일 지남 — 종료 배치가 아직 안 돈 창구를 가정
+
+        serviceAt(today).getBattleDetail(OWNER, BATTLE_ID);
+
+        verify(expenseRepository).sumTodayAndTotalByUsers(
+                eq(List.of(OWNER)), eq(battle.getStartDate()), eq(battle.getEndDate()), eq(today), eq(ExpenseStatus.ACTIVE));
     }
 
     @Test

--- a/src/test/java/Hampouch/server/domain/battle/service/BattleServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/battle/service/BattleServiceTest.java
@@ -7,6 +7,7 @@ import Hampouch.server.domain.battle.entity.BattleStatus;
 import Hampouch.server.domain.battle.repository.BattleParticipantRepository;
 import Hampouch.server.domain.battle.repository.BattleRepository;
 import Hampouch.server.domain.expense.entity.ExpenseStatus;
+import Hampouch.server.domain.expense.repository.BattleParticipantBattleSpending;
 import Hampouch.server.domain.expense.repository.BattleParticipantSpending;
 import Hampouch.server.domain.expense.repository.ExpenseRepository;
 import Hampouch.server.domain.user.entity.User;
@@ -198,8 +199,8 @@ class BattleServiceTest {
         battle.start();
         BattleParticipant participation = BattleParticipant.of(user(OWNER), battle);
         when(battleParticipantRepository.findMyParticipations(OWNER, null)).thenReturn(List.of(participation));
-        when(battleParticipantRepository.findByBattle_IdWithUser(10L)).thenReturn(List.of(participation));
-        when(expenseRepository.sumTodayAndTotalByUsers(anyList(), any(), any(), any(), any())).thenReturn(List.of());
+        when(battleParticipantRepository.findByBattle_IdInWithUser(List.of(10L))).thenReturn(List.of(participation));
+        when(expenseRepository.sumTodayAndTotalByBattleIds(eq(List.of(10L)), any(), any())).thenReturn(List.of());
 
         BattleListResponse res = serviceAt(LocalDate.of(2026, 7, 1)).getMyBattles(OWNER, null);
 
@@ -207,6 +208,59 @@ class BattleServiceTest {
         assertThat(summary.participants()).hasSize(1);
         assertThat(summary.participants().getFirst().todayAmount()).isZero();
         assertThat(summary.participants().getFirst().totalAmount()).isZero();
+    }
+
+    @Test
+    @DisplayName("ONGOING 배틀이 여러 개여도 참가자 조회·지출 집계 쿼리는 배틀 ID 목록 기준으로 딱 한 번씩만 나간다 " +
+            "(2026-08-11, PR #128 리뷰 반영 — 원래는 ONGOING 배틀마다 쿼리 2개씩 추가되던 N+1이었음)")
+    void getMyBattles_batchesOngoingQueriesAcrossMultipleBattles() {
+        Battle battleA = Battle.of("AAAA0001", "배틀A", 4, 7, LocalDate.of(2026, 8, 1), "치킨 사주기", user(OWNER));
+        Battle battleB = Battle.of("BBBB0002", "배틀B", 4, 7, LocalDate.of(2026, 7, 1), "커피 사기", user(OWNER));
+        ReflectionTestUtils.setField(battleA, "id", 10L);
+        ReflectionTestUtils.setField(battleB, "id", 20L);
+        battleA.start();
+        battleB.start();
+        BattleParticipant participationA = BattleParticipant.of(user(OWNER), battleA);
+        BattleParticipant participationB = BattleParticipant.of(user(OWNER), battleB);
+        when(battleParticipantRepository.findMyParticipations(OWNER, null))
+                .thenReturn(List.of(participationA, participationB));
+        when(battleParticipantRepository.findByBattle_IdInWithUser(List.of(10L, 20L)))
+                .thenReturn(List.of(participationA, participationB));
+        when(expenseRepository.sumTodayAndTotalByBattleIds(eq(List.of(10L, 20L)), any(), any()))
+                .thenReturn(List.of(
+                        new BattleParticipantBattleSpending(10L, OWNER, 0, 1000),
+                        new BattleParticipantBattleSpending(20L, OWNER, 0, 2000)));
+
+        BattleListResponse res = serviceAt(LocalDate.of(2026, 7, 10)).getMyBattles(OWNER, null);
+
+        assertThat(res.battles()).hasSize(2);
+        BattleSummary.Ongoing summaryA = (BattleSummary.Ongoing) res.battles().stream()
+                .filter(b -> b.battleId().equals(10L)).findFirst().orElseThrow();
+        BattleSummary.Ongoing summaryB = (BattleSummary.Ongoing) res.battles().stream()
+                .filter(b -> b.battleId().equals(20L)).findFirst().orElseThrow();
+        assertThat(summaryA.participants().getFirst().totalAmount()).isEqualTo(1000L);
+        assertThat(summaryB.participants().getFirst().totalAmount()).isEqualTo(2000L);
+        // 배틀이 2개인데도 참가자 조회·지출 집계 쿼리는 각각 딱 1번만 — 배틀 개수만큼 늘어나지 않는다.
+        verify(battleParticipantRepository, times(1)).findByBattle_IdInWithUser(anyList());
+        verify(expenseRepository, times(1)).sumTodayAndTotalByBattleIds(anyList(), any(), any());
+        verify(battleParticipantRepository, never()).findByBattle_IdWithUser(any());
+        verify(expenseRepository, never()).sumTodayAndTotalByUsers(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("참가 목록에 ONGOING 배틀이 하나도 없으면 배치 조회 쿼리 자체를 안 태운다")
+    void getMyBattles_skipsOngoingBatchQueriesWhenNoOngoingBattles() {
+        Battle battle = Battle.of("ABCD1234", "짠테크 배틀", 4, 7, LocalDate.of(2026, 8, 1), "치킨 사주기", user(OWNER));
+        ReflectionTestUtils.setField(battle, "id", 10L);
+        BattleParticipant participation = BattleParticipant.of(user(OWNER), battle); // READY 그대로
+
+        when(battleParticipantRepository.findMyParticipations(OWNER, null)).thenReturn(List.of(participation));
+        when(battleParticipantRepository.countByBattle_Id(10L)).thenReturn(1);
+
+        serviceAt(LocalDate.of(2026, 7, 1)).getMyBattles(OWNER, null);
+
+        verify(battleParticipantRepository, never()).findByBattle_IdInWithUser(any());
+        verifyNoInteractions(expenseRepository);
     }
 
     @Test

--- a/src/test/java/Hampouch/server/domain/battle/service/BattleServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/battle/service/BattleServiceTest.java
@@ -477,6 +477,25 @@ class BattleServiceTest {
     }
 
     @Test
+    @DisplayName("ONGOING 지출 합계가 int 최대값을 넘어도 오버플로 없이 그대로 반환한다")
+    void getBattleDetail_ongoingDoesNotOverflowWhenAmountExceedsIntRange() {
+        Battle battle = battleWithStatus(BattleStatus.ONGOING, 4);
+        BattleParticipant me = BattleParticipant.of(user(OWNER), battle);
+        when(battleRepository.findById(BATTLE_ID)).thenReturn(Optional.of(battle));
+        when(battleParticipantRepository.findByBattle_IdWithUser(BATTLE_ID)).thenReturn(List.of(me));
+        // int였다면 랩어라운드돼 음수가 됐어야 할 값들 — 예전 (int) 캐스팅이 남아있다면 이 테스트가 실패한다.
+        long hugeTodayAmount = Integer.MAX_VALUE + 500L;
+        long hugeTotalAmount = Integer.MAX_VALUE + 1000L;
+        when(expenseRepository.sumTodayAndTotalByUsers(anyList(), any(), any(), any(), any()))
+                .thenReturn(List.of(new BattleParticipantSpending(OWNER, hugeTodayAmount, hugeTotalAmount)));
+
+        BattleDetailResponse res = serviceAt(LocalDate.of(2026, 7, 10)).getBattleDetail(OWNER, BATTLE_ID);
+
+        assertThat(res.participants().getFirst().todayAmount()).isEqualTo(hugeTodayAmount);
+        assertThat(res.participants().getFirst().totalAmount()).isEqualTo(hugeTotalAmount);
+    }
+
+    @Test
     @DisplayName("TERMINATED는 재집계하지 않고 참가자 스냅샷(rank/totalAmount)을 그대로 읽고, " +
             "리포지토리가 반환한 순서와 무관하게 rank 오름차순으로 정렬해 반환한다 " +
             "— todayAmount는 0 고정, penaltyTargetNickname은 Battle.penaltyUser 스냅샷에서 나온다 " +
@@ -499,9 +518,9 @@ class BattleServiceTest {
         BattleDetailResponse res = serviceAt(LocalDate.of(2026, 7, 20)).getBattleDetail(OWNER, BATTLE_ID);
 
         assertThat(res.participants()).extracting(BattleDetailResponse.ParticipantRanking::todayAmount)
-                .containsExactly(0, 0);
+                .containsExactly(0L, 0L);
         assertThat(res.participants()).extracting(BattleDetailResponse.ParticipantRanking::totalAmount)
-                .containsExactly(10000, 50000);
+                .containsExactly(10000L, 50000L);
         assertThat(res.participants()).extracting(BattleDetailResponse.ParticipantRanking::rank)
                 .containsExactly(1, 2);
         assertThat(res.penaltyTargetNickname()).isEqualTo(loser.getNickname());

--- a/src/test/java/Hampouch/server/domain/battle/service/BattleServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/battle/service/BattleServiceTest.java
@@ -477,8 +477,10 @@ class BattleServiceTest {
     }
 
     @Test
-    @DisplayName("TERMINATED는 재집계하지 않고 참가자 스냅샷(rank/totalAmount)을 그대로 읽는다 " +
-            "— todayAmount는 0 고정, penaltyTargetNickname은 Battle.penaltyUser 스냅샷에서 나온다")
+    @DisplayName("TERMINATED는 재집계하지 않고 참가자 스냅샷(rank/totalAmount)을 그대로 읽고, " +
+            "리포지토리가 반환한 순서와 무관하게 rank 오름차순으로 정렬해 반환한다 " +
+            "— todayAmount는 0 고정, penaltyTargetNickname은 Battle.penaltyUser 스냅샷에서 나온다 " +
+            "(2026-08-11, PR #128 리뷰 반영 — 원래는 정렬을 안 해서 리포지토리 반환 순서 그대로 나갔음)")
     void getBattleDetail_terminatedUsesSnapshot() {
         Battle battle = battleWithStatus(BattleStatus.ONGOING, 4);
         User winner = user(1L);
@@ -489,8 +491,10 @@ class BattleServiceTest {
         loserParticipant.finalizeResult(2, 50000);
         battle.terminate(loser);
         when(battleRepository.findById(BATTLE_ID)).thenReturn(Optional.of(battle));
+        // 일부러 rank와 반대 순서(loser=2등 먼저, winner=1등 나중)로 반환 — 서비스가 정렬을 안 하면
+        // 이 테스트가 실패해야 한다(findByBattle_IdWithUser는 참가순이지 rank순이 아니므로 실제로 있을 수 있는 순서).
         when(battleParticipantRepository.findByBattle_IdWithUser(BATTLE_ID))
-                .thenReturn(List.of(winnerParticipant, loserParticipant));
+                .thenReturn(List.of(loserParticipant, winnerParticipant));
 
         BattleDetailResponse res = serviceAt(LocalDate.of(2026, 7, 20)).getBattleDetail(OWNER, BATTLE_ID);
 

--- a/src/test/java/Hampouch/server/domain/battle/service/BattleServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/battle/service/BattleServiceTest.java
@@ -6,6 +6,8 @@ import Hampouch.server.domain.battle.entity.BattleParticipant;
 import Hampouch.server.domain.battle.entity.BattleStatus;
 import Hampouch.server.domain.battle.repository.BattleParticipantRepository;
 import Hampouch.server.domain.battle.repository.BattleRepository;
+import Hampouch.server.domain.expense.repository.BattleParticipantSpending;
+import Hampouch.server.domain.expense.repository.ExpenseRepository;
 import Hampouch.server.domain.user.entity.User;
 import Hampouch.server.domain.user.repository.UserRepository;
 import Hampouch.server.global.common.exception.CustomException;
@@ -29,6 +31,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.*;
 
 /**
@@ -47,13 +50,15 @@ class BattleServiceTest {
     @Mock
     BattleParticipantRepository battleParticipantRepository;
     @Mock
+    ExpenseRepository expenseRepository;
+    @Mock
     UserRepository userRepository;
     @Mock
     BattleCodeGenerator battleCodeGenerator;
 
     private BattleService serviceAt(LocalDate today) {
         Clock clock = Clock.fixed(today.atTime(12, 0).atZone(SEOUL).toInstant(), SEOUL);
-        return new BattleService(battleRepository, battleParticipantRepository, userRepository, battleCodeGenerator, clock);
+        return new BattleService(battleRepository, battleParticipantRepository, expenseRepository, userRepository, battleCodeGenerator, clock);
     }
 
     private static User user(Long id) {
@@ -184,31 +189,40 @@ class BattleServiceTest {
     }
 
     @Test
-    @DisplayName("ONGOING 배틀은 현재 today/total 실시간 집계가 없어 참가자 목록이 빈 리스트로 나간다 (③에서 구현 예정)")
-    void getMyBattles_mapsOngoingWithEmptyParticipants() {
+    @DisplayName("ONGOING 배틀은 참가자별 today/total 실시간 집계 카드로 매핑된다 — 아직 지출이 없으면 0원으로 채워진다")
+    void getMyBattles_mapsOngoingWithAggregatedParticipants() {
         Battle battle = Battle.of("ABCD1234", "짠테크 배틀", 4, 7, LocalDate.of(2026, 8, 1), "치킨 사주기", user(OWNER));
+        ReflectionTestUtils.setField(battle, "id", 10L);
         battle.start();
         BattleParticipant participation = BattleParticipant.of(user(OWNER), battle);
         when(battleParticipantRepository.findMyParticipations(OWNER, null)).thenReturn(List.of(participation));
+        when(battleParticipantRepository.findByBattle_IdWithUser(10L)).thenReturn(List.of(participation));
+        when(expenseRepository.sumTodayAndTotalByUsers(anyList(), any(), any(), any(), any())).thenReturn(List.of());
 
         BattleListResponse res = serviceAt(LocalDate.of(2026, 7, 1)).getMyBattles(OWNER, null);
 
-        BattleSummary.Ongoing summary = (BattleSummary.Ongoing) res.battles().get(0);
-        assertThat(summary.participants()).isEmpty();
+        BattleSummary.Ongoing summary = (BattleSummary.Ongoing) res.battles().getFirst();
+        assertThat(summary.participants()).hasSize(1);
+        assertThat(summary.participants().getFirst().todayAmount()).isZero();
+        assertThat(summary.participants().getFirst().totalAmount()).isZero();
     }
 
     @Test
-    @DisplayName("TERMINATED 배틀은 승자 요약 카드로 매핑된다 (winnerNickname은 현재 스텁 null)")
+    @DisplayName("TERMINATED 배틀은 rank=1 스냅샷을 가진 참가자의 닉네임을 승자로 요약한다")
     void getMyBattles_mapsTerminated() {
         Battle battle = Battle.of("ABCD1234", "짠테크 배틀", 4, 7, LocalDate.of(2026, 8, 1), "치킨 사주기", user(OWNER));
+        ReflectionTestUtils.setField(battle, "id", 10L);
         battle.start();
         battle.terminate(user(2L));
         BattleParticipant participation = BattleParticipant.of(user(OWNER), battle);
+        participation.finalizeResult(1, 5000); // 종료 배치가 이미 스냅샷을 박아뒀다고 가정(④ 구현 전 임시)
         when(battleParticipantRepository.findMyParticipations(OWNER, null)).thenReturn(List.of(participation));
+        when(battleParticipantRepository.findByBattle_IdWithUser(10L)).thenReturn(List.of(participation));
 
         BattleListResponse res = serviceAt(LocalDate.of(2026, 7, 1)).getMyBattles(OWNER, null);
 
-        assertThat(res.battles().get(0)).isInstanceOf(BattleSummary.Terminated.class);
+        BattleSummary.Terminated summary = (BattleSummary.Terminated) res.battles().getFirst();
+        assertThat(summary.winnerNickname()).isEqualTo(user(OWNER).getNickname());
     }
 
     // ---------- getInvitation ----------
@@ -353,5 +367,208 @@ class BattleServiceTest {
         assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 7, 1)).join(OWNER, "ABCD1234"))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", BattleErrorCode.ALREADY_JOINED);
+    }
+
+    // ---------- getBattleDetail ----------
+
+    @Test
+    @DisplayName("존재하지 않는 battleId면 404(BATTLE_NOT_FOUND)를 던진다")
+    void getBattleDetail_throwsWhenBattleNotFound() {
+        when(battleRepository.findById(BATTLE_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 7, 1)).getBattleDetail(OWNER, BATTLE_ID))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", BattleErrorCode.BATTLE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("요청자가 참가자 목록에 없으면 403(FORBIDDEN_NOT_PARTICIPANT)을 던진다")
+    void getBattleDetail_throwsWhenNotParticipant() {
+        Battle battle = battleWithStatus(BattleStatus.READY, 4);
+        when(battleRepository.findById(BATTLE_ID)).thenReturn(Optional.of(battle));
+        BattleParticipant other = BattleParticipant.of(user(2L), battle);
+        when(battleParticipantRepository.findByBattle_IdWithUser(BATTLE_ID)).thenReturn(List.of(other));
+
+        assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 7, 1)).getBattleDetail(OWNER, BATTLE_ID))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", BattleErrorCode.FORBIDDEN_NOT_PARTICIPANT);
+    }
+
+    @Test
+    @DisplayName("READY 배틀은 모든 참가자가 rank=null, today/total 0원으로 나가고 penaltyTargetNickname도 null이다")
+    void getBattleDetail_readyReturnsZeroedRankings() {
+        Battle battle = battleWithStatus(BattleStatus.READY, 4);
+        BattleParticipant me = BattleParticipant.of(user(OWNER), battle);
+        BattleParticipant other = BattleParticipant.of(user(2L), battle);
+        when(battleRepository.findById(BATTLE_ID)).thenReturn(Optional.of(battle));
+        when(battleParticipantRepository.findByBattle_IdWithUser(BATTLE_ID)).thenReturn(List.of(me, other));
+
+        BattleDetailResponse res = serviceAt(LocalDate.of(2026, 7, 1)).getBattleDetail(OWNER, BATTLE_ID);
+
+        assertThat(res.participants()).hasSize(2);
+        assertThat(res.participants()).allSatisfy(p -> {
+            assertThat(p.rank()).isNull();
+            assertThat(p.todayAmount()).isZero();
+            assertThat(p.totalAmount()).isZero();
+            assertThat(p.isValid()).isTrue();
+        });
+        assertThat(res.penaltyTargetNickname()).isNull();
+        verifyNoInteractions(expenseRepository);
+    }
+
+    @Test
+    @DisplayName("CANCELLED 배틀도 READY와 동일하게 랭킹 없이 0/null로 나간다")
+    void getBattleDetail_cancelledReturnsZeroedRankings() {
+        Battle battle = battleWithStatus(BattleStatus.CANCELLED, 4);
+        BattleParticipant me = BattleParticipant.of(user(OWNER), battle);
+        when(battleRepository.findById(BATTLE_ID)).thenReturn(Optional.of(battle));
+        when(battleParticipantRepository.findByBattle_IdWithUser(BATTLE_ID)).thenReturn(List.of(me));
+
+        BattleDetailResponse res = serviceAt(LocalDate.of(2026, 7, 1)).getBattleDetail(OWNER, BATTLE_ID);
+
+        assertThat(res.participants().getFirst().rank()).isNull();
+        assertThat(res.penaltyTargetNickname()).isNull();
+    }
+
+    @Test
+    @DisplayName("ONGOING은 실시간 집계로 경쟁 순위를 매기고, 최하위 참가자를 penaltyTargetNickname으로 노출한다")
+    void getBattleDetail_ongoingRanksParticipantsAndExposesPenaltyTarget() {
+        Battle battle = battleWithStatus(BattleStatus.ONGOING, 4);
+        BattleParticipant p1 = BattleParticipant.of(user(1L), battle);
+        BattleParticipant p2 = BattleParticipant.of(user(2L), battle);
+        BattleParticipant p3 = BattleParticipant.of(user(3L), battle);
+        BattleParticipant p4 = BattleParticipant.of(user(4L), battle);
+        when(battleRepository.findById(BATTLE_ID)).thenReturn(Optional.of(battle));
+        when(battleParticipantRepository.findByBattle_IdWithUser(BATTLE_ID)).thenReturn(List.of(p1, p2, p3, p4));
+        when(expenseRepository.sumTodayAndTotalByUsers(anyList(), any(), any(), any(), any())).thenReturn(List.of(
+                new BattleParticipantSpending(1L, 100, 1000),
+                new BattleParticipantSpending(2L, 100, 1000), // 1위 동점
+                new BattleParticipantSpending(3L, 0, 2000),
+                new BattleParticipantSpending(4L, 0, 3000)    // 최하위 → 벌칙 대상
+        ));
+
+        BattleDetailResponse res = serviceAt(LocalDate.of(2026, 7, 10)).getBattleDetail(OWNER, BATTLE_ID);
+
+        assertThat(res.participants()).extracting(BattleDetailResponse.ParticipantRanking::rank)
+                .containsExactly(1, 1, 3, 4);
+        assertThat(res.penaltyTargetNickname()).isEqualTo(user(4L).getNickname());
+    }
+
+    @Test
+    @DisplayName("ONGOING에서 지출 집계 결과가 없는 참가자는 today/total 0원으로 채운다 " +
+            "(지출이 없으므로 오히려 최상위 등수가 된다)")
+    void getBattleDetail_ongoingFillsZeroForParticipantWithoutExpense() {
+        Battle battle = battleWithStatus(BattleStatus.ONGOING, 4);
+        BattleParticipant me = BattleParticipant.of(user(OWNER), battle);
+        BattleParticipant noExpense = BattleParticipant.of(user(2L), battle);
+        when(battleRepository.findById(BATTLE_ID)).thenReturn(Optional.of(battle));
+        when(battleParticipantRepository.findByBattle_IdWithUser(BATTLE_ID)).thenReturn(List.of(me, noExpense));
+        when(expenseRepository.sumTodayAndTotalByUsers(anyList(), any(), any(), any(), any()))
+                .thenReturn(List.of(new BattleParticipantSpending(OWNER, 500, 3000)));
+
+        BattleDetailResponse res = serviceAt(LocalDate.of(2026, 7, 10)).getBattleDetail(OWNER, BATTLE_ID);
+
+        BattleDetailResponse.ParticipantRanking noExpenseRanking = res.participants().stream()
+                .filter(p -> p.userId().equals(2L))
+                .findFirst().orElseThrow();
+        assertThat(noExpenseRanking.todayAmount()).isZero();
+        assertThat(noExpenseRanking.totalAmount()).isZero();
+        assertThat(noExpenseRanking.rank()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("TERMINATED는 재집계하지 않고 참가자 스냅샷(rank/totalAmount)을 그대로 읽는다 " +
+            "— todayAmount는 0 고정, penaltyTargetNickname은 Battle.penaltyUser 스냅샷에서 나온다")
+    void getBattleDetail_terminatedUsesSnapshot() {
+        Battle battle = battleWithStatus(BattleStatus.ONGOING, 4);
+        User winner = user(1L);
+        User loser = user(2L);
+        BattleParticipant winnerParticipant = BattleParticipant.of(winner, battle);
+        BattleParticipant loserParticipant = BattleParticipant.of(loser, battle);
+        winnerParticipant.finalizeResult(1, 10000);
+        loserParticipant.finalizeResult(2, 50000);
+        battle.terminate(loser);
+        when(battleRepository.findById(BATTLE_ID)).thenReturn(Optional.of(battle));
+        when(battleParticipantRepository.findByBattle_IdWithUser(BATTLE_ID))
+                .thenReturn(List.of(winnerParticipant, loserParticipant));
+
+        BattleDetailResponse res = serviceAt(LocalDate.of(2026, 7, 20)).getBattleDetail(OWNER, BATTLE_ID);
+
+        assertThat(res.participants()).extracting(BattleDetailResponse.ParticipantRanking::todayAmount)
+                .containsExactly(0, 0);
+        assertThat(res.participants()).extracting(BattleDetailResponse.ParticipantRanking::totalAmount)
+                .containsExactly(10000, 50000);
+        assertThat(res.participants()).extracting(BattleDetailResponse.ParticipantRanking::rank)
+                .containsExactly(1, 2);
+        assertThat(res.penaltyTargetNickname()).isEqualTo(loser.getNickname());
+        verifyNoInteractions(expenseRepository);
+    }
+
+    @Test
+    @DisplayName("TERMINATED인데 참가자에 rank/totalAmount 스냅샷이 없으면 데이터 정합성 예외를 던진다 " +
+            "(2026-08-10, 실제 gradle test로 발견 — 원래는 int 언박싱에서 의미 불명확한 NPE가 났음)")
+    void getBattleDetail_throwsWhenTerminatedParticipantMissingSnapshot() {
+        Battle battle = battleWithStatus(BattleStatus.ONGOING, 4);
+        ReflectionTestUtils.setField(battle, "status", BattleStatus.TERMINATED); // finalizeResult() 없이 강제로 TERMINATED
+        BattleParticipant me = BattleParticipant.of(user(OWNER), battle);
+        when(battleRepository.findById(BATTLE_ID)).thenReturn(Optional.of(battle));
+        when(battleParticipantRepository.findByBattle_IdWithUser(BATTLE_ID)).thenReturn(List.of(me));
+
+        assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 7, 1)).getBattleDetail(OWNER, BATTLE_ID))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("rank/totalAmount");
+    }
+
+    @Test
+    @DisplayName("참가자 스냅샷은 있는데 Battle.penaltyUser 스냅샷만 없으면 데이터 정합성 예외를 던진다")
+    void getBattleDetail_throwsWhenTerminatedWithoutPenaltyUser() {
+        Battle battle = battleWithStatus(BattleStatus.ONGOING, 4);
+        BattleParticipant me = BattleParticipant.of(user(OWNER), battle);
+        me.finalizeResult(1, 10000); // 참가자 스냅샷은 정상 — battle.terminate()만 호출 안 해서 penaltyUser가 null
+        ReflectionTestUtils.setField(battle, "status", BattleStatus.TERMINATED);
+        when(battleRepository.findById(BATTLE_ID)).thenReturn(Optional.of(battle));
+        when(battleParticipantRepository.findByBattle_IdWithUser(BATTLE_ID)).thenReturn(List.of(me));
+
+        assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 7, 1)).getBattleDetail(OWNER, BATTLE_ID))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("penaltyUser");
+    }
+
+    @Test
+    @DisplayName("탈퇴한 참가자는 닉네임이 고정 문구로 마스킹되고 avatarUrl은 null로 나간다")
+    void getBattleDetail_masksDeletedParticipant() {
+        Battle battle = battleWithStatus(BattleStatus.READY, 4);
+        User deletedUser = user(2L);
+        deletedUser.delete();
+        BattleParticipant me = BattleParticipant.of(user(OWNER), battle);
+        BattleParticipant deletedParticipant = BattleParticipant.of(deletedUser, battle);
+        when(battleRepository.findById(BATTLE_ID)).thenReturn(Optional.of(battle));
+        when(battleParticipantRepository.findByBattle_IdWithUser(BATTLE_ID)).thenReturn(List.of(me, deletedParticipant));
+
+        BattleDetailResponse res = serviceAt(LocalDate.of(2026, 7, 1)).getBattleDetail(OWNER, BATTLE_ID);
+
+        BattleDetailResponse.ParticipantRanking masked = res.participants().stream()
+                .filter(p -> p.userId().equals(2L))
+                .findFirst().orElseThrow();
+        assertThat(masked.nickname()).isEqualTo("탈퇴한 사용자");
+        assertThat(masked.avatarUrl()).isNull();
+    }
+
+    @Test
+    @DisplayName("무효화된(isValid=false) 참가자는 그대로 노출되고, 다른 참가자는 영향받지 않는다")
+    void getBattleDetail_exposesInvalidatedParticipant() {
+        Battle battle = battleWithStatus(BattleStatus.READY, 4);
+        BattleParticipant me = BattleParticipant.of(user(OWNER), battle);
+        BattleParticipant invalidated = BattleParticipant.of(user(2L), battle);
+        invalidated.invalidate();
+        when(battleRepository.findById(BATTLE_ID)).thenReturn(Optional.of(battle));
+        when(battleParticipantRepository.findByBattle_IdWithUser(BATTLE_ID)).thenReturn(List.of(me, invalidated));
+
+        BattleDetailResponse res = serviceAt(LocalDate.of(2026, 7, 1)).getBattleDetail(OWNER, BATTLE_ID);
+
+        assertThat(res.participants().stream().filter(p -> p.userId().equals(2L)).findFirst().orElseThrow().isValid())
+                .isFalse();
+        assertThat(res.participants().stream().filter(p -> p.userId().equals(OWNER)).findFirst().orElseThrow().isValid())
+                .isTrue();
     }
 }

--- a/src/test/java/Hampouch/server/domain/battle/service/RankAssignerTest.java
+++ b/src/test/java/Hampouch/server/domain/battle/service/RankAssignerTest.java
@@ -1,0 +1,78 @@
+package Hampouch.server.domain.battle.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * RankAssigner.assign()의 경쟁 순위 계산만 단독 검증 — Repository/Entity 의존이 없는 순수 함수라
+ * Mockito/Spring 없이 바로 테스트한다.
+ */
+class RankAssignerTest {
+
+    private record Item(String name, int amount) {
+    }
+
+    @Test
+    @DisplayName("빈 리스트를 넣으면 빈 리스트를 반환한다")
+    void assign_returnsEmptyForEmptyInput() {
+        List<RankAssigner.Ranked<Item>> result = RankAssigner.assign(List.of(), Item::amount);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("단일 아이템은 무조건 1등이다")
+    void assign_singleItemIsRankOne() {
+        List<RankAssigner.Ranked<Item>> result = RankAssigner.assign(List.of(new Item("solo", 500)), Item::amount);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().rank()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("동점자가 없으면 금액 오름차순으로 1,2,3등을 매기고, 반환 순서도 등수 오름차순이다")
+    void assign_assignsSequentialRanksWithoutTies() {
+        List<Item> items = List.of(new Item("c", 300), new Item("a", 100), new Item("b", 200));
+
+        List<RankAssigner.Ranked<Item>> result = RankAssigner.assign(items, Item::amount);
+
+        assertThat(result).extracting(r -> r.item().name()).containsExactly("a", "b", "c");
+        assertThat(result).extracting(RankAssigner.Ranked::rank).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    @DisplayName("동점자는 같은 등수를 공유하고, 다음 등수는 동점자 수만큼 건너뛴다 (경쟁 순위 1,1,3,4)")
+    void assign_skipsRanksAfterTies() {
+        List<Item> items = List.of(
+                new Item("a", 1000), new Item("b", 1000), new Item("c", 2000), new Item("d", 3000));
+
+        List<RankAssigner.Ranked<Item>> result = RankAssigner.assign(items, Item::amount);
+
+        assertThat(result).extracting(RankAssigner.Ranked::rank).containsExactly(1, 1, 3, 4);
+    }
+
+    @Test
+    @DisplayName("연속된 두 그룹이 동점이면 (1,1,3,3)처럼 각각 건너뛴다")
+    void assign_handlesMultipleTieGroups() {
+        List<Item> items = List.of(
+                new Item("a", 100), new Item("b", 100), new Item("c", 200), new Item("d", 200));
+
+        List<RankAssigner.Ranked<Item>> result = RankAssigner.assign(items, Item::amount);
+
+        assertThat(result).extracting(RankAssigner.Ranked::rank).containsExactly(1, 1, 3, 3);
+    }
+
+    @Test
+    @DisplayName("전원 동점이면 전부 1등이다 (READY 배틀 — 전원 0원 케이스와 동일 시나리오)")
+    void assign_allTiedGetRankOne() {
+        List<Item> items = List.of(new Item("a", 0), new Item("b", 0), new Item("c", 0));
+
+        List<RankAssigner.Ranked<Item>> result = RankAssigner.assign(items, Item::amount);
+
+        assertThat(result).extracting(RankAssigner.Ranked::rank).containsExactly(1, 1, 1);
+    }
+}

--- a/src/test/java/Hampouch/server/domain/expense/repository/ExpenseRepositoryTest.java
+++ b/src/test/java/Hampouch/server/domain/expense/repository/ExpenseRepositoryTest.java
@@ -222,6 +222,52 @@ class ExpenseRepositoryTest {
         assertThat(result).extracting(ExpenseDailyTotal::date, ExpenseDailyTotal::totalAmount)
                 .containsExactly(tuple(d1, 8000L), tuple(d2, 15000L));
     }
+
+    @Test
+    @DisplayName("sumTodayAndTotalByUsers는 유저별로 today CASE WHEN 합계와 기간 전체 합계를 한 행으로 같이 집계한다")
+    void sumTodayAndTotalByUsers_aggregatesPerUserSplitByToday() {
+        LocalDate start = LocalDate.of(2026, 8, 1);
+        LocalDate today = LocalDate.of(2026, 8, 5);
+        User userB = userRepository.save(User.createLocalUser("b@hampouch.com", "encoded", "b"));
+        expenseRepository.save(Expense.of("어제 지출", 3000, ExpenseCategory.CAFE, ExpenseEmotion.STRESS, today.minusDays(1), user));
+        expenseRepository.save(Expense.of("오늘 지출", 5000, ExpenseCategory.CAFE, ExpenseEmotion.STRESS, today, user));
+        expenseRepository.save(Expense.of("userB 오늘 지출", 2000, ExpenseCategory.CAFE, ExpenseEmotion.STRESS, today, userB));
+        expenseRepository.flush();
+
+        List<BattleParticipantSpending> result = expenseRepository.sumTodayAndTotalByUsers(
+                List.of(user.getId(), userB.getId()), start, today, today, ExpenseStatus.ACTIVE);
+
+        assertThat(result)
+                .extracting(BattleParticipantSpending::userId, BattleParticipantSpending::todayAmount, BattleParticipantSpending::totalAmount)
+                .containsExactlyInAnyOrder(
+                        tuple(user.getId(), 5000L, 8000L),
+                        tuple(userB.getId(), 2000L, 2000L));
+    }
+
+    @Test
+    @DisplayName("sumTodayAndTotalByUsers는 기간 밖·DELETED·조회 대상 아닌 유저 지출은 집계에서 빼고, 지출이 없는 유저는 결과 행 자체가 없다")
+    void sumTodayAndTotalByUsers_excludesOutOfRangeDeletedAndOtherUsers_andOmitsRowForZeroSpendUser() {
+        LocalDate start = LocalDate.of(2026, 8, 1);
+        LocalDate end = LocalDate.of(2026, 8, 7);
+        LocalDate today = LocalDate.of(2026, 8, 5);
+        User noSpend = userRepository.save(User.createLocalUser("nospend@hampouch.com", "encoded", "nospend"));
+        User notQueried = userRepository.save(User.createLocalUser("notqueried@hampouch.com", "encoded", "notqueried"));
+        expenseRepository.save(Expense.of("기간 안 지출", 4000, ExpenseCategory.CAFE, ExpenseEmotion.STRESS, today, user));
+        expenseRepository.save(Expense.of("기간 밖 지출", 9999, ExpenseCategory.CAFE, ExpenseEmotion.STRESS, end.plusDays(1), user));
+        Expense deleted = expenseRepository.save(
+                Expense.of("삭제된 지출", 9999, ExpenseCategory.CAFE, ExpenseEmotion.STRESS, today, user));
+        deleted.delete();
+        expenseRepository.save(Expense.of("조회 대상 아닌 유저 지출", 9999, ExpenseCategory.CAFE, ExpenseEmotion.STRESS, today, notQueried));
+        expenseRepository.flush();
+
+        List<BattleParticipantSpending> result = expenseRepository.sumTodayAndTotalByUsers(
+                List.of(user.getId(), noSpend.getId()), start, end, today, ExpenseStatus.ACTIVE);
+
+        assertThat(result)
+                .extracting(BattleParticipantSpending::userId, BattleParticipantSpending::totalAmount)
+                .containsExactly(tuple(user.getId(), 4000L)); // noSpend는 행 자체가 없음 — 호출부가 0으로 채워야 하는 이유
+    }
+
     @Test
     @DisplayName("findPeriodExpenses는 기간 내 ACTIVE 지출만 최신순으로 돌려주고 기간 밖·DELETED·다른 유저 지출은 제외한다")
     void findPeriodExpenses_filtersAndOrdersByDateDesc() {


### PR DESCRIPTION
## 📎연관된 이슈

- close: #99

## 📄 작업 내용 요약

- 햄배틀 세 번째 기능(상세 조회 + 랭킹) 구현. #43, #70 으로 이미 merge된 `Battle`/`BattleParticipant` 위에 이어붙인 작업이라 엔티티 스키마 변경은 없음(엔티티에 이미 있던 `rank`/`totalAmount`/`penaltyUser`를 이번에 처음 실제로 채우고 응답에 노출).

- `RankAssigner` 신설 — 경쟁 순위 산정 순수 유틸(동점자는 같은 등수, 다음 등수는 동점자 수만큼 스킵. 예: 1,1,3,4)
- `BattleParticipantRepository.findByBattle_IdWithUser` 추가 — 참가자 전원을 User와 함께 JOIN FETCH
- `ExpenseRepository.sumTodayAndTotalByUsers` 추가 — 참가자 전원의 today/total 지출을 CASE WHEN + GROUP BY로 쿼리 1번에 집계
- `BattleDetailResponse`(+`ParticipantRanking`) DTO 신설
- `BattleService.getBattleDetail()` 추가 — 상태별 분기(READY/CANCELLED는 0/null, ONGOING은 실시간 집계+랭킹, TERMINATED는 종료 배치가 남긴 스냅샷 그대로 사용하고 절대 재집계하지 않음), 벌칙 대상자(`penaltyTargetNickname`)를 ONGOING(실시간 최하위)·TERMINATED(스냅샷) 공통 필드로 통일
- `BattleController`에 `GET /api/battles/{battleId}` 추가(참가자만 조회 가능, 아니면 `FORBIDDEN_NOT_PARTICIPANT`)
- 단위 테스트: `BattleServiceTest`(`getBattleDetail` 케이스 11종 — not found/forbidden/4개 상태/동점 순위/무지출 참가자/탈퇴 유저 마스킹/isValid/데이터 정합성 방어 2종), `BattleControllerTest`, `BattleParticipantRepositoryTest`/`ExpenseRepositoryTest`에 신규 리포지토리 메서드 전용 테스트
- 통합 테스트: `BattleTransactionIntegrationTest` 신규 — Mockito로는 검증 못 하는 실제 JPQL(`findByBattle_IdWithUser`의 JOIN FETCH, `sumTodayAndTotalByUsers`의 CASE WHEN GROUP BY)이 H2(MODE=MySQL)에서 실제로 동작하는지, TERMINATED가 종료 후 지출을 재집계하지 않고 스냅샷만 읽는지 검증

## 👀 중요 변경 사항

- **TERMINATED는 절대 재집계하지 않음**: 종료된 배틀은 `BattleParticipant.rank`/`totalAmount`, `Battle.penaltyUser` 스냅샷을 그대로 읽기만 한다. 종료 이후 등록된 지출은 랭킹에 반영되지 않는다(의도된 동작 — `BattleTransactionIntegrationTest`가 "종료 후 poison expense를 심어도 스냅샷이 안 바뀐다"를 직접 검증).
- **데이터 정합성 방어 추가**: TERMINATED인데 참가자 스냅샷(rank/totalAmount)이나 `penaltyUser`가 비어 있으면 `IllegalStateException`을 명확하게 던진다. 원래는 이런 상태에 도달할 수 없어야 하지만(종료 배치가 항상 같이 채워야 함), 로컬 빌드에서 관련 테스트 하나가 raw `NullPointerException`으로 실패하며 실제로 발견된 방어 누락이었다. ④(종료 배치) 구현 후에도 배치 버그를 조기에 잡아주는 안전장치로 유지.
- **`penaltyTargetNickname` 필드 통일**: Figma 확인 결과 벌칙 대상자는 진행 중 화면에도, 종료 결과 화면에도 둘 다 노출돼야 해서 상태 무관 단일 필드로 뒀다. ONGOING은 매 요청마다 실시간 계산(값이 바뀔 수 있음), TERMINATED는 고정 스냅샷이라는 차이는 있다.
- **`capacity`/`durationDays`가 상세 응답엔 없음**: Notion 스펙 대조 결과 상세 화면엔 두 필드가 안 쓰여서 뺐다(생성/초대 응답엔 그대로 있음).

## 🔖 Uncompleted Tasks

- ④(배틀 자동 취소·무효화·종료 스냅샷 배치)가 아직 없어서, TERMINATED/CANCELLED 상태 응답은 지금은 실제 데이터로 도달할 수 없고 단위 테스트로만 검증됨 — ④ merge 후 이 API로 실제 종단 검증이 한 번 더 필요.
- `BattleParticipant.isValid`가 응답 필드로는 나가지만 이를 갱신하는 무효화 배치(3일 연속 미기록)가 아직 없어 지금은 항상 true.

## 📢 To Reviewers

- `BattleService.toRankings()`/`findPenaltyTargetNickname()`의 데이터 정합성 방어(`IllegalStateException`)가 적절한 위치·메시지인지 봐주세요 — ④가 아직 없어 지금은 테스트로만 도달 가능합니다.
- `penaltyTargetNickname`을 ONGOING/TERMINATED 공통 필드 하나로 통일한 설계가 괜찮은지 확인 부탁드립니다(화면 문구는 다르지만 값의 의미가 "현재 상태 기준 벌칙 대상자"로 같다고 판단했습니다).
- `RankAssigner`의 동점 처리 방식(1,1,3,4)이 기획 의도와 맞는지 한 번 더 확인 부탁드립니다.