### PR TITLE
chore(deps): bump JJWT from 0.12.6 to 0.13.0 [base: develop]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,9 +40,9 @@ dependencies {
 	runtimeOnly 'org.flywaydb:flyway-mysql'
 
 	//jwt
-	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
-	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
-	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+	implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.13.0'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.13.0'
 
 	// Testcontainers — 실 MySQL 8.0 컨테이너 계층. H2(MODE=MySQL)가 통과시키는 MySQL 고유 거부를 잡는다.
 	testImplementation 'org.springframework.boot:spring-boot-testcontainers'


### PR DESCRIPTION
## 📎연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) closes #[issue number]

- closes #164

## 📄 작업 내용 요약
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.

- `jjwt-api`, `jjwt-impl`, `jjwt-jackson` 버전을 0.12.6에서 0.13.0으로 함께 올렸습니다.
- 인증 토큰 생성·검증 로직과 API 계약은 변경하지 않았습니다.

## 👀 중요 변경 사항
> API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요

- JJWT 세 모듈의 버전을 동일하게 유지했습니다.
- PR CI에서 전체 빌드와 실제 `JwtProvider`를 사용하는 인증 통합 흐름을 검증합니다.

## 🔖 Uncompleted Tasks
> 후속 작업 예정인 사항이 있다면 작성해주세요.

- 없음

## 📢 To Reviewers
> Reviewer가 주로 확인해주었으면 하는 부분을 적어주세요.

- 0.13.0 의존성 해석과 기존 토큰 발급·검증 테스트의 호환성을 확인해주세요.