### PR TITLE
release: CD 자동 롤백 수정 운영 배포 [base: main]

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,8 +79,10 @@ jobs:
 
       - name: Copy deployment artifacts to EC2
         run: |
-          scp -i ~/.ssh/deploy_key hampouch-server.tar docker-compose.prod.yml \
+          scp -i ~/.ssh/deploy_key hampouch-server.tar \
             ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }}:~/Hampouch-Server/
+          scp -i ~/.ssh/deploy_key docker-compose.prod.yml \
+            ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }}:~/Hampouch-Server/docker-compose.prod.next.yml
           scp -i ~/.ssh/deploy_key \
             scripts/deployment/deploy-and-verify.sh \
             scripts/deployment/datadog_verification.py \
@@ -96,6 +98,8 @@ jobs:
         run: |
           ssh -i ~/.ssh/deploy_key ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }} \
             "cd ~/Hampouch-Server && \
+            COMPOSE_FILE='docker-compose.prod.next.yml' \
+            ACTIVE_COMPOSE_FILE='docker-compose.prod.yml' \
             DEPLOY_SHA_TAG='${{ steps.vars.outputs.sha_tag }}' \
             EXPECTED_COMPOSE_SHA256='${{ steps.vars.outputs.compose_sha }}' \
             bash scripts/deployment/deploy-and-verify.sh"

--- a/scripts/deployment/deploy-and-verify.sh
+++ b/scripts/deployment/deploy-and-verify.sh
@@ -2,6 +2,7 @@
 set -Eeuo pipefail
 
 compose_file="${COMPOSE_FILE:-docker-compose.prod.yml}"
+active_compose_file="${ACTIVE_COMPOSE_FILE:-$compose_file}"
 image_tar="${IMAGE_TAR:-hampouch-server.tar}"
 sha_tag="${DEPLOY_SHA_TAG:?DEPLOY_SHA_TAG가 필요합니다}"
 expected_compose_sha="${EXPECTED_COMPOSE_SHA256:?EXPECTED_COMPOSE_SHA256가 필요합니다}"
@@ -17,6 +18,12 @@ compose=(docker compose -f "$compose_file")
 previous_image_id=""
 deployment_started=false
 deployment_started_epoch=""
+staged_compose=false
+log_probe_containers=(hampouch-app-log-probe hampouch-mysql-log-probe)
+
+if [ "$compose_file" != "$active_compose_file" ]; then
+    staged_compose=true
+fi
 
 service_exists() {
     "${compose[@]}" config --services | grep -Fxq "$1"
@@ -106,22 +113,44 @@ verify_app_and_database() {
     echo "앱 health와 MySQL 읽기 전용 요청을 확인했습니다."
 }
 
+cleanup_log_probes() {
+    docker rm -f "${log_probe_containers[@]}" >/dev/null 2>&1 || true
+}
+
 verify_datadog_delivery() {
+    local app_image_id="$1"
     local marker="hampouch_deploy_verification sha:${sha_tag}"
-    local container
+    local mysql_image_id
+    local verification_exit_code=0
 
     command -v python3 >/dev/null
-    for container in hampouch-server hampouch-mysql; do
-        docker exec -e HAMPOUCH_DEPLOY_MARKER="$marker" "$container" sh -ec \
-            'printf "%s\n" "$HAMPOUCH_DEPLOY_MARKER" > /proc/1/fd/1'
-    done
-    echo "Datadog 로그 도착 검증용 배포 표식을 앱과 MySQL 로그에 기록했습니다."
+    mysql_image_id="$(docker inspect --format='{{.Image}}' hampouch-mysql)"
+    cleanup_log_probes
+    docker run --detach --name "${log_probe_containers[0]}" \
+        --label com.datadoghq.tags.env=prod \
+        --label com.datadoghq.tags.service=hampouch-server \
+        --label 'com.datadoghq.ad.logs=[{"source":"java","service":"hampouch-server"}]' \
+        --env HAMPOUCH_DEPLOY_MARKER="$marker" \
+        --entrypoint /bin/sh \
+        "$app_image_id" -ec \
+        'while :; do printf "%s\n" "$HAMPOUCH_DEPLOY_MARKER"; sleep 5; done' >/dev/null
+    docker run --detach --name "${log_probe_containers[1]}" \
+        --label com.datadoghq.tags.env=prod \
+        --label com.datadoghq.tags.service=hampouch-mysql \
+        --label 'com.datadoghq.ad.logs=[{"source":"mysql","service":"hampouch-mysql"}]' \
+        --env HAMPOUCH_DEPLOY_MARKER="$marker" \
+        --entrypoint /bin/sh \
+        "$mysql_image_id" -ec \
+        'while :; do printf "%s\n" "$HAMPOUCH_DEPLOY_MARKER"; sleep 5; done' >/dev/null
+    echo "Datadog 로그 도착 검증용 임시 앱·MySQL 로그 표식을 기록했습니다."
 
     python3 scripts/deployment/datadog_verification.py \
         --env-file .env \
         deployment \
         --from-epoch "$deployment_started_epoch" \
-        --sha "$sha_tag"
+        --sha "$sha_tag" || verification_exit_code="$?"
+    cleanup_log_probes
+    return "$verification_exit_code"
 }
 
 verify_resources() {
@@ -168,14 +197,18 @@ print_diagnostics() {
 
 rollback() {
     local rollback_image_id
+    local -a rollback_compose=("${compose[@]}")
 
     if [ -z "$previous_image_id" ]; then
         echo "복구할 이전 앱 이미지가 없습니다." >&2
         return 1
     fi
+    if [ "$staged_compose" = true ] && [ -f "$active_compose_file" ]; then
+        rollback_compose=(docker compose -f "$active_compose_file")
+    fi
 
     docker image tag "$previous_image_id" hampouch-server:latest || return 1
-    "${compose[@]}" up -d --no-deps --force-recreate app || return 1
+    "${rollback_compose[@]}" up -d --no-deps --force-recreate app || return 1
     wait_for_health hampouch-server || return 1
     rollback_image_id="$(docker inspect --format='{{.Image}}' hampouch-server)" || return 1
     if [ "$rollback_image_id" != "$previous_image_id" ]; then
@@ -185,12 +218,25 @@ rollback() {
     echo "이전 이미지로 앱 컨테이너를 복구하고 health를 확인했습니다."
 }
 
+discard_staged_compose() {
+    if [ "$staged_compose" = true ]; then
+        rm -f -- "$compose_file"
+    fi
+}
+
+promote_staged_compose() {
+    if [ "$staged_compose" = true ]; then
+        mv -f -- "$compose_file" "$active_compose_file"
+    fi
+}
+
 on_error() {
     local exit_code="$?"
     local rollback_exit_code=0
 
     trap - ERR
     set +e
+    cleanup_log_probes
     echo "배포 검증이 실패했습니다." >&2
     print_diagnostics
     if [ "$deployment_started" = true ]; then
@@ -198,6 +244,8 @@ on_error() {
         rollback_exit_code="$?"
         if [ "$rollback_exit_code" -ne 0 ]; then
             echo "자동 롤백도 실패했습니다." >&2
+        else
+            discard_staged_compose
         fi
     fi
     exit "$exit_code"
@@ -263,10 +311,11 @@ fi
 
 verify_app_and_database "$expected_image_id"
 if service_exists datadog; then
-    verify_datadog_delivery
+    verify_datadog_delivery "$expected_image_id"
 fi
 verify_resources
 
+promote_staged_compose
 deployment_started=false
 trap - ERR
 cleanup_old_images

--- a/scripts/deployment/test-deploy-and-verify.sh
+++ b/scripts/deployment/test-deploy-and-verify.sh
@@ -39,6 +39,7 @@ docker() {
                 return 0
             fi
             [ "${1:-}" = "-f" ] || fail "compose 파일 인자가 없습니다"
+            local selected_compose_file="${2:-}"
             shift 2
             case "${1:-}" in
                 config)
@@ -48,7 +49,7 @@ docker() {
                     ;;
                 up)
                     write_state current_image "$(read_state latest_image)"
-                    printf 'compose-up\n' >>"$FAKE_STATE_DIR/events"
+                    printf 'compose-up:%s\n' "$selected_compose_file" >>"$FAKE_STATE_DIR/events"
                     ;;
                 ps)
                     echo "fake compose ps"
@@ -66,7 +67,13 @@ docker() {
                 esac
             fi
             case "${1:-}" in
-                *".Image"*) read_state current_image ;;
+                *".Image"*)
+                    if [ "${2:-}" = "hampouch-mysql" ]; then
+                        echo "mysql-image"
+                    else
+                        read_state current_image
+                    fi
+                    ;;
                 *)
                     printf 'health:%s\n' "${2:-}" >>"$FAKE_STATE_DIR/events"
                     echo "healthy"
@@ -99,31 +106,19 @@ docker() {
             write_state latest_image "$(read_state new_image)"
             ;;
         exec)
-            local exec_env=""
             if [ "${1:-}" = "-e" ]; then
-                exec_env="${2:-}"
-                shift 2
+                fail "실행 중인 컨테이너의 /proc에 로그 표식을 쓰면 안 됩니다"
             fi
             local container="${1:-}"
             shift || true
             case "$container" in
                 hampouch-server)
-                    if [ -n "$exec_env" ]; then
-                        printf 'marker:%s:%s\n' "$container" "${exec_env#HAMPOUCH_DEPLOY_MARKER=}" \
-                            >>"$FAKE_STATE_DIR/events"
-                        return 0
-                    fi
                     if [ "${FAKE_APP_CHECK_FAIL:-0}" = "1" ]; then
                         return 1
                     fi
                     echo '{"status":"UP"}'
                     ;;
                 hampouch-mysql)
-                    if [ -n "$exec_env" ]; then
-                        printf 'marker:%s:%s\n' "$container" "${exec_env#HAMPOUCH_DEPLOY_MARKER=}" \
-                            >>"$FAKE_STATE_DIR/events"
-                        return 0
-                    fi
                     echo "1"
                     ;;
                 hampouch-datadog)
@@ -133,6 +128,48 @@ docker() {
                     fail "지원하지 않는 docker exec 대상: $container"
                     ;;
             esac
+            ;;
+        run)
+            local probe_name=""
+            local probe_service=""
+            local probe_marker=""
+            while [ "$#" -gt 0 ]; do
+                case "$1" in
+                    --detach)
+                        shift
+                        ;;
+                    --name)
+                        probe_name="${2:-}"
+                        shift 2
+                        ;;
+                    --label)
+                        case "${2:-}" in
+                            com.datadoghq.tags.service=*)
+                                probe_service="${2#com.datadoghq.tags.service=}"
+                                ;;
+                        esac
+                        shift 2
+                        ;;
+                    --env)
+                        probe_marker="${2#HAMPOUCH_DEPLOY_MARKER=}"
+                        shift 2
+                        ;;
+                    --entrypoint)
+                        shift 2
+                        ;;
+                    *)
+                        break
+                        ;;
+                esac
+            done
+            [ -n "$probe_name" ] || fail "로그 검증 컨테이너 이름이 없습니다"
+            [ -n "$probe_service" ] || fail "로그 검증 서비스 라벨이 없습니다"
+            [ -n "$probe_marker" ] || fail "로그 검증 표식이 없습니다"
+            printf 'probe:%s:%s:%s\n' "$probe_name" "$probe_service" "$probe_marker" \
+                >>"$FAKE_STATE_DIR/events"
+            ;;
+        rm)
+            return 0
             ;;
         stats)
             if [[ " $* " == *" --format "* ]]; then
@@ -197,7 +234,8 @@ run_case() {
     fi
 
     mkdir -p "$state_dir" "$case_dir/scripts/deployment" "$case_dir/scripts/observability"
-    printf 'services:\n  app: {}\n  db: {}\n  datadog: {}\n' >"$case_dir/docker-compose.prod.yml"
+    printf 'active compose\n' >"$case_dir/docker-compose.prod.yml"
+    printf 'services:\n  app: {}\n  db: {}\n  datadog: {}\n' >"$case_dir/docker-compose.prod.next.yml"
     printf 'image archive\n' >"$case_dir/hampouch-server.tar"
     printf 'PRETTY_NAME="Test Linux"\n' >"$case_dir/os-release"
     printf 'MemAvailable: 1048576 kB\n' >"$case_dir/meminfo"
@@ -220,6 +258,8 @@ run_case() {
         cd "$case_dir"
         DEPLOY_SHA_TAG=abcdef12 \
             EXPECTED_COMPOSE_SHA256=compose-hash \
+            COMPOSE_FILE=docker-compose.prod.next.yml \
+            ACTIVE_COMPOSE_FILE=docker-compose.prod.yml \
             HEALTH_ATTEMPTS=1 \
             HEALTH_INTERVAL_SECONDS=0 \
             OS_RELEASE_FILE="$case_dir/os-release" \
@@ -240,9 +280,9 @@ run_case() {
         || fail "Datadog Agent 검증이 실행되지 않았습니다"
 
     if [ "$app_check_fail" = "0" ]; then
-        grep -qx 'marker:hampouch-server:hampouch_deploy_verification sha:abcdef12' "$state_dir/events" \
+        grep -qx 'probe:hampouch-app-log-probe:hampouch-server:hampouch_deploy_verification sha:abcdef12' "$state_dir/events" \
             || fail "앱 로그 배포 표식이 기록되지 않았습니다"
-        grep -qx 'marker:hampouch-mysql:hampouch_deploy_verification sha:abcdef12' "$state_dir/events" \
+        grep -qx 'probe:hampouch-mysql-log-probe:hampouch-mysql:hampouch_deploy_verification sha:abcdef12' "$state_dir/events" \
             || fail "MySQL 로그 배포 표식이 기록되지 않았습니다"
         grep -qx 'datadog-verification' "$state_dir/events" \
             || fail "Datadog 데이터 도착 검증이 실행되지 않았습니다"
@@ -250,14 +290,22 @@ run_case() {
 
     if [ "$expected_failure" = "0" ]; then
         [ "$(read_state current_image)" = "new-image" ] || fail "새 이미지가 실행되지 않았습니다"
-        [ "$(grep -c '^compose-up$' "$state_dir/events")" = "1" ] \
+        [ "$(grep -c '^compose-up:docker-compose.prod.next.yml$' "$state_dir/events")" = "1" ] \
             || fail "성공 배포의 compose 실행 횟수가 다릅니다"
+        [ ! -f "$case_dir/docker-compose.prod.next.yml" ] || fail "검증을 통과한 임시 Compose가 남았습니다"
+        grep -q '^services:' "$case_dir/docker-compose.prod.yml" \
+            || fail "검증을 통과한 Compose가 활성 파일로 승격되지 않았습니다"
         grep -q '운영 환경 검증을 통과했습니다' "$log_file" || fail "성공 로그가 없습니다"
     else
         [ "$(read_state current_image)" = "old-image" ] || fail "이전 이미지로 롤백되지 않았습니다"
         [ "$(read_state latest_image)" = "old-image" ] || fail "latest가 이전 이미지로 복구되지 않았습니다"
-        [ "$(grep -c '^compose-up$' "$state_dir/events")" = "2" ] \
-            || fail "롤백 재생성 횟수가 다릅니다"
+        grep -qx 'compose-up:docker-compose.prod.next.yml' "$state_dir/events" \
+            || fail "새 Compose로 배포하지 않았습니다"
+        grep -qx 'compose-up:docker-compose.prod.yml' "$state_dir/events" \
+            || fail "기존 Compose로 롤백하지 않았습니다"
+        [ ! -f "$case_dir/docker-compose.prod.next.yml" ] || fail "롤백 뒤 임시 Compose가 남았습니다"
+        grep -qx 'active compose' "$case_dir/docker-compose.prod.yml" \
+            || fail "롤백 뒤 활성 Compose가 바뀌었습니다"
         grep -q '이전 이미지로 앱 컨테이너를 복구하고 health를 확인했습니다' "$log_file" \
             || fail "롤백 성공 로그가 없습니다"
     fi


### PR DESCRIPTION
## 📎연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) closes #[issue number]

- related: #143

## 📄 작업 내용 요약
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.

- `develop`의 CD 로그 검증 및 자동 롤백 수정을 `main`에 반영해 운영 배포합니다.
- Datadog 서비스 라벨을 붙인 임시 컨테이너로 배포 로그 도착을 검증합니다.
- 새 Compose 파일을 단계 배포하고 전체 검증 성공 후에만 활성 파일로 승격합니다.
- 검증 실패 시 이전 이미지와 기존 활성 Compose 파일로 롤백합니다.

## 👀 중요 변경 사항
> API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요

- 이 PR을 머지하면 `main` push로 CD가 자동 실행됩니다.
- 배포 후보 Compose는 검증 성공 후에만 `docker-compose.prod.yml`로 승격됩니다.
- 로그 검증용 임시 컨테이너는 검증 종료 또는 오류 처리 시 제거됩니다.

## 🔖 Uncompleted Tasks
> 후속 작업 예정인 사항이 있다면 작성해주세요.

- 머지 후 CD 성공 여부와 운영 health를 확인합니다.

## 📢 To Reviewers
> Reviewer가 주로 확인해주었으면 하는 부분을 적어주세요.

- 후보 Compose 승격 시점과 실패 시 기존 Compose 기반 롤백 흐름을 확인해 주세요.
- 운영 컨테이너 권한을 건드리지 않는 로그 검증 방식과 정리 경로를 확인해 주세요.