### PR TITLE
feat: 챌린지 결과 화면용 지출 집계 조회 진입점(ExpenseSpendingQuery 제공)

### DIFF
--- a/src/main/java/Hampouch/server/domain/challenge/dto/ResultResponse.java
+++ b/src/main/java/Hampouch/server/domain/challenge/dto/ResultResponse.java
@@ -2,6 +2,7 @@ package Hampouch.server.domain.challenge.dto;
 
 import Hampouch.server.domain.challenge.entity.Challenge;
 import Hampouch.server.domain.challenge.entity.ChallengeStatus;
+import Hampouch.server.domain.expense.service.EmotionSpending;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -10,17 +11,18 @@ import java.util.List;
 /**
  * GET /api/challenges/{id}/result 응답 — 종료 결과.
  *
- * TODO(령준 지출 연동): categoryBreakdown/emotionBreakdown 채우기 — EXPENSE(외부) 의존이라
- * 그전(Phase 1)에는 빈 배열로 둔다.
+ * emotionBreakdown은 ExpenseSpendingQuery.periodSpending()이 채운다
+ * — 지출 분석 화면과 같은 record(EmotionSpending: enum + amount + 정수 ratio)를 그대로 써서 두 화면의 그래프 각도 계산 근거가
+ * 어긋나지 않게 한다.
+ * - 자체 EmotionRatio 및 categoryBreakDown(챌린지 현황 화면 미지원) 제거
  */
 public record ResultResponse(
         Long challengeId,
         ChallengeStatus status,
-        LocalDateTime closedAt,                  // 최종 종료 시각. null이면 아직 안 눌러 [지출 수정하기]·[챌린지 종료] 팝업을 띄울 상태
+        LocalDateTime closedAt,                   // 최종 종료 시각. null이면 아직 안 눌러 [지출 수정하기]·[챌린지 종료] 팝업을 띄울 상태
         Period period,
         Summary summary,
-        List<CategoryAmount> categoryBreakdown,  // 결과 화면 "카테고리별 지출 금액" 그래프용 (배달 38400, 카페 23500…). 령준 연동 전엔 빈 배열
-        List<EmotionRatio> emotionBreakdown      // 결과 화면 "감정별 지출 비율" 그래프용 (충동 0.42, 스트레스 0.31…). 령준 연동 전엔 빈 배열
+        List<EmotionSpending> emotionBreakdown    // 결과 화면 "소비 감정 분석" 그래프용
 ) {
     public record Period(
             LocalDate startDate,
@@ -41,20 +43,6 @@ public record ResultResponse(
             int maxStreak,
             int budgetTotal,
             int actualSpent
-    ) {
-    }
-
-    /** categoryBreakdown의 원소 — 카테고리 이름 + 그 카테고리에 쓴 금액(원). */
-    public record CategoryAmount(
-            String category,
-            int amount
-    ) {
-    }
-
-    /** emotionBreakdown의 원소 — 감정 이름 + 그 감정으로 쓴 지출의 비율(0~1, 합 1.0). */
-    public record EmotionRatio(
-            String emotion,
-            double ratio
     ) {
     }
 }

--- a/src/main/java/Hampouch/server/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/Hampouch/server/domain/challenge/service/ChallengeService.java
@@ -6,6 +6,8 @@ import Hampouch.server.domain.challenge.repository.ChallengeAdjustmentRepository
 import Hampouch.server.domain.challenge.repository.ChallengeDayRepository;
 import Hampouch.server.domain.challenge.repository.ChallengeRepository;
 import Hampouch.server.domain.expense.service.ExpenseService;
+import Hampouch.server.domain.expense.service.ExpenseSpendingQuery;
+import Hampouch.server.domain.expense.service.PeriodSpending;
 import Hampouch.server.domain.rest.entity.UserRest;
 import Hampouch.server.domain.rest.repository.UserRestRepository;
 import Hampouch.server.global.common.exception.CustomException;
@@ -35,6 +37,7 @@ public class ChallengeService {
     private final ChallengeRepository challengeRepository;
     private final ChallengeDayRepository challengeDayRepository;
     private final ExpenseService expenseService;
+    private final ExpenseSpendingQuery expenseSpendingQuery; // #64 — 결과 화면 소비 감정 분석 그래프. ExpenseAnalysisService 통째 주입 금지 이유는 그 인터페이스 Javadoc 참조
     private final ChallengeAdjustmentRepository challengeAdjustmentRepository;
     // UserRestService가 아니라 리포지토리를 주입한다 — 그쪽이 이 서비스를 주입받고 있어서 서로 주입하면 순환으로 기동이 실패한다.
     private final UserRestRepository userRestRepository;
@@ -243,8 +246,12 @@ public class ChallengeService {
         var summary = new ResultResponse.Summary(
                 s.successDays(), s.overDays(), s.savedAmount(), s.overAmount(),
                 s.maxStreak(), c.getBudgetTotal(), s.actualSpent());
-        // categoryBreakdown / emotionBreakdown 은 령준 지출(EXPENSE) 의존 → 연동 확정까지 빈 배열
-        return new ResultResponse(c.getId(), c.getStatus(), c.getClosedAt(), period, summary, List.of(), List.of());
+        // TODO(령준 지출 연동) 미해결)
+        // emotionBreakdown은 EXPENSE 원본 합계 — summary.actualSpent(ChallengeDay 합계,
+        // 와는 출처가 아직 다를 수 있다. day-level 자동 갱신이 붙기 전까지는
+        // 두 숫자가 항상 같다고 보장하지 않는다 — 이 갭은 #64 범위 밖(day-level ChallengeDay 갱신은 별도 이슈).
+        PeriodSpending spending = expenseSpendingQuery.periodSpending(userId, c.getStartDate(), c.getEndDate());
+        return new ResultResponse(c.getId(), c.getStatus(), c.getClosedAt(), period, summary, spending.emotionBreakdown());
     }
 
     /**

--- a/src/main/java/Hampouch/server/domain/expense/service/EmotionSpending.java
+++ b/src/main/java/Hampouch/server/domain/expense/service/EmotionSpending.java
@@ -3,21 +3,12 @@ package Hampouch.server.domain.expense.service;
 import Hampouch.server.domain.expense.entity.ExpenseEmotion;
 
 /**
- * Challenge 도메인이 결과 화면의 "소비 감정 분석" 그래프를 그릴 때 쓰는 조회 결과를
- * ResultResponse.EmotionRatio(String emotion, double ratio)를 이 모양으로 바꾸자는 제안을 코드로 적어둔 것.
- * Challenge 도메인 파일은 이 브랜치에서 건드리지 않으므로, 실제 교체는 Challenge 담당이 한다.
- * 교체 전까지 ResultResponse는 지금처럼 빈 배열을 유지하면 되고 컴파일에 영향이 없다.
- * 1. emotion이 String -> ExpenseEmotion.
- *    emotion은 Enum 형태로 저장되어 있으므로 data의 정확성을 위해 Enum type으로 Entity 설정과 통일한다.
- *    분석 API가 enum을 그대로 내보내므로 여기만 String이면 같은 데이터가 두 화면에서 다른 표현으로 나간다.
- * 2. ratio가 double(0~1) -> int(정수 퍼센트).
- *    화면이 표시하는 값 자체가 정수 퍼센트다. double로 두면 우리가 넘길 수 있는 값이 어차피 42 / 100.0 = 0.42라
- *    소수점 둘째 자리까지밖에 못 담으면서 타입만 더 정밀해 보인다.
- * 3. amount 추가.
- *    ratio가 정수 퍼센트면 반올림 때문에 합이 99나 101이 될 수 있다. 도넛 각도를 ratio로 누적해 그리면
+ * Challenge 도메인이 결과 화면의 소비 감정 분석 결과.
+ * ExpenseSpendingQuery.periodSpending()이 challenge에 진입점을 제공하기 위해 사용하는 dto
+ * - emotion은 Enum 형태로 저장되어 있으므로 data의 정확성을 위해 Enum type으로 Entity 설정과 통일
+ * - ratio가 정수 퍼센트면 반올림 때문에 합이 99나 101이 될 수 있다. 도넛 각도를 ratio로 누적해 그리면
  *    마지막 조각이 모자라거나 넘치는데, 지금 EmotionRatio에는 amount가 없어 그 회피로(각도는 amount로 계산)를
- *    쓸 수가 없다. CategoryAmount에는 amount가 있으니 대칭을 맞추는 셈이기도 하다.
- * ratio의 분모는 "그 챌린지 기간의 총 지출액"이며 분석 화면 도넛과 동일
+ *    쓸 수가 없다. ratio의 분모는 그 챌린지 기간의 총 지출액
  */
 public record EmotionSpending(
         ExpenseEmotion emotion,

--- a/src/main/java/Hampouch/server/domain/expense/service/ExpenseAnalysisService.java
+++ b/src/main/java/Hampouch/server/domain/expense/service/ExpenseAnalysisService.java
@@ -25,13 +25,14 @@ import java.time.temporal.ChronoUnit;
 import java.util.*;
 
 /**
- * 지출 분석 API 4종의 서비스 계층 — ExpenseService(5개 우선순위 API)와 분리
+ * 지출 분석 API 4종의 서비스 계층 — ExpenseService와 분리
  * 분석은 기간을 받아 집계만 하는 읽기 전용 책임, ExpenseService와 공유할 상태가 하나도 없다.
+ * ExpenseSpendingQuery를 구현해 Challenge 도메인에 이유별 집계를 좁게 노출 — analyze()와 같은 집계 로직을 그대로 재사용
  */
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class ExpenseAnalysisService {
+public class ExpenseAnalysisService implements ExpenseSpendingQuery {
 
     /** 분석 기간 상한 -  챌린지 기간 상한: 100일 */
     private static final int MAX_PERIOD_DAYS = 100;
@@ -172,7 +173,7 @@ public class ExpenseAnalysisService {
 
     /**
      * 기간 검증 3종. 파라미터 누락(null)은 여기서 잡지 않는다 — 컨트롤러의 필수 @RequestParam이 먼저 막고,
-     * 그 응답을 500이 아니라 400으로 만드는 건 GlobalExceptionHandler 몫이다(별도 이슈).
+     * 그 응답을 500이 아니라 400으로 만드는 건 GlobalExceptionHandler 몫
      * 그래서 여기 도달한 null은 사용자 입력이 아니라 내부 호출 버그이므로 CustomException이 아니라 NPE로 드러낸다.
      */
     private void validatePeriod(LocalDate periodStart, LocalDate periodEnd) {
@@ -182,8 +183,7 @@ public class ExpenseAnalysisService {
         if (periodStart.isAfter(periodEnd)) {
             throw new CustomException(ExpenseErrorCode.EXPENSE_ANALYSIS_INVALID_PERIOD);
         }
-        // 미래 검증은 startDate에만 건다. endDate에 걸면 이번 달 분석(5월 10일에 05-01~05-31 조회)과
-        // 진행 중 챌린지 분석이 전부 400 Error 발생
+        // 미래 검증은 startDate에만 건다
         // 미래 날짜엔 지출이 없어 잘라도 집계 결과가 같으므로 서버가 endDate를 보정할 필요도 없다.
         if (periodStart.isAfter(LocalDate.now(clock))) {
             throw new CustomException(ExpenseErrorCode.EXPENSE_ANALYSIS_FUTURE_PERIOD);
@@ -220,23 +220,65 @@ public class ExpenseAnalysisService {
                 .toList();
     }
 
-    /** ExpenseEmotion 5개 전부(지출 0원인 이유도 amount 0으로 포함), 금액 내림차순. */
+    /**
+     * GET /expenses/analysis 응답 전용 래퍼 — 실제 집계는 emotionSpending()에 위임.
+     * EmotionAmount는 analyze() 응답의 중첩 타입이라 그대로 두고, 챌린지 결과 화면과 공유하는 값(EmotionSpending)만
+     * 별도 타입으로 뺐다 — 두 화면이 같은 record를 직접 참조하면 한쪽 응답 모양을 바꿀 때 다른 쪽까지 흔들린다.
+     */
     private List<EmotionAmount> emotionBreakdown(List<Expense> expenses, int totalAmount) {
+        return emotionSpending(expenses, totalAmount).stream()
+                .map(es -> new EmotionAmount(es.emotion(), es.amount(), es.ratio()))
+                .toList();
+    }
+
+    /**
+     * ExpenseEmotion 5개 전부(지출 0원인 이유도 amount 0으로 포함), 금액 내림차순.
+     * analyze()의 emotionBreakdown()과 periodSpending()(#64)이 이 메서드 하나를 같이 쓴다 — 집계가 두 벌이면
+     * 분석 화면과 챌린지 결과 화면의 숫자가 어느 날 어긋난다. EmotionSpending은 이미 Challenge 쪽 제안으로
+     * 존재하던 record다(그 파일 Javadoc 참조) — #64에서 실제로 연결한다.
+     */
+    private List<EmotionSpending> emotionSpending(List<Expense> expenses, int totalAmount) {
         Map<ExpenseEmotion, Integer> amountByEmotion = new EnumMap<>(ExpenseEmotion.class);
         for (Expense expense : expenses) {
             amountByEmotion.merge(expense.getEmotion(), expense.getPrice(), Integer::sum);
         }
 
-        Comparator<EmotionAmount> byAmount = Comparator.comparingInt(EmotionAmount::amount);
-        Comparator<EmotionAmount> order = byAmount.reversed().thenComparing(EmotionAmount::emotion);
+        Comparator<EmotionSpending> byAmount = Comparator.comparingInt(EmotionSpending::amount);
+        Comparator<EmotionSpending> order = byAmount.reversed().thenComparing(EmotionSpending::emotion);
 
         return Arrays.stream(ExpenseEmotion.values())
                 .map(emotion -> {
                     int amount = amountByEmotion.getOrDefault(emotion, 0);
-                    return new EmotionAmount(emotion, amount, percentOf(amount, totalAmount));
+                    return new EmotionSpending(emotion, amount, percentOf(amount, totalAmount));
                 })
                 .sorted(order)
                 .toList();
+    }
+
+    /**
+     * 챌린지 결과 화면(소비 감정 분석 그래프·총 지출액) 진입점 — ExpenseSpendingQuery 구현.
+     */
+    @Override
+    public PeriodSpending periodSpending(Long userId, LocalDate periodStart, LocalDate periodEnd) {
+        // null / 기간 역전 / 100일 초과시 NPE/IAE로 던진다 — 호출자가 이미 검증된 기간만 넘긴다는 전제
+        Objects.requireNonNull(userId, "userId");
+        Objects.requireNonNull(periodStart, "periodStart");
+        Objects.requireNonNull(periodEnd, "periodEnd");
+        if (periodStart.isAfter(periodEnd)) {
+            throw new IllegalArgumentException(
+                    "periodStart(%s)는 periodEnd(%s)보다 늦을 수 없습니다".formatted(periodStart, periodEnd));
+        }
+        if (ChronoUnit.DAYS.between(periodStart, periodEnd) + 1 > MAX_PERIOD_DAYS) {
+            throw new IllegalArgumentException("조회 기간은 최대 " + MAX_PERIOD_DAYS + "일까지만 허용됩니다");
+        }
+
+        // analyze()와 다르게 시작일이 미래여도 예외 대신 빈 집계 — 아직 시작하지 않은 챌린지의 결과 조회를
+        // 정상 호출로 취급한다(호출 시점엔 이미 종료된 챌린지뿐이라 실제로는 안 타지만, 방어적으로 열어 둔다).
+        List<Expense> expenses = periodStart.isAfter(LocalDate.now(clock))
+                ? List.of()
+                : expenseRepository.findPeriodExpenses(userId, ExpenseStatus.ACTIVE, periodStart, periodEnd);
+        int totalAmount = sumPrice(expenses);
+        return new PeriodSpending(totalAmount, emotionSpending(expenses, totalAmount));
     }
 
     /** 7요일 전부. 이 앱의 주는 일요일 시작이라 DayOfWeek.values() 순서를 쓰면 안 된다. */

--- a/src/main/java/Hampouch/server/domain/expense/service/ExpenseSpendingQuery.java
+++ b/src/main/java/Hampouch/server/domain/expense/service/ExpenseSpendingQuery.java
@@ -1,0 +1,18 @@
+package Hampouch.server.domain.expense.service;
+
+import java.time.LocalDate;
+
+/**
+ * Challenge 도메인이 결과 화면의 소비 감정 분석 그래프·총 지출액을 그릴 때 쓰는 지출 집계 진입점
+ * Expense domain에 해당하는 내용이지만 해당 domain의 전용 errorCode 도출을 막기 위해 Interface 활용
+ */
+public interface ExpenseSpendingQuery {
+
+    /**
+     * userId의 [periodStart, periodEnd] 기간 지출을 이유별로 집계
+     * 챌린지 결과 화면 전용 — 호출자가 이미 유효한 기간만 넘긴다는 전제,
+     * null / 기간 역전 / 100일 초과는 CustomException이 아니라 NullPointerException/IllegalArgumentException으로
+     * 던진다. 시작일이 미래면 예외 대신 빈 집계를 반환한다
+     */
+    PeriodSpending periodSpending(Long userId, LocalDate periodStart, LocalDate periodEnd);
+}

--- a/src/main/java/Hampouch/server/domain/expense/service/PeriodSpending.java
+++ b/src/main/java/Hampouch/server/domain/expense/service/PeriodSpending.java
@@ -1,0 +1,13 @@
+package Hampouch.server.domain.expense.service;
+
+import java.util.List;
+
+/**
+ * ExpenseSpendingQuery.periodSpending()의 결과 — 챌린지 결과 화면 소비 감정 분석 탭에서 한 번의 호출로 받아 쓴다.
+ * totalAmount는 emotionBreakdown의 ratio 분모와 같은 값을 노출해 둔 것 — 응답과 문구가 다른 집계를 보지 않게 한다.
+ */
+public record PeriodSpending(
+        int totalAmount,
+        List<EmotionSpending> emotionBreakdown
+) {
+}

--- a/src/test/java/Hampouch/server/domain/challenge/controller/ChallengeControllerTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/controller/ChallengeControllerTest.java
@@ -514,12 +514,12 @@ class ChallengeControllerTest {
     }
 
     @Test
-    @DisplayName("결과 응답의 JSON 필드명(period·summary·categoryBreakdown·emotionBreakdown)이 명세 계약대로 고정돼 있다")
+    @DisplayName("결과 응답의 JSON 필드명(period·summary·emotionBreakdown)이 명세 계약대로 고정돼 있다(categoryBreakdowm 삭제)")
     void result_responseShape() throws Exception {
         var period = new ResultResponse.Period(LocalDate.of(2026, 5, 1), LocalDate.of(2026, 5, 14), 14);
         var summary = new ResultResponse.Summary(14, 0, 68200, 0, 14, 280000, 211800);
         when(service.getResult(anyLong(), anyLong()))
-                .thenReturn(new ResultResponse(1L, ChallengeStatus.SUCCESS, null, period, summary, List.of(), List.of()));
+                .thenReturn(new ResultResponse(1L, ChallengeStatus.SUCCESS, null, period, summary, List.of()));
 
         mvc.perform(get("/api/challenges/1/result"))
                 .andExpect(status().isOk())
@@ -527,7 +527,7 @@ class ChallengeControllerTest {
                 .andExpect(jsonPath("$.data.period.durationDays").value(14))
                 .andExpect(jsonPath("$.data.summary.savedAmount").value(68200))
                 .andExpect(jsonPath("$.data.summary.actualSpent").value(211800))
-                .andExpect(jsonPath("$.data.categoryBreakdown").isArray())
+                .andExpect(jsonPath("$.data.categoryBreakdown").doesNotExist())
                 .andExpect(jsonPath("$.data.emotionBreakdown").isArray());
     }
 
@@ -537,7 +537,7 @@ class ChallengeControllerTest {
         var period = new ResultResponse.Period(LocalDate.of(2026, 5, 1), LocalDate.of(2026, 5, 14), 14);
         var summary = new ResultResponse.Summary(14, 0, 68200, 0, 14, 280000, 211800);
         when(service.getResult(anyLong(), anyLong()))
-                .thenReturn(new ResultResponse(1L, ChallengeStatus.SUCCESS, null, period, summary, List.of(), List.of()));
+                .thenReturn(new ResultResponse(1L, ChallengeStatus.SUCCESS, null, period, summary, List.of()));
 
         mvc.perform(get("/api/challenges/1/result"))
                 .andExpect(status().isOk())

--- a/src/test/java/Hampouch/server/domain/challenge/controller/ChallengeControllerTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/controller/ChallengeControllerTest.java
@@ -3,6 +3,8 @@ package Hampouch.server.domain.challenge.controller;
 import Hampouch.server.domain.challenge.dto.*;
 import Hampouch.server.domain.challenge.entity.ChallengeStatus;
 import Hampouch.server.domain.challenge.service.ChallengeService;
+import Hampouch.server.domain.expense.entity.ExpenseEmotion;
+import Hampouch.server.domain.expense.service.EmotionSpending;
 import Hampouch.server.global.common.exception.CustomException;
 import Hampouch.server.global.common.exception.domain.ChallengeErrorCode;
 import Hampouch.server.global.jwt.JwtProvider;
@@ -24,6 +26,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -514,12 +517,13 @@ class ChallengeControllerTest {
     }
 
     @Test
-    @DisplayName("결과 응답의 JSON 필드명(period·summary·emotionBreakdown)이 명세 계약대로 고정돼 있다(categoryBreakdowm 삭제)")
+    @DisplayName("결과 응답의 JSON 필드명(period·summary·emotionBreakdown)이 명세 계약대로 고정돼 있다(categoryBreakdown 삭제) — emotionBreakdown 원소의 필드값까지 확인한다")
     void result_responseShape() throws Exception {
         var period = new ResultResponse.Period(LocalDate.of(2026, 5, 1), LocalDate.of(2026, 5, 14), 14);
         var summary = new ResultResponse.Summary(14, 0, 68200, 0, 14, 280000, 211800);
+        List<EmotionSpending> emotionBreakdown = List.of(new EmotionSpending(ExpenseEmotion.STRESS, 8_000, 80));
         when(service.getResult(anyLong(), anyLong()))
-                .thenReturn(new ResultResponse(1L, ChallengeStatus.SUCCESS, null, period, summary, List.of()));
+                .thenReturn(new ResultResponse(1L, ChallengeStatus.SUCCESS, null, period, summary, emotionBreakdown));
 
         mvc.perform(get("/api/challenges/1/result"))
                 .andExpect(status().isOk())
@@ -528,7 +532,10 @@ class ChallengeControllerTest {
                 .andExpect(jsonPath("$.data.summary.savedAmount").value(68200))
                 .andExpect(jsonPath("$.data.summary.actualSpent").value(211800))
                 .andExpect(jsonPath("$.data.categoryBreakdown").doesNotExist())
-                .andExpect(jsonPath("$.data.emotionBreakdown").isArray());
+                .andExpect(jsonPath("$.data.emotionBreakdown", hasSize(1)))
+                .andExpect(jsonPath("$.data.emotionBreakdown[0].emotion").value("STRESS"))
+                .andExpect(jsonPath("$.data.emotionBreakdown[0].amount").value(8_000))
+                .andExpect(jsonPath("$.data.emotionBreakdown[0].ratio").value(80));
     }
 
     @Test

--- a/src/test/java/Hampouch/server/domain/challenge/service/ChallengeServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/service/ChallengeServiceTest.java
@@ -5,7 +5,11 @@ import Hampouch.server.domain.challenge.entity.*;
 import Hampouch.server.domain.challenge.repository.ChallengeAdjustmentRepository;
 import Hampouch.server.domain.challenge.repository.ChallengeDayRepository;
 import Hampouch.server.domain.challenge.repository.ChallengeRepository;
+import Hampouch.server.domain.expense.entity.ExpenseEmotion;
+import Hampouch.server.domain.expense.service.EmotionSpending;
 import Hampouch.server.domain.expense.service.ExpenseService;
+import Hampouch.server.domain.expense.service.ExpenseSpendingQuery;
+import Hampouch.server.domain.expense.service.PeriodSpending;
 import Hampouch.server.domain.rest.entity.UserRest;
 import Hampouch.server.domain.rest.repository.UserRestRepository;
 import Hampouch.server.global.common.exception.CustomException;
@@ -49,6 +53,8 @@ class ChallengeServiceTest {
     @Mock
     ExpenseService expenseService;
     @Mock
+    ExpenseSpendingQuery expenseSpendingQuery; // #64
+    @Mock
     UserRestRepository userRestRepository; // 휴식(#8) 연동분 — 목이 기본으로 빈 Optional을 돌려줘 기존 시나리오(휴식 없음)는 스텁 없이 그대로 통과
     @Mock
     ChallengeAdjustmentRepository challengeAdjustmentRepository; // 조정(#7) — 목 기본값이 count 0·빈 리스트라 조정 없는 시나리오는 스텁 없이 통과
@@ -57,12 +63,15 @@ class ChallengeServiceTest {
     void defaultExpenseInput() {
         lenient().when(expenseService.hasDayRecord(anyLong(), any(LocalDate.class)))
                 .thenReturn(true);
+        // getResult()가 항상 호출하므로 기본값을 빈 집계로 깔아 둔다(#64) — 실제 배선을 보는 테스트만 스텁을 따로 덮어쓴다.
+        lenient().when(expenseSpendingQuery.periodSpending(anyLong(), any(LocalDate.class), any(LocalDate.class)))
+                .thenReturn(new PeriodSpending(0, List.of()));
     }
 
     private ChallengeService serviceAt(LocalDate today) {
         Clock clock = Clock.fixed(today.atTime(12, 0).atZone(SEOUL).toInstant(), SEOUL);
         return new ChallengeService(challengeRepository, challengeDayRepository,
-                expenseService, challengeAdjustmentRepository, userRestRepository, clock);
+                expenseService, expenseSpendingQuery, challengeAdjustmentRepository, userRestRepository, clock);
     }
 
     @Test
@@ -1325,6 +1334,21 @@ class ChallengeServiceTest {
         assertThat(others.getWeakCategories())
                 .extracting(ChallengeWeakCategory::getCategory)
                 .containsExactly("배달");
+    }
+
+    @Test
+    @DisplayName("결과의 emotionBreakdown은 ExpenseSpendingQuery.periodSpending(챌린지 시작일~종료일)이 채운다 (#64)")
+    void result_fillsEmotionBreakdownFromExpenseSpendingQuery() {
+        Challenge ch = inProgress(LocalDate.of(2026, 6, 1)); // endDate 2026-06-14
+        when(challengeRepository.findById(10L)).thenReturn(Optional.of(ch));
+        when(challengeDayRepository.findByChallenge_Id(10L)).thenReturn(List.of());
+        List<EmotionSpending> emotionBreakdown = List.of(new EmotionSpending(ExpenseEmotion.STRESS, 7_000, 100));
+        when(expenseSpendingQuery.periodSpending(USER, ch.getStartDate(), ch.getEndDate()))
+                .thenReturn(new PeriodSpending(7_000, emotionBreakdown));
+
+        ResultResponse res = serviceAt(LocalDate.of(2026, 6, 20)).getResult(USER, 10L);
+
+        assertThat(res.emotionBreakdown()).isEqualTo(emotionBreakdown);
     }
 
     /** 목 환경엔 채번이 없어 id를 직접 박아 둔 진행 중 챌린지 — 응답의 challengeId 확인용. */

--- a/src/test/java/Hampouch/server/domain/expense/service/ExpenseAnalysisServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/expense/service/ExpenseAnalysisServiceTest.java
@@ -435,6 +435,82 @@ class ExpenseAnalysisServiceTest {
                 .doesNotThrowAnyException();
     }
 
+    // ---------- 챌린지 결과 집계(periodSpending, #64) ----------
+
+    /**
+     * analyze()의 emotionBreakdown과 완전히 같은 값이 나와야 한다 — 집계 로직을 공유하기 때문
+     * (emotionSpending을 emotionBreakdown과 같이 쓴다). 카테고리는 여기 없다 — 실제 결과 화면(Figma)엔
+     * 카테고리 그래프가 없어 PeriodSpending에 넣지 않기로 함(담당자 승인, 2026-08-11).
+     */
+    @Test
+    @DisplayName("periodSpending은 analyze()와 같은 이유별 집계 로직을 재사용한다")
+    void periodSpending_reusesSameAggregationAsAnalyze() {
+        givenPeriodExpenses();
+
+        PeriodSpending result = serviceAt(LocalDate.of(2026, 6, 5)).periodSpending(OWNER, PERIOD_START, PERIOD_END);
+
+        assertThat(result.totalAmount()).isEqualTo(10_000);
+        assertThat(result.emotionBreakdown()).containsExactly(
+                new EmotionSpending(ExpenseEmotion.STRESS, 8_000, 80),
+                new EmotionSpending(ExpenseEmotion.IMPULSE, 2_000, 20),
+                new EmotionSpending(ExpenseEmotion.COMPENSATION, 0, 0),
+                new EmotionSpending(ExpenseEmotion.CONVENIENCE, 0, 0),
+                new EmotionSpending(ExpenseEmotion.ETC, 0, 0)
+        );
+    }
+
+    /**
+     * analyze()는 미래 시작일을 EXPENSE_ANALYSIS_FUTURE_PERIOD(400)로 막지만, periodSpending()은 예외 대신
+     * 빈 집계를 돌려준다 — 아직 시작하지 않은 챌린지의 결과 조회를 정상 호출로 취급해야 하기 때문(#64).
+     */
+    @Test
+    @DisplayName("시작일이 미래여도 예외 대신 총액 0 / 전부 0원인 빈 집계를 반환한다")
+    void periodSpending_futureStartReturnsEmptyInsteadOfThrowing() {
+        LocalDate futureStart = LocalDate.of(2026, 7, 1);
+        LocalDate futureEnd = LocalDate.of(2026, 7, 14);
+
+        PeriodSpending result = serviceAt(LocalDate.of(2026, 6, 5)).periodSpending(OWNER, futureStart, futureEnd);
+
+        assertThat(result.totalAmount()).isZero();
+        assertThat(result.emotionBreakdown()).hasSize(5).allMatch(e -> e.amount() == 0 && e.ratio() == 0);
+    }
+
+    /**
+     * null/기간 역전/100일 초과는 analyze()처럼 CustomException(400)이 아니라 NPE/IAE다 — 호출자가
+     * 이미 검증된 기간만 넘긴다는 전제라 여기 도달한 위반은 사용자 입력이 아니라 호출자 버그이기 때문(#64).
+     */
+    @Test
+    @DisplayName("userId/periodStart/periodEnd가 null이면 NullPointerException, CustomException이 아니다")
+    void periodSpending_rejectsNullWithNpe() {
+        var service = serviceAt(LocalDate.of(2026, 6, 5));
+        assertThatThrownBy(() -> service.periodSpending(null, PERIOD_START, PERIOD_END))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> service.periodSpending(OWNER, null, PERIOD_END))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> service.periodSpending(OWNER, PERIOD_START, null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    @DisplayName("periodStart가 periodEnd보다 늦으면 IllegalArgumentException, CustomException이 아니다")
+    void periodSpending_rejectsReversedPeriodWithIae() {
+        assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 6, 5))
+                .periodSpending(OWNER, PERIOD_END, PERIOD_START))
+                .isInstanceOf(IllegalArgumentException.class)
+                .isNotInstanceOf(CustomException.class);
+    }
+
+    @Test
+    @DisplayName("101일이면 IllegalArgumentException, CustomException이 아니다")
+    void periodSpending_rejectsHundredAndOneDaysWithIae() {
+        LocalDate start = LocalDate.of(2026, 1, 1);
+
+        assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 6, 5))
+                .periodSpending(OWNER, start, start.plusDays(100)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .isNotInstanceOf(CustomException.class);
+    }
+
     // ---------- fixtures ----------
 
     /** 총 10,000원 — CAFE 7,000(70%) / DELIVERY 3,000(30%), STRESS 8,000(80%) / IMPULSE 2,000(20%).


### PR DESCRIPTION
## 📎연관된 이슈

- close: #64

## 📄 작업 내용 요약

- 챌린지 결과 화면(소비 감정 분석 그래프)이 지출 데이터를 조회할 수 있는 좁은 진입점(`ExpenseSpendingQuery`)을 expense 도메인에 추가
  - `ExpenseSpendingQuery` 인터페이스 — `periodSpending(userId, periodStart, periodEnd)` 1개 메서드만 노출
  - `PeriodSpending`(totalAmount + emotionBreakdown) DTO 추가 — `EmotionSpending`은 기존에 미리 만들어져 있던 record를 그대로 재사용
- `ExpenseAnalysisService`가 `ExpenseSpendingQuery`를 구현 — `analyze()`가 쓰던 이유별 집계 로직(`emotionSpending`)을 공유해서, 분석 화면과 챌린지 결과 화면의 숫자가 갈라지지 않게 함
- `ChallengeService.getResult()`가 `ExpenseSpendingQuery`를 주입받아 `ResultResponse.emotionBreakdown`을 채우도록 배선
- 위 변경에 맞춰 테스트 3종 정합화/추가 — `ExpenseAnalysisServiceTest`(periodSpending 재사용·미래 시작일·예외 규칙 검증 5건), `ChallengeServiceTest`(mock 배선 + 실제 배선 검증 1건), `ChallengeControllerTest`(생성자 인자 변경 반영)

## 👀 중요 변경 사항

- **`ResultResponse` API 계약이 바뀝니다.** `categoryBreakdown` 필드가 완전히 사라졌고(실제 Figma 결과 화면엔 카테고리 그래프가 없음 — 카테고리는 "자세한 식비 지출 분석 보기" 버튼으로 들어가는 기존 `GET /expenses/analysis` 화면이 담당, Challenge 담당자 확인·승인 완료), `emotionBreakdown`의 원소 타입이 `EmotionRatio(String emotion, double ratio)`에서 `EmotionSpending(ExpenseEmotion emotion, int amount, int ratio)`로 바뀌었습니다. 안드로이드 쪽 파싱 코드 확인이 필요합니다.
- `ExpenseSpendingQuery.periodSpending()`은 `analyze()`와 예외 규칙이 다릅니다 — null/기간 역전/100일 초과를 `CustomException`(400)이 아니라 `NullPointerException`/`IllegalArgumentException`으로 던집니다(호출자가 이미 검증된 기간만 넘긴다는 전제, 사용자 입력 오류가 아니라 호출자 버그로 취급). 시작일이 미래면 예외 대신 빈 집계를 반환합니다.
- `summary.actualSpent`(ChallengeDay 합계 기준)와 `emotionBreakdown`의 합(Expense 원본 기준)은 아직 출처가 다를 수 있습니다 — day-level `ChallengeDay` 자동 갱신이 아직 없어서(`TODO(령준 지출 연동)`), 두 숫자가 항상 같다고 보장하지 않습니다.

## 🔖 Uncompleted Tasks

- `ChallengeWeakCategory.category`(String)를 `ExpenseCategory`와 매칭하는 방식 — #52 의 블로커로 남아있고, 아직 결정 못함(ERD가 "직접추가"를 허용하고 있어 enum 전환은 스키마 영향 있음, #52 착수 시 다시 논의)
- `summary.actualSpent`와 `emotionBreakdown` 출처 일치 — day-level `ChallengeDay` 자동 갱신 이슈가 별도로 필요
- `ExpenseInsightWriter.closingSentence`의 `TODO(#38 후속)`(전반/후반 추세 대신 실제 예산·일한도 사용률로 교체) — 이번 PR 범위 밖으로 보류

## 📢 To Reviewers

- `ResultResponse` 필드/타입 변경이 안드로이드와 맞는 계약인지 확인 부탁드립니다.
- 챌린지 현황 화면에 Category 탭이 없어 해당 field 삭제했는데 적절한 결정인지 확인 부탁드립니다.