### PR TITLE
chore(ci): Datadog 알림 경로 테스트를 오전 10시에 실행 [base: develop]

### DIFF
--- a/.github/workflows/datadog-alert-path.yml
+++ b/.github/workflows/datadog-alert-path.yml
@@ -2,7 +2,7 @@ name: Datadog Alert Path Verification
 
 on:
   schedule:
-    - cron: "0 18 * * *"
+    - cron: "0 1 * * *"
   workflow_dispatch:
 
 permissions:

--- a/scripts/deployment/README.md
+++ b/scripts/deployment/README.md
@@ -45,7 +45,7 @@ Discord 연결은 다음과 같이 설정한다.
 
 검증기는 고정된 Discord API 주소에서 최신 메시지 최대 100개만 읽는다. 설정한 incoming webhook이 작성한 메시지인지 확인한 뒤 정확한 `signal_id`와 `phase`가 모두 있는 경우에만 실제 수신으로 인정한다. 봇 토큰이나 Discord webhook 전체 URL을 저장소, PR, GitHub Actions 로그에 넣지 않는다.
 
-저장소 Actions 변수 `DD_ALERT_TEST_ENABLED`를 `true`로 설정하면 워크플로가 매일 03:00 KST에 주기를 확인하고, 승인된 시간이 지난 경우에만 시험한다. 수동 실행은 주기와 관계없이 즉시 시험한다.
+저장소 Actions 변수 `DD_ALERT_TEST_ENABLED`를 `true`로 설정하면 워크플로가 매일 10:00 KST에 주기를 확인하고, 승인된 시간이 지난 경우에만 시험한다. 수동 실행은 주기와 관계없이 즉시 시험한다.
 
 ## 테스트 경계
 


### PR DESCRIPTION
## 📎연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) closes #[issue number]

- Closes #150

## 📄 작업 내용 요약
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.

- Datadog 알림 경로 정기 실행을 매일 03:00 KST에서 10:00 KST로 변경했습니다.
- 운영 배포 검증 문서의 실행 시간도 10:00 KST로 맞췄습니다.

## 👀 중요 변경 사항
> API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요

- GitHub Actions cron은 `0 1 * * *`이며 UTC 기준 01:00, KST 기준 10:00입니다.
- `DD_ALERT_TEST_ENABLED`와 승인된 재실행 주기를 확인하는 기존 동작은 변경하지 않았습니다.
- API와 애플리케이션 실행 로직 변경은 없습니다.

## 🔖 Uncompleted Tasks
> 후속 작업 예정인 사항이 있다면 작성해주세요.

- 없습니다.

## 📢 To Reviewers
> Reviewer가 주로 확인해주었으면 하는 부분을 적어주세요.

- 워크플로의 cron과 운영 문서의 10:00 KST 표기가 일치하는지 확인 부탁드립니다.