### PR TITLE
chore(infra): Datadog Agent 도입 및 EC2 운영 모니터링 구성 [base: develop]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ DB_PASSWORD=hampouch1234
 DB_PORT=3307
 
 MYSQL_ROOT_PASSWORD=local_root_password
+MYSQL_MONITOR_PASSWORD=
 
 APP_PORT=8080
 JPA_DDL_AUTO=update
@@ -23,5 +24,5 @@ AWS_S3_REGION=ap-northeast-2
 AWS_ACCESS_KEY=access-key(카톡참고)
 AWS_SECRET_KEY=secret-key(카톡참고)
 
-DD_API_KEY=Datadog API 키(운영 EC2 .env에만 설정)
+DD_API_KEY=
 DD_SITE=datadoghq.com

--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,6 @@ AWS_S3_BUCKET=hampouch-images
 AWS_S3_REGION=ap-northeast-2
 AWS_ACCESS_KEY=access-key(카톡참고)
 AWS_SECRET_KEY=secret-key(카톡참고)
+
+DD_API_KEY=Datadog API 키(운영 EC2 .env에만 설정)
+DD_SITE=datadoghq.com

--- a/.github/workflows/observability.yml
+++ b/.github/workflows/observability.yml
@@ -1,0 +1,91 @@
+name: Observability CI
+
+on:
+  pull_request:
+    branches: ["develop", "main"]
+    paths:
+      - ".github/workflows/observability.yml"
+      - ".env.example"
+      - "Dockerfile.deploy"
+      - "build.gradle"
+      - "docker-compose.prod.yml"
+      - "gradle/**"
+      - "gradlew"
+      - "scripts/observability/**"
+      - "settings.gradle"
+      - "src/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: observability-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compose-integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      DB_NAME: hampouch_ci
+      DB_USERNAME: hampouch_ci
+      DB_PASSWORD: ci-db-password
+      DB_PORT: "3307"
+      MYSQL_ROOT_PASSWORD: ci-root-password
+      MYSQL_MONITOR_PASSWORD: ci-datadog-monitor-password-123456
+      APP_PORT: "8080"
+      JWT_SECRET: ci-jwt-secret-key-with-at-least-32-bytes
+      JWT_ACCESS_TOKEN_EXPIRES_IN_MS: "3600000"
+      JWT_REFRESH_TOKEN_EXPIRES_IN_MS: "1209600000"
+      MAIL_USERNAME: ci@example.com
+      MAIL_PASSWORD: ci-mail-password
+      GOOGLE_CLIENT_ID: ci-google-client-id
+      KAKAO_REST_API_KEY: ci-kakao-rest-api-key
+      AWS_S3_BUCKET: ci-bucket
+      AWS_S3_REGION: ap-northeast-2
+      AWS_ACCESS_KEY: ci-access-key
+      AWS_SECRET_KEY: ci-secret-key
+      DD_API_KEY: "00000000000000000000000000000000"
+      DD_SITE: datadoghq.com
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: gradle
+
+      - name: Grant execute permission
+        run: chmod +x gradlew scripts/observability/*.sh
+
+      - name: Render production Compose
+        run: docker compose -f docker-compose.prod.yml config --quiet
+
+      - name: Build deploy image
+        run: |
+          ./gradlew clean bootJar -x test --no-daemon
+          mkdir -p deploy
+          cp build/libs/*.jar deploy/
+          docker build -f Dockerfile.deploy -t hampouch-server:latest ./deploy
+
+      - name: Start production stack
+        run: docker compose -f docker-compose.prod.yml up -d
+
+      - name: Verify Datadog integrations
+        run: scripts/observability/verify-datadog.sh
+
+      - name: Print diagnostics
+        if: failure()
+        run: |
+          docker compose -f docker-compose.prod.yml ps -a
+          docker compose -f docker-compose.prod.yml logs --no-color --tail 200
+          docker inspect hampouch-server hampouch-mysql hampouch-datadog || true
+
+      - name: Stop production stack
+        if: always()
+        run: docker compose -f docker-compose.prod.yml down -v --remove-orphans

--- a/.github/workflows/observability.yml
+++ b/.github/workflows/observability.yml
@@ -13,7 +13,7 @@ on:
       - "gradlew"
       - "scripts/observability/**"
       - "settings.gradle"
-      - "src/**"
+      - "src/main/**"
   workflow_dispatch:
 
 permissions:

--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:21-jre
 
-# healthcheck에서 curl로 /actuator/health를 확인하기 위해 설치
+# healthcheck에서 내부 관리 포트의 readiness를 확인하기 위해 설치
 RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,7 @@ dependencies {
 
 	//actuator - 운영 health check용
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 }
 
 tasks.named('test') {

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -27,6 +27,10 @@ services:
       timeout: 5s
       retries: 20
       start_period: 20s
+    labels:
+      com.datadoghq.tags.env: prod
+      com.datadoghq.tags.service: hampouch-mysql
+      com.datadoghq.ad.logs: '[{"source":"mysql","service":"hampouch-mysql"}]'
 
   app:
     image: hampouch-server:latest

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -4,7 +4,7 @@ services:
     container_name: hampouch-mysql
     restart: always
     #컨테이너가 쓸 수 있는 메모리 상한 - 부족해지면 증량
-    mem_limit: 250m
+    mem_limit: 320m
     environment:
       #VAR이 .env에 없으면 "메시지"를 띄우며 docker compose up 자체가 즉시 실패
       MYSQL_DATABASE: ${DB_NAME:?DB_NAME이 .env에 설정되어야 합니다}
@@ -31,6 +31,44 @@ services:
       com.datadoghq.tags.env: prod
       com.datadoghq.tags.service: hampouch-mysql
       com.datadoghq.ad.logs: '[{"source":"mysql","service":"hampouch-mysql"}]'
+      com.datadoghq.ad.checks: >-
+        {"mysql":{"instances":[{"host":"%%host%%","port":3306,"username":"datadog","password":"%%env_MYSQL_MONITOR_PASSWORD%%","dbm":false,"options":{"replication":false,"extra_status_metrics":false,"extra_innodb_metrics":false,"extra_performance_metrics":false,"schema_size_metrics":false,"disable_innodb_metrics":false}}]}}
+
+  mysql-monitoring-init:
+    image: mysql:8.0
+    container_name: hampouch-mysql-monitoring-init
+    restart: "no"
+    mem_limit: 64m
+    network_mode: "service:db"
+    depends_on:
+      db:
+        condition: service_healthy
+    entrypoint: ["/bin/sh", "-ec"]
+    command:
+      - |
+        password="$$MYSQL_MONITOR_PASSWORD"
+        length="$$(printf %s "$$password" | wc -c | tr -d ' ')"
+        if [ "$$length" -lt 24 ]; then
+          echo "MYSQL_MONITOR_PASSWORD는 24자 이상이어야 합니다." >&2
+          exit 1
+        fi
+        case "$$password" in
+          *[!A-Za-z0-9._-]*)
+            echo "MYSQL_MONITOR_PASSWORD는 영문자, 숫자, 점, 밑줄, 하이픈만 사용할 수 있습니다." >&2
+            exit 1
+            ;;
+        esac
+        export MYSQL_PWD="$$MYSQL_ROOT_PASSWORD"
+        mysql --protocol=TCP --host=127.0.0.1 --port=3306 --user=root <<SQL
+        CREATE USER IF NOT EXISTS 'datadog'@'%' IDENTIFIED BY '$$password';
+        ALTER USER 'datadog'@'%' IDENTIFIED BY '$$password';
+        ALTER USER 'datadog'@'%' WITH MAX_USER_CONNECTIONS 5;
+        GRANT REPLICATION CLIENT, PROCESS ON *.* TO 'datadog'@'%';
+        SQL
+        echo "Datadog MySQL 모니터링 계정 구성을 완료했습니다."
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:?MYSQL_ROOT_PASSWORD가 .env에 설정되어야 합니다}
+      MYSQL_MONITOR_PASSWORD: ${MYSQL_MONITOR_PASSWORD:?MYSQL_MONITOR_PASSWORD가 .env에 설정되어야 합니다}
 
   app:
     image: hampouch-server:latest
@@ -42,13 +80,21 @@ services:
         condition: service_healthy
     ports:
       - "${APP_PORT}:8080"
+    expose:
+      - "8081"
     # app 컨테이너 자체의 healthcheck
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8080/actuator/health" ]
+      test: [ "CMD", "curl", "-f", "http://localhost:8081/actuator/health/readiness" ]
       interval: 10s
       timeout: 5s
       retries: 5
       start_period: 40s
+    labels:
+      com.datadoghq.tags.env: prod
+      com.datadoghq.tags.service: hampouch-server
+      com.datadoghq.ad.logs: '[{"source":"java","service":"hampouch-server"}]'
+      com.datadoghq.ad.checks: >-
+        {"openmetrics":{"instances":[{"openmetrics_endpoint":"http://%%host%%:8081/actuator/prometheus","namespace":"hampouch","metrics":[{"jvm_memory_used_bytes":"jvm.memory.used"},{"jvm_memory_max_bytes":"jvm.memory.max"},{"jvm_threads_live_threads":"jvm.threads.live"},{"jvm_gc_pause_seconds_count":"jvm.gc.pause.count"},{"process_cpu_usage":"process.cpu.usage"},{"process_uptime_seconds":"process.uptime"},{"hikaricp_connections_active":"hikaricp.connections.active"},{"hikaricp_connections_pending":"hikaricp.connections.pending"}]}]},"http_check":{"instances":[{"name":"hampouch-readiness","url":"http://%%host%%:8081/actuator/health/readiness","timeout":5,"content_match":"\"status\":\"UP\"","tags":["component:readiness"]}]}}
     environment:
       SPRING_PROFILES_ACTIVE: prod
       SPRING_DATASOURCE_URL: jdbc:mysql://db:3306/${DB_NAME}?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul&characterEncoding=utf8
@@ -66,5 +112,40 @@ services:
       AWS_ACCESS_KEY: ${AWS_ACCESS_KEY:?필수값 누락}
       AWS_SECRET_KEY: ${AWS_SECRET_KEY:?필수값 누락}
 
+  datadog:
+    image: registry.datadoghq.com/agent:7
+    container_name: hampouch-datadog
+    restart: always
+    mem_limit: 384m
+    pid: host
+    depends_on:
+      mysql-monitoring-init:
+        condition: service_completed_successfully
+    labels:
+      com.datadoghq.tags.env: prod
+      com.datadoghq.tags.service: datadog-agent
+    environment:
+      DD_API_KEY: ${DD_API_KEY:?DD_API_KEY가 .env에 설정되어야 합니다}
+      DD_SITE: ${DD_SITE:-datadoghq.com}
+      DD_ENV: prod
+      MYSQL_MONITOR_PASSWORD: ${MYSQL_MONITOR_PASSWORD:?MYSQL_MONITOR_PASSWORD가 .env에 설정되어야 합니다}
+      DD_LOGS_ENABLED: "true"
+      DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL: "false"
+      DD_APM_ENABLED: "false"
+      DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED: "false"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /proc/:/host/proc/:ro
+      - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
+      - datadog_run:/opt/datadog-agent/run:rw
+    healthcheck:
+      test: ["CMD", "agent", "health"]
+      interval: 15s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+
 volumes:
   db_data:
+  datadog_run:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -22,7 +22,11 @@ services:
     volumes:
       - db_data:/var/lib/mysql
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${MYSQL_ROOT_PASSWORD}"]
+      test:
+        [
+          "CMD-SHELL",
+          "MYSQL_PWD=\"$${MYSQL_ROOT_PASSWORD}\" mysql --protocol=TCP --host=127.0.0.1 --port=3306 --user=root --execute='SELECT 1' --silent >/dev/null",
+        ]
       interval: 5s
       timeout: 5s
       retries: 20

--- a/scripts/observability/README.md
+++ b/scripts/observability/README.md
@@ -1,0 +1,54 @@
+# Datadog 운영 절차
+
+## 도입 전 기준값
+
+EC2에서 앱과 MySQL만 실행한 상태로 다음 명령을 실행하고 결과를 작업 기록에 남긴다.
+
+```bash
+scripts/observability/collect-baseline.sh
+```
+
+호스트 가용 메모리, 루트 디스크, Compose 서비스 상태와 컨테이너별 CPU·메모리를 기록한다.
+
+## 운영 환경 변수
+
+운영 EC2의 `.env`에 아래 두 값만 추가한다. API 키는 저장소, PR 본문, CI/CD 로그에 넣지 않는다.
+
+```dotenv
+DD_API_KEY=<Datadog API key>
+DD_SITE=datadoghq.com
+```
+
+## 배포와 검증
+
+```bash
+docker compose -f docker-compose.prod.yml up -d
+scripts/observability/verify-datadog.sh
+scripts/observability/collect-baseline.sh
+```
+
+도입 전후 결과를 비교해 `hampouch-server`, `hampouch-mysql`, `hampouch-datadog`이 각 메모리 상한 안에서 동작하는지 확인한다. Datadog에서는 다음 항목을 확인한다.
+
+- Infrastructure의 Containers에서 세 컨테이너의 CPU·메모리·디스크 I/O·재시작 횟수가 보인다.
+- Logs에서 `service:hampouch-server`와 `service:hampouch-mysql` 로그가 보인다.
+- Metrics Explorer에서 `hampouch.jvm.memory.used`, `hampouch.process.cpu.usage`, `hampouch.hikaricp.connections.active`가 보인다.
+- `hampouch.openmetrics.health`와 `http.can_connect`(`instance:hampouch_readiness`) 서비스 체크가 정상 상태다.
+
+## 모니터
+
+첫 데이터가 들어온 뒤 다음 네 가지 모니터를 만들고 실제 알림을 한 번 발생시켜 수신 경로를 확인한다.
+
+1. 각 컨테이너의 `container.memory.working_set / container.memory.limit`가 5분 동안 85%를 넘으면 경고한다.
+2. `container.memory.oom_events`가 0보다 커지면 즉시 경고한다.
+3. `container.restarts`가 증가하면 경고한다.
+4. `http.can_connect`의 `instance:hampouch_readiness`가 CRITICAL이거나 데이터가 끊겨 No Data가 되면 경고한다.
+
+## 비활성화와 롤백
+
+Agent가 앱이나 MySQL의 안정성을 해치면 먼저 Agent만 중단한다.
+
+```bash
+docker compose -f docker-compose.prod.yml stop datadog
+```
+
+앱과 MySQL은 그대로 유지된다. 원인을 확인한 뒤 Agent의 메모리 상한이나 수집 범위를 조정하고 다시 시작한다.

--- a/scripts/observability/README.md
+++ b/scripts/observability/README.md
@@ -36,6 +36,13 @@ scripts/observability/verify-datadog.sh
 scripts/observability/collect-baseline.sh
 ```
 
+Actuator는 Compose 내부 관리 포트 `8081`에서만 제공하고 호스트에는 publish하지 않는다. 따라서 기존 외부 경로 `https://api.hampouch.com/actuator/health`는 배포 확인에 사용하지 않는다. EC2에서는 다음 명령으로 컨테이너 health가 `healthy`인지, readiness 응답이 `"status":"UP"`인지 확인한다.
+
+```bash
+docker inspect --format='{{.State.Health.Status}}' hampouch-server
+docker exec hampouch-server curl -fsS http://localhost:8081/actuator/health/readiness
+```
+
 PR에서는 `.github/workflows/observability.yml`이 임시 자격 증명으로 운영 Compose 전체를 띄운다. MySQL 모니터링 계정 초기화, 앱 readiness·Prometheus, Agent health와 MySQL·OpenMetrics·HTTP check를 검증하고 실패 시 Compose 상태와 컨테이너 로그를 Actions에 남긴다. 실제 Datadog 계정으로의 전송과 알림 수신은 운영 EC2 배포 뒤 확인한다.
 
 도입 전후 결과를 비교해 `hampouch-server`, `hampouch-mysql`, `hampouch-datadog`이 각 메모리 상한 안에서 동작하는지 확인한다. Datadog에서는 다음 항목을 확인한다.

--- a/scripts/observability/README.md
+++ b/scripts/observability/README.md
@@ -12,12 +12,21 @@ scripts/observability/collect-baseline.sh
 
 ## 운영 환경 변수
 
-운영 EC2의 `.env`에 아래 두 값만 추가한다. API 키는 저장소, PR 본문, CI/CD 로그에 넣지 않는다.
+MySQL 모니터링 전용 비밀번호를 먼저 생성한다.
+
+```bash
+openssl rand -hex 24
+```
+
+운영 EC2의 `.env`에 아래 세 값을 추가한다. API 키와 MySQL 모니터링 비밀번호는 저장소, PR 본문, CI/CD 로그에 넣지 않는다.
 
 ```dotenv
+MYSQL_MONITOR_PASSWORD=<위 명령으로 생성한 값>
 DD_API_KEY=<Datadog API key>
 DD_SITE=datadoghq.com
 ```
+
+Compose의 `mysql-monitoring-init` 서비스가 기존 데이터 볼륨에서도 `datadog` 계정을 생성하거나 비밀번호를 갱신한다. 이 계정에는 표준 MySQL 지표 수집에 필요한 `REPLICATION CLIENT`, `PROCESS` 권한만 부여하고 동시 연결은 5개로 제한한다. DBM은 끄고 MySQL의 `performance_schema=OFF`도 유지한다.
 
 ## 배포와 검증
 
@@ -27,21 +36,26 @@ scripts/observability/verify-datadog.sh
 scripts/observability/collect-baseline.sh
 ```
 
+PR에서는 `.github/workflows/observability.yml`이 임시 자격 증명으로 운영 Compose 전체를 띄운다. MySQL 모니터링 계정 초기화, 앱 readiness·Prometheus, Agent health와 MySQL·OpenMetrics·HTTP check를 검증하고 실패 시 Compose 상태와 컨테이너 로그를 Actions에 남긴다. 실제 Datadog 계정으로의 전송과 알림 수신은 운영 EC2 배포 뒤 확인한다.
+
 도입 전후 결과를 비교해 `hampouch-server`, `hampouch-mysql`, `hampouch-datadog`이 각 메모리 상한 안에서 동작하는지 확인한다. Datadog에서는 다음 항목을 확인한다.
 
 - Infrastructure의 Containers에서 세 컨테이너의 CPU·메모리·디스크 I/O·재시작 횟수가 보인다.
 - Logs에서 `service:hampouch-server`와 `service:hampouch-mysql` 로그가 보인다.
 - Metrics Explorer에서 `hampouch.jvm.memory.used`, `hampouch.process.cpu.usage`, `hampouch.hikaricp.connections.active`가 보인다.
+- Metrics Explorer에서 `mysql.performance.threads_connected`, `mysql.performance.threads_running`, `mysql.net.max_connections_available`, `mysql.performance.queries`가 보인다.
 - `hampouch.openmetrics.health`와 `http.can_connect`(`instance:hampouch_readiness`) 서비스 체크가 정상 상태다.
+- `mysql.can_connect` 서비스 체크가 정상 상태다.
 
 ## 모니터
 
-첫 데이터가 들어온 뒤 다음 네 가지 모니터를 만들고 실제 알림을 한 번 발생시켜 수신 경로를 확인한다.
+첫 데이터가 들어온 뒤 다음 다섯 가지 모니터를 만들고 실제 알림을 한 번 발생시켜 수신 경로를 확인한다.
 
 1. 각 컨테이너의 `container.memory.working_set / container.memory.limit`가 5분 동안 85%를 넘으면 경고한다.
 2. `container.memory.oom_events`가 0보다 커지면 즉시 경고한다.
 3. `container.restarts`가 증가하면 경고한다.
 4. `http.can_connect`의 `instance:hampouch_readiness`가 CRITICAL이거나 데이터가 끊겨 No Data가 되면 경고한다.
+5. `mysql.performance.threads_connected / mysql.net.max_connections_available`가 5분 동안 0.8을 넘으면 경고한다.
 
 ## 비활성화와 롤백
 

--- a/scripts/observability/collect-baseline.sh
+++ b/scripts/observability/collect-baseline.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+compose_file="${1:-docker-compose.prod.yml}"
+
+for command_name in docker free df; do
+    if ! command -v "$command_name" >/dev/null 2>&1; then
+        echo "필수 명령을 찾을 수 없습니다: $command_name" >&2
+        exit 1
+    fi
+done
+
+echo "Docker Compose"
+docker compose version
+
+echo
+echo "Host memory"
+free -h
+
+echo
+echo "Host disk"
+df -h /
+
+echo
+echo "Compose services"
+docker compose -f "$compose_file" ps
+
+echo
+echo "Container resources"
+docker stats --no-stream --format 'table {{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}\t{{.MemPerc}}\t{{.PIDs}}'

--- a/scripts/observability/verify-datadog.sh
+++ b/scripts/observability/verify-datadog.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+attempts="${VERIFY_ATTEMPTS:-36}"
+interval_seconds="${VERIFY_INTERVAL_SECONDS:-5}"
+
+wait_for() {
+    local description="$1"
+    shift
+    local attempt
+
+    for ((attempt = 1; attempt <= attempts; attempt++)); do
+        if "$@" >/dev/null 2>&1; then
+            echo "$description 확인 완료"
+            return 0
+        fi
+        sleep "$interval_seconds"
+    done
+
+    echo "$description 확인 시간이 초과됐습니다." >&2
+    "$@"
+}
+
+container_is_healthy() {
+    local container="$1"
+    [ "$(docker inspect --format='{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$container")" = "healthy" ]
+}
+
+monitoring_init_succeeded() {
+    [ "$(docker inspect --format='{{.State.Status}}:{{.State.ExitCode}}' hampouch-mysql-monitoring-init)" = "exited:0" ]
+}
+
+readiness_is_up() {
+    docker exec hampouch-server curl -fsS http://localhost:8081/actuator/health/readiness \
+        | grep -q '"status":"UP"'
+}
+
+prometheus_has_metrics() {
+    docker exec hampouch-server curl -fsS http://localhost:8081/actuator/prometheus \
+        | grep -Eq '^(jvm_memory_used_bytes|process_cpu_usage)'
+}
+
+agent_is_healthy() {
+    docker exec hampouch-datadog agent health
+}
+
+mysql_has_metrics() {
+    local output
+    local expectation
+
+    output="$(docker exec hampouch-datadog agent check mysql --check-rate 2>&1)" || {
+        printf '%s\n' "$output" >&2
+        return 1
+    }
+    for expectation in \
+        mysql.can_connect \
+        mysql.performance.queries \
+        mysql.performance.threads_connected \
+        mysql.performance.threads_running \
+        mysql.net.max_connections_available; do
+        if ! grep -Fq "$expectation" <<<"$output"; then
+            echo "MySQL 수집 결과에서 $expectation 항목을 찾지 못했습니다." >&2
+            return 1
+        fi
+    done
+}
+
+openmetrics_check_succeeds() {
+    docker exec hampouch-datadog agent check openmetrics --check-rate
+}
+
+http_check_succeeds() {
+    docker exec hampouch-datadog agent check http_check --check-rate
+}
+
+wait_for "MySQL 모니터링 계정 초기화" monitoring_init_succeeded
+
+containers=(hampouch-server hampouch-mysql hampouch-datadog)
+for container in "${containers[@]}"; do
+    wait_for "$container health" container_is_healthy "$container"
+done
+
+wait_for "DB를 포함한 앱 readiness" readiness_is_up
+wait_for "Prometheus JVM·프로세스 지표" prometheus_has_metrics
+wait_for "Datadog Agent health" agent_is_healthy
+wait_for "Datadog MySQL 연결·쿼리 지표" mysql_has_metrics
+wait_for "Datadog OpenMetrics check" openmetrics_check_succeeds
+wait_for "Datadog HTTP check" http_check_succeeds
+
+echo "Datadog Agent와 MySQL·JVM 메트릭 수집 검증을 통과했습니다."

--- a/src/main/java/Hampouch/server/global/security/SecurityConfig.java
+++ b/src/main/java/Hampouch/server/global/security/SecurityConfig.java
@@ -39,7 +39,8 @@ public class SecurityConfig {
                                 "/api/auth/social",
                                 "/api/auth/refresh",
                                 "/api/auth/password/reset",
-                                "/actuator/health"
+                                "/actuator/health/**",
+                                "/actuator/prometheus"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -16,6 +16,19 @@ logging:
     Hampouch.server: INFO
     org.hibernate.SQL: WARN
 
+management:
+  server:
+    port: 8081
+  endpoint:
+    health:
+      group:
+        readiness:
+          include: readinessState,db
+  endpoints:
+    web:
+      exposure:
+        include: health,prometheus
+
 jwt:
   secret: ${JWT_SECRET}
   access-token-expires-in-ms: ${JWT_ACCESS_TOKEN_EXPIRES_IN_MS}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -28,17 +28,15 @@ management:
     web:
       exposure:
         include: health,prometheus
+  health:
+    mail:
+      enabled: false
 
 jwt:
   secret: ${JWT_SECRET}
   access-token-expires-in-ms: ${JWT_ACCESS_TOKEN_EXPIRES_IN_MS}
   refresh-token-expires-in-ms: ${JWT_REFRESH_TOKEN_EXPIRES_IN_MS}
 
-management:
-  health:
-    mail:
-      enabled: false
-      
 sentry:
   # DSN 미주입이면 SDK가 스스로 비활성 — 이 값 없이도 부팅은 정상 (실값은 EC2 .env 의 SENTRY_DSN)
   dsn: ${SENTRY_DSN:}


### PR DESCRIPTION
## 📎연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) closes #[issue number]

- close: #121
- related: #122

## 📄 작업 내용 요약
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.

- 운영 Compose에 Datadog Agent와 전용 MySQL 모니터링 계정 초기화 서비스를 추가했습니다.
- 앱 readiness와 Prometheus 지표를 내부 관리 포트 `8081`에서 제공하고, JVM·프로세스·HikariCP·MySQL 지표와 앱·MySQL 로그 수집 범위를 설정했습니다.
- 앱·MySQL·Agent의 메모리 상한과 Agent 비활성화·롤백 절차를 문서화했습니다.
- 운영 Compose 전체를 가짜 자격 증명으로 실행해 Agent 내부 MySQL·OpenMetrics·HTTP check를 검증하는 GitHub Actions와 검증 스크립트를 추가했습니다.
- 최신 `develop`의 Testcontainers·Sentry·Swagger 설정을 함께 유지했습니다.

## 👀 중요 변경 사항
> API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요

- 실제 비밀값은 운영 EC2의 `.env`에만 주입하며 저장소와 CI/CD 로그에 포함하지 않습니다.
- 앱 기능과 외부 API 포트는 바뀌지 않습니다. Actuator 관리 포트 `8081`은 호스트에 publish하지 않고 Compose 내부에서 Agent가 접근합니다.
- MySQL 모니터링 계정에는 `PROCESS`, `REPLICATION CLIENT`만 추가하고 최대 동시 연결을 5개로 제한했습니다.
- Docker 소켓·컨테이너 로그·호스트 지표를 Datadog Agent에 읽기 전용 범위로 마운트합니다.

## 🔖 Uncompleted Tasks
> 후속 작업 예정인 사항이 있다면 작성해주세요.

- 운영 배포 후 실제 Datadog 지표·로그 전송과 대시보드 표시를 확인합니다.
- 도입 전후 EC2 메모리 사용량을 비교합니다.
- 알림 수신과 배포 검증 자동화는 #122에서 이어서 처리합니다.

## 📢 To Reviewers
> Reviewer가 주로 확인해주었으면 하는 부분을 적어주세요.

- 앱 `550m`, MySQL `320m`, Agent `384m`의 메모리 상한
- MySQL 모니터링 계정의 권한 및 최대 동시 연결 5개 범위
- Docker 소켓·컨테이너 로그·호스트 지표 마운트 범위
- `src/**` 변경 PR에서 운영 Compose 통합 검증을 실행하는 워크플로 범위

### 검증

- `origin/develop...HEAD` 기준 변경 파일 9개 확인
- `git diff --check origin/develop...HEAD` 통과
- 반복 가능한 JUnit·Docker/Compose·Actuator 검증은 프로젝트 규칙에 따라 로컬에서 실행하지 않고 이 PR의 GitHub Actions에서 수행합니다.
