### PR TITLE
chore(deps): bump AWS SDK BOM from 2.28.11 to 2.51.3 [base: develop]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ dependencies {
 	implementation 'com.google.api-client:google-api-client:2.7.0'
 
 	//s3
-	implementation platform('software.amazon.awssdk:bom:2.28.11')
+	implementation platform('software.amazon.awssdk:bom:2.51.3')
 	implementation 'software.amazon.awssdk:s3'
 
 	//actuator - 운영 health check용


### PR DESCRIPTION
## 📎연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) closes #[issue number]

- closes #166

## 📄 작업 내용 요약
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.

- AWS SDK BOM 버전을 2.28.11에서 2.51.3으로 올렸습니다.
- S3 클라이언트·presigner 사용 코드와 이미지 API 계약은 변경하지 않았습니다.

## 👀 중요 변경 사항
> API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요

- BOM 변경으로 `software.amazon.awssdk:s3`의 전이 의존성 버전이 함께 갱신됩니다.
- 기존 단위 테스트는 presign, HEAD 확인, GET URL 발급과 교체 이미지 DELETE 경로를 mock 기반으로 검증합니다.

## 🔖 Uncompleted Tasks
> 후속 작업 예정인 사항이 있다면 작성해주세요.

- 격리된 S3 테스트 객체로 presigned PUT·HEAD·GET·DELETE 실연동 확인
- 업로더 IAM의 `s3:DeleteObject` 권한 확인

## 📢 To Reviewers
> Reviewer가 주로 확인해주었으면 하는 부분을 적어주세요.

- 2.51.3 의존성 해석과 기존 S3 클라이언트·presigner API 호환성을 확인해주세요.