### PR TITLE
ci: CI build job을 검증 단계별로 분리 [base: develop]

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -2,7 +2,7 @@
 
 | 구성 | 실행 시점 | 책임 |
 | --- | --- | --- |
-| `ci.yml` | develop/main 대상 PR, develop push | PR 의존성 변경에서 High 이상 취약점 차단, JUnit, Testcontainers MySQL, 배포·롤백 스크립트 기능 테스트, Python 검증기 테스트, 애플리케이션 `Dockerfile` 이미지 빌드 |
+| `ci.yml` | develop/main 대상 PR, develop push | `dependency-review`, `gradle-test`, `mysql-test`, `deployment-scripts`, `docker-image`를 독립 실행하고 `build`에서 결과 집계 |
 | `quality.yml` | develop/main 대상 PR·push, 수동 실행 | Actionlint로 전체 워크플로와 인라인 셸 검사, ShellCheck로 저장소의 모든 셸 스크립트 검사, 미해결 merge marker 차단 |
 | `observability.yml` | 관련 운영 설정이 바뀐 develop/main 대상 PR, 수동 실행 | 비밀값 없는 CI 전용 값으로 운영 Compose 렌더링, `Dockerfile.deploy` 이미지 빌드, 앱·MySQL·Datadog 통합 검증 |
 | `codeql.yml` | develop/main 대상 PR·push, 주 1회, 수동 실행 | Java 코드의 CodeQL 보안 분석 |
@@ -11,6 +11,6 @@
 | `deploy.yml` | main push 또는 수동 실행 | EC2 배포 후 앱·DB·Datadog을 검증하고 실패 시 이전 이미지로 자동 롤백 |
 | `dependabot.yml` | 매주 월요일 | Gradle, GitHub Actions, Docker 업데이트 PR을 develop 대상으로 생성 |
 
-정적 검사는 `quality.yml`, 의존성 변경 차단과 반복 가능한 애플리케이션·스크립트 기능 검증은 필수 검사인 `ci.yml`의 `build` job, 운영 Compose와 관측성 통합 검증은 `observability.yml`이 담당한다. 같은 검사를 여러 워크플로에서 반복하지 않는다.
+정적 검사는 `quality.yml`, 의존성 변경 차단과 반복 가능한 애플리케이션·스크립트 기능 검증은 `ci.yml`의 독립 job, 운영 Compose와 관측성 통합 검증은 `observability.yml`이 담당한다. PR 화면에서 실패 영역을 바로 구분할 수 있도록 CI 검증은 병렬 실행하고, 필수 검사 이름을 유지하는 `CI / build`가 모든 결과를 최종 집계한다. 같은 검사를 여러 워크플로에서 반복하지 않는다.
 
 CI와 배포 검증은 GitHub 러너와 실제 EC2에서 실행한다. 로컬에서는 Actionlint와 ShellCheck 같은 정적 검사만 확인하고 JUnit·Docker Compose·API 검증을 반복하지 않는다.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,22 +17,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  dependency_review:
+    name: dependency-review
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 10
 
     steps:
-      #현재 github 레포 코드들 actions 실행 환경으로 가져옴
       - name: Checkout source code
         uses: actions/checkout@v7
 
       - name: Review dependency changes
-        if: github.event_name == 'pull_request'
         uses: actions/dependency-review-action@v5
         with:
           fail-on-severity: high
 
-      #자바 개발 환경 설정
+  gradle_test:
+    name: gradle-test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v7
+
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
@@ -44,12 +52,60 @@ jobs:
         with:
           cache-provider: basic
 
-      #gradlew 실행 권한 부여
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Verify Docker daemon
-        run: docker info
+      - name: Build and test
+        run: ./gradlew clean build
+
+      - name: Upload test report
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: gradle-test-report
+          path: build/reports/tests/test/
+
+  mysql_test:
+    name: mysql-test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v7
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-provider: basic
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Test with MySQL container
+        run: ./gradlew mysqlTest
+
+      - name: Upload MySQL test report
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: mysql-test-report
+          path: build/reports/tests/mysqlTest/
+
+  deployment_scripts:
+    name: deployment-scripts
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v7
 
       - name: Verify deployment and rollback script
         run: |
@@ -57,22 +113,62 @@ jobs:
           python3 -m py_compile scripts/deployment/datadog_verification.py
           python3 -m unittest scripts/deployment/test_datadog_verification.py
 
-      #gradle 빌드 및 테스트 실행
-      - name: Build and test
-        run: ./gradlew clean build
+  docker_image:
+    name: docker-image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
 
-      - name: Test with MySQL container
-        run: ./gradlew mysqlTest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v7
 
-      - name: Upload test report
-        if: failure()
-        uses: actions/upload-artifact@v7
-        with:
-          name: test-report
-          path: |
-            build/reports/tests/test/
-            build/reports/tests/mysqlTest/
-
-      #Dockerfile이 정상적으로 이미지 빌드되는지 확인
       - name: Build Docker image
         run: docker build -t hampouch-server .
+
+  build:
+    name: build
+    if: ${{ always() }}
+    needs:
+      - dependency_review
+      - gradle_test
+      - mysql_test
+      - deployment_scripts
+      - docker_image
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Summarize required job results
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DEPENDENCY_REVIEW_RESULT: ${{ needs.dependency_review.result }}
+          GRADLE_TEST_RESULT: ${{ needs.gradle_test.result }}
+          MYSQL_TEST_RESULT: ${{ needs.mysql_test.result }}
+          DEPLOYMENT_SCRIPTS_RESULT: ${{ needs.deployment_scripts.result }}
+          DOCKER_IMAGE_RESULT: ${{ needs.docker_image.result }}
+        run: |
+          failed=0
+
+          require_success() {
+            local job_name="$1"
+            local result="$2"
+
+            printf '%s: %s\n' "$job_name" "$result"
+            if [ "$result" != "success" ]; then
+              failed=1
+            fi
+          }
+
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            require_success "dependency-review" "$DEPENDENCY_REVIEW_RESULT"
+          else
+            printf 'dependency-review: %s (not required for %s)\n' \
+              "$DEPENDENCY_REVIEW_RESULT" "$EVENT_NAME"
+          fi
+
+          require_success "gradle-test" "$GRADLE_TEST_RESULT"
+          require_success "mysql-test" "$MYSQL_TEST_RESULT"
+          require_success "deployment-scripts" "$DEPLOYMENT_SCRIPTS_RESULT"
+          require_success "docker-image" "$DOCKER_IMAGE_RESULT"
+
+          exit "$failed"


### PR DESCRIPTION
## 📎연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) closes #[issue number]

- Closes #174

## 📄 작업 내용 요약
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.

- 단일 `CI / build` 안에 있던 의존성 검토, Gradle 테스트, MySQL 테스트, 배포 스크립트 검증, Docker 이미지 빌드를 독립 job으로 분리했습니다.
- 일반 테스트와 MySQL 테스트의 실패 보고서를 각각 별도 artifact로 업로드합니다.
- 하위 job 결과를 모으는 `build` 집계 job을 유지하고 자동 검증 범위 문서를 갱신했습니다.

### 검증

- `actionlint`
- 저장소 전체 추적 셸 스크립트 `bash -n` 및 `shellcheck`
- `git diff --check origin/develop...HEAD`
- 집계 스크립트의 PR 성공, develop push 의존성 검사 skip, MySQL job 실패 분기
- pre-PR API/CI gap audit: API 변경 없음

## 👀 중요 변경 사항
> API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요

- develop ruleset의 필수 status context인 `build` 이름은 그대로 유지합니다.
- `dependency-review`는 PR에서만 실행하며 develop push에서는 skip됩니다. 집계 job은 이 skip을 실패로 처리하지 않습니다.

## 🔖 Uncompleted Tasks
> 후속 작업 예정인 사항이 있다면 작성해주세요.

- 없음

## 📢 To Reviewers
> Reviewer가 주로 확인해주었으면 하는 부분을 적어주세요.

- PR 체크 목록에서 실패 영역이 독립 job으로 구분되는지 확인해 주세요.
- 하위 job 실패 또는 취소 시 최종 `CI / build`도 실패하는 집계 조건을 확인해 주세요.