### PR TITLE
fix(chore): 에러 로그에서 userId 확인

### DIFF
--- a/src/main/java/Hampouch/server/global/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/Hampouch/server/global/common/exception/GlobalExceptionHandler.java
@@ -8,6 +8,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.FieldError;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -35,7 +37,7 @@ public class GlobalExceptionHandler {
 
         String auth = request.getHeader("Authorization");
         boolean hasAuth = auth != null && !auth.isBlank();
-        Object userId = request.getAttribute("userId");
+        Object userId = resolveUserId();
 
         log.warn(
                 "[CustomException] {} {} | status={} code={} | userId={} | hasAuth={} | ua={}",
@@ -49,6 +51,17 @@ public class GlobalExceptionHandler {
                 .body(ErrorResponse.from(errorCode, e.getMessage()));
     }
 
+    // JwtFilter가 SecurityContext에 심어둔 인증 정보에서 userId를 꺼낸다.
+    // principal이 JwtFilter에서 넣어준 Long 타입일 때만 값을 채우고, 인증이 없거나(anonymous 등) principal 타입이 다르면 null로 남긴다.
+    private Object resolveUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.isAuthenticated()
+                && authentication.getPrincipal() instanceof Long principalUserId) {
+            return principalUserId;
+        }
+        return null;
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
             MethodArgumentNotValidException e,
@@ -60,8 +73,8 @@ public class GlobalExceptionHandler {
         }
 
         log.warn(
-                "[ValidationException] {} {} | fieldErrors={} | globalErrors={}",
-                request.getMethod(), request.getRequestURI(),
+                "[ValidationException] {} {} | userId={} | fieldErrors={} | globalErrors={}",
+                request.getMethod(), request.getRequestURI(), resolveUserId(),
                 fieldErrors, e.getBindingResult().getGlobalErrors()
         );
 
@@ -88,8 +101,8 @@ public class GlobalExceptionHandler {
         });
 
         log.warn(
-                "[HandlerMethodValidationException] {} {} | fieldErrors={} | message={}",
-                request.getMethod(), request.getRequestURI(),
+                "[HandlerMethodValidationException] {} {} | userId={} | fieldErrors={} | message={}",
+                request.getMethod(), request.getRequestURI(), resolveUserId(),
                 fieldErrors, e.getMessage()
         );
 
@@ -114,8 +127,8 @@ public class GlobalExceptionHandler {
         }
 
         log.warn(
-                "[ConstraintViolationException] {} {} | fieldErrors={}",
-                request.getMethod(), request.getRequestURI(), fieldErrors
+                "[ConstraintViolationException] {} {} | userId={} | fieldErrors={}",
+                request.getMethod(), request.getRequestURI(), resolveUserId(), fieldErrors
         );
 
         return ResponseEntity
@@ -134,8 +147,8 @@ public class GlobalExceptionHandler {
         fieldErrors.put(fieldName, fieldName + "은(는) " + requiredType + " 형식이어야 합니다.");
 
         log.warn(
-                "[MethodArgumentTypeMismatchException] {} {} | field={} | value={}",
-                request.getMethod(), request.getRequestURI(),
+                "[MethodArgumentTypeMismatchException] {} {} | userId={} | field={} | value={}",
+                request.getMethod(), request.getRequestURI(), resolveUserId(),
                 fieldName, e.getValue()
         );
 
@@ -156,8 +169,8 @@ public class GlobalExceptionHandler {
         fieldErrors.put(paramName, paramName + "은(는) 필수 파라미터입니다.");
 
         log.warn(
-                "[MissingServletRequestParameterException] {} {} | param={} | type={}",
-                request.getMethod(), request.getRequestURI(),
+                "[MissingServletRequestParameterException] {} {} | userId={} | param={} | type={}",
+                request.getMethod(), request.getRequestURI(), resolveUserId(),
                 paramName, e.getParameterType()
         );
 
@@ -175,8 +188,8 @@ public class GlobalExceptionHandler {
             HttpServletRequest request
     ) {
         log.warn(
-                "[HttpMessageNotReadableException] {} {} | message={}",
-                request.getMethod(), request.getRequestURI(), e.getMessage()
+                "[HttpMessageNotReadableException] {} {} | userId={} | message={}",
+                request.getMethod(), request.getRequestURI(), resolveUserId(), e.getMessage()
         );
 
         return ResponseEntity
@@ -192,8 +205,8 @@ public class GlobalExceptionHandler {
             HttpServletRequest request
     ) {
         log.warn(
-                "[HttpRequestMethodNotSupportedException] {} {} | supported={}",
-                request.getMethod(), request.getRequestURI(), e.getSupportedHttpMethods()
+                "[HttpRequestMethodNotSupportedException] {} {} | userId={} | supported={}",
+                request.getMethod(), request.getRequestURI(), resolveUserId(), e.getSupportedHttpMethods()
         );
 
         ResponseEntity.BodyBuilder response = ResponseEntity
@@ -213,8 +226,8 @@ public class GlobalExceptionHandler {
             HttpServletRequest request
     ) {
         log.warn(
-                "[NoResourceFoundException] {} {}",
-                request.getMethod(), request.getRequestURI()
+                "[NoResourceFoundException] {} {} | userId={} ",
+                request.getMethod(), request.getRequestURI(), resolveUserId()
         );
 
         return ResponseEntity
@@ -227,7 +240,7 @@ public class GlobalExceptionHandler {
             Exception e,
             HttpServletRequest request
     ) {
-        log.error("[UnhandledException] {} {}", request.getMethod(), request.getRequestURI(), e);
+        log.error("[UnhandledException] {} {} | userId={}", request.getMethod(), request.getRequestURI(), resolveUserId(), e);
 
         return ResponseEntity
                 .status(CommonErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())

--- a/src/test/java/Hampouch/server/global/common/exception/GlobalExceptionHandlerIntegrationTest.java
+++ b/src/test/java/Hampouch/server/global/common/exception/GlobalExceptionHandlerIntegrationTest.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -123,6 +124,25 @@ class GlobalExceptionHandlerIntegrationTest {
 
         assertThat(listAppender.list)
                 .anyMatch(event -> event.getFormattedMessage().contains("userId=7"));
+    }
+
+    @Test
+    @DisplayName("CustomException이 발생하면 로그에 실제 userId가 찍힌다")
+    void customException_logsActualUserId() throws Exception {
+        long nonExistentUserId = 999999L;
+
+        mvc.perform(patch("/api/auth/nickname")
+                        .header("Authorization", bearer(nonExistentUserId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"nickname\": \"테스터\"}"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("USER_NOT_FOUND"));
+
+        assertThat(listAppender.list)
+                .anySatisfy(event -> {
+                    assertThat(event.getFormattedMessage()).contains("[CustomException]");
+                    assertThat(event.getFormattedMessage()).contains("userId=" + nonExistentUserId);
+                });
     }
 
     @Test

--- a/src/test/java/Hampouch/server/global/common/exception/GlobalExceptionHandlerIntegrationTest.java
+++ b/src/test/java/Hampouch/server/global/common/exception/GlobalExceptionHandlerIntegrationTest.java
@@ -2,13 +2,20 @@ package Hampouch.server.global.common.exception;
 
 import Hampouch.server.domain.user.entity.UserRole;
 import Hampouch.server.global.jwt.JwtProvider;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -27,6 +34,24 @@ class GlobalExceptionHandlerIntegrationTest {
     MockMvc mvc;
     @Autowired
     JwtProvider jwtProvider;
+
+    // GlobalExceptionHandler는 Lombok @Slf4j로 로거 이름이 클래스 풀네임(GlobalExceptionHandler)이다.
+    // 이 로거에 ListAppender를 붙여, 실제로 찍힌 로그 메시지 안에 userId가 들어있는지 직접 확인한다.
+    Logger handlerLogger;
+    ListAppender<ILoggingEvent> listAppender;
+
+    @BeforeEach
+    void setUpLogCapture() {
+        handlerLogger = (Logger) LoggerFactory.getLogger(GlobalExceptionHandler.class);
+        listAppender = new ListAppender<>();
+        listAppender.start();
+        handlerLogger.addAppender(listAppender);
+    }
+
+    @AfterEach
+    void tearDownLogCapture() {
+        handlerLogger.detachAppender(listAppender);
+    }
 
     /** 실제 서명이 붙은 액세스 토큰의 Authorization 헤더 값 — 로그인 API를 거치지 않고 발급만 빌려 쓴다. */
     private String bearer(Long userId) {
@@ -74,5 +99,40 @@ class GlobalExceptionHandlerIntegrationTest {
                 .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
                 .andExpect(jsonPath("$.fieldErrors.date").value("date은(는) 필수 파라미터입니다."))
                 .andExpect(jsonPath("$.status").value(400));
+    }
+
+    // ===== userId 로깅 검증 =====
+    // GlobalExceptionHandler의 모든 핸들러가 resolveUserId()로 로그에 userId를 남기도록
+    // 수정했는데, 이게 실제로 로그 문자열에 반영되는지 확인한다.
+
+    @Test
+    @DisplayName("인증된 요청에서 405가 발생하면 로그에 실제 userId가 찍힌다")
+    void unsupportedMethod_logsActualUserId() throws Exception {
+        mvc.perform(patch("/api/mini-challenges").header("Authorization", bearer(42L)))
+                .andExpect(status().isMethodNotAllowed());
+
+        assertThat(listAppender.list)
+                .anyMatch(event -> event.getFormattedMessage().contains("userId=42"));
+    }
+
+    @Test
+    @DisplayName("인증된 요청에서 필수 파라미터 누락으로 400이 발생하면 로그에 실제 userId가 찍힌다")
+    void missingRequiredQueryParameter_logsActualUserId() throws Exception {
+        mvc.perform(get("/api/expenses/day").header("Authorization", bearer(7L)))
+                .andExpect(status().isBadRequest());
+
+        assertThat(listAppender.list)
+                .anyMatch(event -> event.getFormattedMessage().contains("userId=7"));
+    }
+
+    @Test
+    @DisplayName("인증되지 않은 요청에서 예외가 발생하면 로그에 userId=null이 찍힌다")
+    void unauthenticatedRequest_logsNullUserId() throws Exception {
+        // Authorization 헤더 없이 405를 유발 (인증 불필요한 로그인 경로에 잘못된 메서드로 요청)
+        mvc.perform(get("/api/auth/login"))
+                .andExpect(status().isMethodNotAllowed());
+
+        assertThat(listAppender.list)
+                .anyMatch(event -> event.getFormattedMessage().contains("userId=null"));
     }
 }


### PR DESCRIPTION
## 📎연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) closes #[issue number]

- close: #135

## 📄 작업 내용 요약
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
- handleCustomeException에서 userId가 null이 뜨던 문제를 resolveUserId 메서드를 만듬으로써 해결
- GlobalExceptionHandler.resolveUserId()를 handleCustomException()뿐 아니라 나머지 모든 예외 핸들러에도 적용하여 전부 로그에 userId 포함
- GlobalExceptionHandlerIntegrationTest에 로그 검증 케이스 3개 추가
  - Logback ListAppender로 GlobalExceptionHandler 로거에 직접 붙어, 응답 바디뿐 아니라 실제 로그 메시지 문자열에 userId가 반영되는지 확인
  - 인증된 요청에서 실제 userId가 찍히는지, 미인증 요청에서 userId=null이 정확히 찍히는지 각각 검증

## 👀 중요 변경 사항
> API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요
- 이제 어떤 종류의 예외가 발생하든(4xx 검증 실패, 405, 404, 500 등) 로그에 누가(userId) 겪은 문제인지 남습니다. 인증이 필요 없는 API에서 나는 예외는 userId=null이 정상적으로 찍히니, 로그를 볼 때 참고 부탁드립니다.

## 🔖 Uncompleted Tasks
> 후속 작업 예정인 사항이 있다면 작성해주세요.

## 📢 To Reviewers
> Reviewer가 주로 확인해주었으면 하는 부분을 적어주세요.
- resolveUserId()가 SecurityContextHolder에서 매 핸들러마다 호출되는데, 요청당 호출 비용이 크지 않다고 판단해 별도 캐싱 없이 단순하게 구현했습니다. 문제없는지 확인 부탁드립니다.