### PR TITLE
fix(infra): Datadog on_missing_data 배포 검증 반영 [base: main]

### DIFF
--- a/scripts/deployment/README.md
+++ b/scripts/deployment/README.md
@@ -25,11 +25,11 @@ Datadog 서비스가 있는 배포에서는 `datadog_verification.py deployment`
 운영 EC2의 `.env`에 다음 값을 설정한다. 값은 저장소, PR, GitHub Actions 로그에 넣지 않는다.
 
 - `DD_API_KEY`는 Agent 전송과 전용 service check 제출에 사용한다.
-- `DD_APP_KEY`는 `timeseries_query`, `logs_read_data`, `monitors_read` 읽기 권한만 가진 Application Key를 사용한다.
+- `DD_APP_KEY`는 `timeseries_query`, `logs_read_data`, `monitors_read`, `monitors_downtime` 권한만 가진 Application Key를 사용한다.
 - `DD_MONITOR_CONTAINER_MEMORY_ID`, `DD_MONITOR_CONTAINER_OOM_ID`, `DD_MONITOR_CONTAINER_RESTART_ID`, `DD_MONITOR_APP_READINESS_ID`, `DD_MONITOR_MYSQL_CONNECTIONS_ID`, `DD_ALERT_TEST_MONITOR_ID`에는 실제 모니터 ID를 넣는다.
 - `DD_REQUIRED_NOTIFICATION_HANDLES`에는 담당자가 승인한 Datadog 알림 수신처를 쉼표로 구분해 넣는다.
 
-모니터 쿼리와 임계치는 `datadog-verification.json`이 정본이다. 변경하려면 실제 Datadog 설정과 이 파일을 함께 변경하고 자원 임계치와 알림 수신처는 담당자 승인을 먼저 받는다.
+모니터 쿼리와 임계치는 `datadog-verification.json`이 정본이다. Datadog UI가 데이터 없음 설정을 새 계약으로 저장한 query monitor는 `on_missing_data`로 검증한다. 변경하려면 실제 Datadog 설정과 이 파일을 함께 변경하고 자원 임계치와 알림 수신처는 담당자 승인을 먼저 받는다.
 
 ## Alert와 Recovery 수신 시험
 

--- a/scripts/deployment/datadog-verification.json
+++ b/scripts/deployment/datadog-verification.json
@@ -92,8 +92,7 @@
       "query": "avg(last_5m):avg:mysql.performance.threads_connected{env:prod} / avg:mysql.net.max_connections_available{env:prod} > 0.8",
       "tags": ["env:prod", "managed-by:hampouch"],
       "options": {
-        "notify_no_data": true,
-        "no_data_timeframe": 10,
+        "on_missing_data": "show_and_notify_no_data",
         "require_full_window": false,
         "thresholds": {
           "critical": 0.8

--- a/scripts/deployment/test_datadog_verification.py
+++ b/scripts/deployment/test_datadog_verification.py
@@ -144,6 +144,21 @@ class DatadogVerificationTest(unittest.TestCase):
             ["@webhook-hampouch-discord"],
         )
 
+    def test_monitor_accepts_on_missing_data_option(self):
+        expected = alert_monitor()
+        expected["options"] = {
+            "on_missing_data": "show_and_notify_no_data",
+            "thresholds": {"critical": 1, "ok": 1},
+        }
+        monitor = actual_monitor()
+        monitor["options"] = dict(expected["options"])
+
+        verification.verify_monitor(
+            FakeClient(monitor),
+            expected,
+            ["@webhook-hampouch-discord"],
+        )
+
     def test_deployment_data_requires_metrics_and_logs(self):
         from_epoch = 1_700_000_000
         client = FakeClient(actual_monitor())


### PR DESCRIPTION
## 📎연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) closes #[issue number]

- #146

## 📄 작업 내용 요약
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.

- Datadog query monitor의 데이터 없음 검증을 `on_missing_data=show_and_notify_no_data` 계약으로 전환
- 신규 계약 회귀 테스트 추가
- 배포 검증 Application Key의 `monitors_downtime` 필수 권한 문서화

## 👀 중요 변경 사항
> API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요

Datadog MySQL 연결률 모니터는 구형 `notify_no_data`·`no_data_timeframe` 대신 `on_missing_data` 값으로 검증합니다.

## 🔖 Uncompleted Tasks
> 후속 작업 예정인 사항이 있다면 작성해주세요.

- main 병합 후 CD와 운영 Datadog 검증 재확인

## 📢 To Reviewers
> Reviewer가 주로 확인해주었으면 하는 부분을 적어주세요.

- Datadog query monitor 설정과 배포 검증 계약의 일치 여부