### PR TITLE
fix(challenge): 생성·상태 전이·휴식 경쟁 요청 정합성 보장 [base: develop]

### DIFF
--- a/src/main/java/Hampouch/server/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/Hampouch/server/domain/challenge/service/ChallengeService.java
@@ -10,6 +10,7 @@ import Hampouch.server.domain.expense.service.ExpenseSpendingQuery;
 import Hampouch.server.domain.expense.service.PeriodSpending;
 import Hampouch.server.domain.rest.entity.UserRest;
 import Hampouch.server.domain.rest.repository.UserRestRepository;
+import Hampouch.server.domain.user.service.UserOperationLock;
 import Hampouch.server.global.common.exception.CustomException;
 import Hampouch.server.global.common.exception.domain.ChallengeErrorCode;
 import Hampouch.server.global.common.exception.domain.CommonErrorCode;
@@ -27,7 +28,7 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true) // 쓰기가 필요한 메서드만 개별 @Transactional로 덮어쓴다
+@Transactional(readOnly = true)
 public class ChallengeService {
 
     private static final int AUTO_CANCEL_MIN_DURATION_DAYS = 8;
@@ -37,22 +38,20 @@ public class ChallengeService {
     private final ChallengeRepository challengeRepository;
     private final ChallengeDayRepository challengeDayRepository;
     private final ExpenseService expenseService;
-    private final ExpenseSpendingQuery expenseSpendingQuery; // #64 — 결과 화면 소비 감정 분석 그래프. ExpenseAnalysisService 통째 주입 금지 이유는 그 인터페이스 Javadoc 참조
+    private final ExpenseSpendingQuery expenseSpendingQuery;
     private final ChallengeAdjustmentRepository challengeAdjustmentRepository;
-    // UserRestService가 아니라 리포지토리를 주입한다 — 그쪽이 이 서비스를 주입받고 있어서 서로 주입하면 순환으로 기동이 실패한다.
-    private final UserRestRepository userRestRepository;
-    // "지금"의 단일 출처(Asia/Seoul). 인자 없는 LocalDate.now()는 UTC 배포에서 한국 새벽에 날짜가 하루 어긋난다.
-    private final Clock clock;
+    private final UserRestRepository userRestRepository; // UserRestService와의 순환 의존을 피한다.
+    private final UserOperationLock userOperationLock;
+    private final Clock clock; // 배포 환경의 기본 시간대와 무관하게 한국 날짜를 사용한다.
 
-    /** 챌린지 생성. 동시 진행 1개 가정 → 진행 중 존재 시 409. 휴식 중이었다면 자동 종료 후 생성(휴식 명세 §1 배타 규칙). */
+    /** 진행 중 챌린지가 없을 때 생성하고 활성 휴식은 오늘 종료한다. */
     @Transactional
     public CreateChallengeResponse create(Long userId, CreateChallengeRequest req) {
-        // 만료 미확정 챌린지를 먼저 확정하지 않으면 저장된 IN_PROGRESS 상태가 새 생성을 잘못 막는다.
+        userOperationLock.lock(userId);
         if (finalizeExpiredAndCheckActiveChallenge(userId)) {
             throw new CustomException(ChallengeErrorCode.CHALLENGE_ALREADY_IN_PROGRESS);
         }
-        // 배타 규칙(#8): 생성 자체가 복귀 의사라 활성 휴식을 오늘로 닫는다(챌린지 시작일이 미래여도 종료일은 오늘 — 명세 문언).
-        // 안 닫으면 챌린지가 끝나는 순간 옛 휴식이 findActiveOn에 다시 잡혀 낡은 날짜의 휴식기 홈이 되살아난다.
+        // 챌린지 생성은 복귀 의사로 간주해 옛 휴식이 나중에 다시 활성화되지 않도록 오늘 종료한다.
         LocalDate today = LocalDate.now(clock);
         userRestRepository.findActiveOn(userId, today).ifPresent(rest -> rest.resume(today));
         int dailyLimit = ChallengeCalculator.dailyLimit(req.budgetTotal(), req.durationDays());
@@ -71,20 +70,17 @@ public class ChallengeService {
         try {
             challengeRepository.save(challenge);
         } catch (DataIntegrityViolationException e) {
-            // 위 존재 검사를 동시에 통과한 경쟁 요청이 DB 유니크(uq_challenge_active_user)에 걸린 경우 — 같은 409로 변환.
-            // id가 IDENTITY라 save()가 즉시 INSERT를 날리므로 위반이 커밋까지 밀리지 않고 이 자리에서 잡힌다.
+            // IDENTITY INSERT가 즉시 실행되므로 조건부 UNIQUE 위반을 이 범위에서 409로 변환할 수 있다.
             throw new CustomException(ChallengeErrorCode.CHALLENGE_ALREADY_IN_PROGRESS);
         }
         return CreateChallengeResponse.from(challenge);
     }
 
-    /** 진행 중 챌린지 + 현황(챌린지 모드). 휴식 중이면 휴식기 홈(휴식 모드, #8) — 둘 다 아닐 때만 404. */
+    /** 진행 중 챌린지를 우선하고, 없으면 휴식 홈을 반환한다. */
     @Transactional
     public CurrentChallengeResponse getCurrent(Long userId) {
-        // 진행 중 챌린지가 있으면 무조건 그쪽 우선(휴식 명세 §1) — 활성 휴식과 공존하는 꼬인 데이터에서도 챌린지 홈이 이긴다.
-        // 여기만 hasActiveChallenge를 안 쓰는 건 의도적이다 — 기간이 끝나도 유저가 종료 팝업에서 [챌린지 종료]를
-        // 누르기 전까지는 아직 끝난 게 아닌데(그 구간에 지출을 마저 입력한다), hasActiveChallenge는 조회만으로
-        // 만료분을 확정해 버려 그 구간이 사라진다. 확정을 유저 액션에 묶는 건 #50 몫이고, 여기선 앞당겨 끝내지만 않는다.
+        userOperationLock.lock(userId);
+        // 조회만으로 만료 상태를 확정하면 최종 종료 전 지출 수정 구간이 사라지므로 hasActiveChallenge를 사용하지 않는다.
         Optional<Challenge> inProgress = challengeRepository.findInProgress(userId);
         if (inProgress.isEmpty()) {
             return restHomeOrNotFound(userId);
@@ -95,18 +91,16 @@ public class ChallengeService {
         LocalDate today = LocalDate.now(clock);
         ExpenseInputState expenseInputState = evaluateExpenseInputState(userId, c, today);
 
-        // TODO(령준 지출 연동): todaySpent 출처 교체(연동 전엔 POST /days로 받은 값).
+        // TODO: todaySpent를 ChallengeDay가 아닌 지출 원본에서 계산한다.
         int dailyLimit = c.getDailyLimit();
-        // 금액과 "오늘 기록이 있는가"(lastJudgedDate 분기) 두 용도라 Optional째 들고 있는다
         Optional<ChallengeDay> todayRow = challengeDayRepository.findByChallenge_IdAndDayDate(c.getId(), today);
         int todaySpent = todayRow.map(ChallengeDay::getSpentAmount).orElse(0);
         double usageRate = ChallengeCalculator.usageRate(todaySpent, dailyLimit);
         AlertLevel alertLevel = AlertLevel.of(usageRate);
 
-        // 집계·스트릭은 판정 완료 구간(시작일 ~ lastJudgedDate)까지만 계산 — 날짜 규칙은 아래 lastJudgedDate() 참조
         LocalDate lastJudgedDate = lastJudgedDate(c, today, todayRow.isPresent());
         ChallengeSummary s = lastJudgedDate.isBefore(c.getStartDate())
-                ? new ChallengeSummary(0, 0, 0, 0, 0, 0) // 시작 첫날 기록 전 — 아직 판정된 날이 없음
+                ? new ChallengeSummary(0, 0, 0, 0, 0, 0)
                 : ChallengeCalculator.summarizeForResult(days, timelineOf(c), c.getStartDate(), lastJudgedDate);
 
         var view = new CurrentChallengeResponse.ChallengeView(
@@ -116,14 +110,12 @@ public class ChallengeService {
                 elapsedDays(c, today), remainingDays(c, today),
                 s.successDays(), s.overDays(),
                 ChallengeCalculator.currentStreakAsOf(days, c.getStartDate(), lastJudgedDate), s.savedAmount());
-        int todayRemaining = dailyLimit - todaySpent; // 초과 시 음수 그대로(명세 확정 — 클램프 안 함)
+        int todayRemaining = dailyLimit - todaySpent; // 초과액을 표현하려고 음수를 허용한다.
         var consumption = new CurrentChallengeResponse.Consumption(
                 todaySpent, todayRemaining, dailyLimit,
                 usageRate, ConsumptionCharacter.of(usageRate), alertLevel);
 
-        // 경고 카드는 오늘 사용률(alertLevel)과 무관한 별개 신호라 공통 게이트가 없다 — 어제까지 3연속 초과면 오늘 사용률이 낮아도 뜬다.
-        // 미기록일은 0원=성공으로 채우므로 하루 건너뛰면 연속이 끊겨 카드가 사라진다.
-        // TODO(#52): WEAK_CATEGORY_ALERT 구현 — 령준 카테고리별 집계가 나온 뒤.
+        // TODO: 카테고리별 집계가 준비되면 WEAK_CATEGORY_ALERT를 추가한다.
         List<WarningCard> warningCards = new ArrayList<>();
         if (c.isInProgress() && ChallengeCalculator.isGoalTooTight(days, c.getStartDate(), lastJudgedDate)) {
             warningCards.add(WarningCard.GOAL_TOO_TIGHT);
@@ -137,7 +129,7 @@ public class ChallengeService {
                 view, progress, consumption, warningCards, expenseInputState, adjustment);
     }
 
-    /** 오늘을 제외한 최근 완료일을 거꾸로 확인한다. 7일 챌린지는 자동 취소 대상이 아니다. */
+    /** 8일 이상 챌린지에서 오늘을 제외한 연속 미입력일을 판정한다. */
     private ExpenseInputState evaluateExpenseInputState(Long userId, Challenge challenge, LocalDate today) {
         if (challenge.getDurationDays() < AUTO_CANCEL_MIN_DURATION_DAYS
                 || today.isBefore(challenge.getStartDate())) {
@@ -166,23 +158,13 @@ public class ChallengeService {
         return ExpenseInputState.NORMAL;
     }
 
-    /**
-     * 휴식기 홈(#8, 휴식 명세 §3) — 활성 휴식이 있으면 404 대신 200으로 challenge:null + rest + keptRecords를
-     * 내려 홈이 휴식 화면을 그리게 하고, 휴식마저 없으면 기존 정책 그대로 404.
-     */
     private CurrentChallengeResponse restHomeOrNotFound(Long userId) {
         UserRest rest = userRestRepository.findActiveOn(userId, LocalDate.now(clock))
                 .orElseThrow(() -> new CustomException(ChallengeErrorCode.NO_ACTIVE_CHALLENGE));
         return CurrentChallengeResponse.forRest(CurrentChallengeResponse.RestView.from(rest), keptRecords(userId));
     }
 
-    /**
-     * 보관 중인 내 기록 = 직전 종료 챌린지의 절약·최고 연속(휴식 명세 §3). 집계는 결과·히스토리와 같은
-     * summarizeForResult를 써야 한다 — 휴식기 홈의 숫자가 직전 결과 화면과 어긋나면 안 되기 때문.
-     * ⚠️ "직전 하나"는 잠정이다 — 시안 라벨("누적 절약 금액")이 역대 누계로도 읽혀 PM 확인 대기 중.
-     * "직전"을 endDate가 아닌 생성순으로 고르는 이유는 리포지토리 쿼리 주석 참조(포기 챌린지의 미래 endDate 함정).
-     * 종료 챌린지가 없으면 0/0(잠정) — 챌린지 없이 휴식을 연 유저에게 실제로 생기는 상태다.
-     */
+    /** 휴식 홈 보관 기록은 직전 종료 한 건을 결과 화면과 같은 규칙으로 계산한다. */
     private CurrentChallengeResponse.KeptRecords keptRecords(Long userId) {
         return challengeRepository.findFirstByUserIdAndStatusInOrderByCreatedAtDescIdDesc(
                         userId, List.of(ChallengeStatus.SUCCESS, ChallengeStatus.FAIL))
@@ -195,24 +177,19 @@ public class ChallengeService {
                 .orElse(new CurrentChallengeResponse.KeptRecords(0, 0));
     }
 
-    /**
-     * 캘린더 — 유저 전체가 아니라 "이 챌린지의" 달력이라 요청한 달 ∩ 챌린지 기간만 조회한다(기록이 그 안에만 존재).
-     */
     public CalendarResponse getCalendar(Long userId, Long challengeId, int year, int month) {
-        Challenge c = loadOwned(userId, challengeId); // 존재·소유 먼저(404/403) → 그 다음 파라미터 검증
+        Challenge c = loadOwned(userId, challengeId);
         if (month < 1 || month > 12) {
-            // 13월은 아래 LocalDate.of가 DateTimeException을 던져 500이 되므로 여기서 400으로 컷
             throw new CustomException(CommonErrorCode.BAD_REQUEST);
         }
         if (year < 1 || year > 9999) {
-            // LocalDate.of는 ±999,999,999까지 받지만 MySQL DATE 범위(1000~9999)를 넘으면 쿼리 단계에서 500이 된다
+            // LocalDate보다 좁은 MySQL DATE 범위를 지킨다.
             throw new CustomException(CommonErrorCode.BAD_REQUEST);
         }
 
         DateRange challengeRangeInMonth = DateRange.ofMonth(year, month)
                 .intersect(new DateRange(c.getStartDate(), c.getEndDate()));
 
-        // 겹치지 않는 달(기간 밖)을 보는 건 달 넘기기의 정상 경로라 400이 아니라 빈 캘린더(200)로 응답
         List<CalendarResponse.DayView> days = challengeRangeInMonth.isEmpty()
                 ? List.of()
                 : challengeDayRepository.findByChallenge_IdAndDayDateBetween(
@@ -223,14 +200,14 @@ public class ChallengeService {
         return new CalendarResponse(challengeId, year, month, days);
     }
 
-    /** 종료 결과. 진행 중이고 아직 end_date 전이면 409, end_date 경과면 최초 계산 시 status 확정 저장(이후 지출 수정 시 upsertDay가 재계산). */
+    /** 기간 종료 후 결과를 확정한다. 최종 종료 전에는 지출 변경으로 다시 계산될 수 있다. */
     @Transactional
     public ResultResponse getResult(Long userId, Long challengeId) {
+        userOperationLock.lock(userId);
         Challenge c = loadOwned(userId, challengeId);
         List<ChallengeDay> days = challengeDayRepository.findByChallenge_Id(challengeId);
 
-        // 결과는 기간 전체 기준 — 미입력일 = 0원 SUCCESS 간주(0630 확정, 명세 §4).
-        // 확정보다 먼저 계산하는 이유: 총액 판정의 입력이 이 집계의 actualSpent다(판정 근거 = 응답 값).
+        // 미입력일은 0원 지출로 간주한다.
         ChallengeSummary s = ChallengeCalculator.summarizeForResult(
                 days, timelineOf(c), c.getStartDate(), c.getEndDate());
 
@@ -239,33 +216,24 @@ public class ChallengeService {
             if (!today.isAfter(c.getEndDate())) {
                 throw new CustomException(ChallengeErrorCode.CHALLENGE_NOT_ENDED);
             }
-            // 기록 0건이어도 그대로 확정(0714 PM: 성공 처리) — 총지출 0원 ≤ 목표라 SUCCESS.
-            c.applyResult(ChallengeCalculator.resultStatus(s.actualSpent(), c.getBudgetTotal())); // end_date 경과 → 최초 계산 시 저장(배치 없음)
+            c.applyResult(ChallengeCalculator.resultStatus(s.actualSpent(), c.getBudgetTotal()));
         }
         var period = ResultResponse.Period.from(c);
         var summary = new ResultResponse.Summary(
                 s.successDays(), s.overDays(), s.savedAmount(), s.overAmount(),
                 s.maxStreak(), c.getBudgetTotal(), s.actualSpent());
-        // TODO(령준 지출 연동) 미해결)
-        // emotionBreakdown은 EXPENSE 원본 합계 — summary.actualSpent(ChallengeDay 합계,
-        // 와는 출처가 아직 다를 수 있다. day-level 자동 갱신이 붙기 전까지는
-        // 두 숫자가 항상 같다고 보장하지 않는다 — 이 갭은 #64 범위 밖(day-level ChallengeDay 갱신은 별도 이슈).
+        // ChallengeDay와 지출 원본이 동기화되기 전에는 요약 합계와 감정별 합계가 다를 수 있다.
         PeriodSpending spending = expenseSpendingQuery.periodSpending(userId, c.getStartDate(), c.getEndDate());
         return new ResultResponse(c.getId(), c.getStatus(), c.getClosedAt(), period, summary, spending.emotionBreakdown());
     }
 
     /**
-     * 최종 종료 — 유저가 결과 팝업의 [챌린지 종료]를 눌러 기록을 잠근다(팝업 문구 "챌린지가 최종 종료되면
-     * 지출 수정이 불가해요"). 기간 종료가 아니라 이 시점이 잠금 경계라, 그 전까지는 지출을 마저 고치고
-     * 결과가 다시 계산되는 구간이 있다(결과 팝업의 다른 선택지 [지출 수정하기]).
-     *
-     * 결과 화면을 안 열고 바로 눌러도 되도록 만료 미확정분을 여기서 확정한다 — 확정을 그대로 두면
-     * 잠긴 챌린지가 IN_PROGRESS로 남아 다음 챌린지 생성까지 막는다.
-     * 중도 포기·자동 취소는 이 흐름을 타지 않는다(409): 기록에서 나온 결과가 아니라 지출을 고쳐도
-     * 재계산되지 않으므로 잠글 대상이 없고, 잠그면 그 기간 지출 수정만 새로 막히게 된다.
+     * 기록 기반 결과를 최종 종료해 해당 기간의 지출을 변경 불가로 확정한다.
+     * 만료된 진행 상태는 먼저 확정하지만 포기·자동 취소는 최종 종료할 수 없다.
      */
     @Transactional
     public CloseResponse close(Long userId, Long challengeId) {
+        userOperationLock.lock(userId);
         Challenge c = loadOwnedForUpdate(userId, challengeId);
         if (c.isClosed()) {
             throw new CustomException(ChallengeErrorCode.CHALLENGE_ALREADY_CLOSED);
@@ -274,7 +242,6 @@ public class ChallengeService {
             throw new CustomException(ChallengeErrorCode.CHALLENGE_NOT_ENDED);
         }
         finalizeIfExpired(c);
-        // 포기·자동 취소는 기록에서 계산된 결과가 아니라 얼릴 대상이 없다(그 기간 지출 편집만 새로 막힌다) → 거절
         if (!c.isResultFromRecords()) {
             throw new CustomException(ChallengeErrorCode.CHALLENGE_NOT_CLOSABLE);
         }
@@ -282,19 +249,19 @@ public class ChallengeService {
         return CloseResponse.from(c);
     }
 
-    /** 일별 지출 수신 → 그날 판정 upsert. */
+    /** 특정 날짜의 지출과 판정을 upsert한다. */
     @Transactional
     public DayUpsertResponse upsertDay(Long userId, Long challengeId, DayUpsertRequest req) {
+        userOperationLock.lock(userId);
         Challenge c = loadOwnedForUpdate(userId, challengeId);
-        // 최종 종료된 챌린지의 기록은 못 고친다 — 날짜 검사(400)보다 먼저 보는 이유는 요청 값이 아니라 상태 문제라서
+        // 상태 충돌은 요청 날짜 오류보다 우선한다.
         if (c.isClosed()) {
             throw new CustomException(ChallengeErrorCode.CHALLENGE_ALREADY_CLOSED);
         }
         if (req.date().isBefore(c.getStartDate()) || req.date().isAfter(c.getEndDate())) {
             throw new CustomException(ChallengeErrorCode.DAY_OUT_OF_RANGE);
         }
-        // 지금 한도가 아니라 "그날" 한도로 채점한다 — 조정 뒤에 지난 날짜를 뒤늦게 입력할 때
-        // 새 한도로 매기면 과거가 소급되는 셈이 된다(조정 명세: 지난 기록은 그대로 유지).
+        // 과거 기록은 조정 후 현재 한도가 아니라 해당 날짜의 한도로 판정한다.
         int dailyLimit = timelineOf(c).on(req.date());
         DayStatus status = ChallengeCalculator.judge(req.spentAmount(), dailyLimit);
 
@@ -306,7 +273,7 @@ public class ChallengeService {
                 .orElseGet(() -> challengeDayRepository.save(
                         ChallengeDay.of(c, req.date(), req.spentAmount(), status, dailyLimit)));
 
-        // 기록으로 계산된 종료 상태만 다시 계산한다. 중도 포기와 미입력 자동 취소는 지출을 고쳐도 되살리지 않는다.
+        // 기록 기반 결과만 수정된 지출로 재계산한다.
         if (!c.isInProgress() && c.isResultFromRecords()) {
             ChallengeSummary s = ChallengeCalculator.summarizeForResult(
                     challengeDayRepository.findByChallenge_Id(challengeId),
@@ -317,29 +284,23 @@ public class ChallengeService {
         return new DayUpsertResponse(day.getDayDate(), day.getSpentAmount(), dailyLimit, day.getStatus());
     }
 
-    /**
-     * 지난 챌린지 리스트(#4) — 종료된 것만, 최근 종료가 먼저. 없으면 빈 리스트(에러 아님).
-     * 조회인데 쓰기 @Transactional인 이유: 확정이 lazy라 결과 화면을 안 연 챌린지는 status가 IN_PROGRESS로
-     * 남아 있고, 그대로 조회하면 방금 끝난 챌린지가 히스토리에서 빠진다.
-     */
+    /** 만료 상태를 지연 확정하므로 조회지만 쓰기 트랜잭션이 필요하다. */
     @Transactional
     public ChallengeHistoryResponse getHistory(Long userId) {
+        userOperationLock.lock(userId);
         finalizeExpiredInProgress(userId);
-        // 방금 확정한 상태는 커밋 전이지만 JPQL 실행 직전 자동 플러시라 아래 조회에 잡힌다
         List<Challenge> ended = challengeRepository.findByUserIdAndStatusInOrderByEndDateDescIdDesc(
                 userId, List.of(ChallengeStatus.SUCCESS, ChallengeStatus.FAIL));
         if (ended.isEmpty()) {
             return new ChallengeHistoryResponse(List.of());
         }
 
-        // 챌린지마다 따로 조회하면 N+1이라 in절 한 방으로 받아 id별로 나눈다.
-        // 기록 0건인 챌린지는 키 자체가 안 생기므로 꺼낼 때 getOrDefault.
         List<Long> endedIds = ended.stream().map(Challenge::getId).toList();
         Map<Long, List<ChallengeDay>> daysByChallengeId = challengeDayRepository
                 .findByChallenge_IdIn(endedIds)
                 .stream()
                 .collect(Collectors.groupingBy(d -> d.getChallenge().getId()));
-        // 조정 이력도 같은 이유로 한 방에 받는다. groupingBy는 스트림 순서를 유지하므로 쿼리의 오름차순 정렬이 그대로 남는다(타임라인 전제).
+        // 조회 정렬을 유지해 날짜가 같은 조정도 타임라인 순서가 보존된다.
         Map<Long, List<ChallengeAdjustment>> adjustmentsByChallengeId = challengeAdjustmentRepository
                 .findByChallenge_IdInOrderByEffectiveDateAscIdAsc(endedIds)
                 .stream()
@@ -347,7 +308,6 @@ public class ChallengeService {
 
         List<ChallengeHistoryResponse.Item> items = ended.stream()
                 .map(c -> {
-                    // 금액 요약은 결과 화면(§4)과 같은 규칙으로 조회 시 계산 — 미입력일 = 0원 지출 = 성공 간주(0630 확정)
                     ChallengeSummary s = ChallengeCalculator.summarizeForResult(
                             daysByChallengeId.getOrDefault(c.getId(), List.of()),
                             DailyLimitTimeline.of(c, adjustmentsByChallengeId.getOrDefault(c.getId(), List.of())),
@@ -358,46 +318,31 @@ public class ChallengeService {
         return new ChallengeHistoryResponse(items);
     }
 
-    /**
-     * 중도 포기 — IN_PROGRESS를 유저 선언 FAIL로 즉시 확정.
-     * 기간 마지막 날까지는 만료가 아니라 포기할 수 있다(getResult의 409 경계와 동일).
-     */
+    /** 기간 마지막 날까지 진행 중 챌린지를 즉시 실패로 확정한다. */
     @Transactional
     public GiveUpResponse giveUp(Long userId, Long challengeId) {
+        userOperationLock.lock(userId);
         Challenge c = loadInProgressOwned(userId, challengeId);
         c.giveUp();
         return GiveUpResponse.from(c);
     }
 
-    /**
-     * 집중 카테고리 수정 — 진행 중일 때만 허용하는 것은 ⚠️잠정이다(수정 화면이 시안에 없어 명세 공백).
-     * 끝난 챌린지의 카테고리는 그 결과·기록을 설명하는 과거 값이라 잠갔다.
-     */
+    /** 과거 결과의 해석이 바뀌지 않도록 진행 중 챌린지만 수정한다. */
     @Transactional
     public FocusCategoriesResponse updateFocusCategories(Long userId, Long challengeId, FocusCategoriesRequest req) {
+        userOperationLock.lock(userId);
         Challenge c = loadInProgressOwned(userId, challengeId);
         c.replaceWeakCategories(req.categories());
         return FocusCategoriesResponse.from(c);
     }
 
     /**
-     * 목표 금액 조정(#7) — 프리셋 배율이나 직접 입력 금액으로 **목표 금액**을 바꾸고, 하루 한도는 거기서 파생한다.
-     * 배율이 하루 한도가 아니라 목표에 붙는 근거는 조정 화면이다: 목표 금액 후보 세 개를 보여 주고
-     * 하루 식비 목표는 고른 값에서 계산된 읽기 전용 표시다(14일·140,000 → 20% → 168,000, 하루 12,000).
-     * 파생 공식은 생성 때와 같은 것을 쓴다 — 갈라지면 온보딩에서 본 하루 금액과 조정 후 하루 금액의 규칙이 달라진다.
-     *
-     * ⚠️잠정 — 기간이 끝났지만 아직 최종 종료 전인 구간에서도 조정을 막는다(loadInProgressOwned의 만료 게이트).
-     * 0727 PM 확답이 그 구간을 연 대상은 "지출 수정"이고 목표 조정은 답의 대상이 아니었다. 막은 쪽으로 간 이유는
-     * 지출 수정이 기록을 정확하게 만드는 방향인 반면 목표 조정은 결과를 유리하게 만드는 방향이고(총액 판정이면
-     * 끝난 뒤 목표를 올려 FAIL을 SUCCESS로 뒤집을 수 있다), 화면 문구가 "남은 기간에만 적용"인데 만료 후엔
-     * 남은 기간이 0일이라서다. 이 구간의 잠금 범위는 #50(최종 종료)이 확정한다.
-     *
-     * 효력은 오늘부터다 — 화면 문구가 "이미 지난 기록은 그대로 유지되고, 남은 기간에만 적용돼요"이고
-     * 오늘은 아직 '지난 날'이 아니다. ⚠️오늘부터의 기록을 새 한도로 다시 판정하는 건 자체 결정이다(잠정):
-     * 시안이 오늘의 취급을 명시하지 않았는데, 오늘을 옛 한도로 두면 오늘이 빠듯해서 누른 조정이 내일에야 듣는다.
+     * 목표 금액을 조정하고 하루 한도를 다시 계산한다.
+     * 결과 역전을 막기 위해 만료 후 조정은 금지하며 새 한도는 오늘부터 적용한다.
      */
     @Transactional
     public AdjustGoalResponse adjustGoal(Long userId, Long challengeId, AdjustGoalRequest req) {
+        userOperationLock.lock(userId);
         Challenge c = loadInProgressOwned(userId, challengeId);
         int usedCount = challengeAdjustmentRepository.countByChallenge_Id(challengeId);
         int maxCount = ChallengeCalculator.maxAdjustmentCount(c.getDurationDays());
@@ -408,7 +353,6 @@ public class ChallengeService {
         LocalDate today = LocalDate.now(clock);
         int previousBudgetTotal = c.getBudgetTotal();
         int previousDailyLimit = c.getDailyLimit();
-        // 요청은 프리셋과 직접 입력 중 하나만 담고 있다(AdjustGoalRequest가 @AssertTrue로 강제) — 여기선 어느 쪽인지만 가른다
         int newBudgetTotal = req.option() != null
                 ? req.option().apply(previousBudgetTotal)
                 : req.budgetTotal();
@@ -426,8 +370,7 @@ public class ChallengeService {
                     .newDailyLimit(newDailyLimit)
                     .build());
         } catch (DataIntegrityViolationException e) {
-            // 위 횟수 검사를 동시에 통과한 경쟁 요청이 같은 번호를 먼저 차지한 경우(uq_challenge_adjustment_seq) — 같은 409로 변환.
-            // 검사와 저장이 갈라져 있는 한 이 창은 코드로 못 닫아서 DB 제약이 마지막 방어선이다(챌린지 생성과 같은 구조).
+            // 순번 UNIQUE는 서비스 잠금을 우회한 중복 조정의 마지막 방어선이다.
             throw new CustomException(ChallengeErrorCode.ADJUSTMENT_LIMIT_EXCEEDED);
         }
         rejudgeFrom(challengeId, today, newDailyLimit);
@@ -435,12 +378,7 @@ public class ChallengeService {
         return new AdjustGoalResponse(challengeId, newBudgetTotal, newDailyLimit, usedCount + 1, maxCount);
     }
 
-    /**
-     * 효력일부터의 기록을 새 한도로 다시 채점한다. 오늘 것만 고치면 안 되는 이유는 일별 입력이 미래 날짜도
-     * 받기 때문이다(범위 검사가 기간만 본다) — 조정 전에 넣어 둔 미래 날짜 기록이 옛 한도 스냅샷을 그대로 물고 있으면,
-     * 그 행만 타임라인과 다른 한도를 말하게 되고 결과 판정까지 옛 기준으로 굳는다.
-     * 효력일 앞의 행은 건드리지 않는다(과거 소급 금지).
-     */
+    /** 효력일부터 미리 입력된 기록도 새 한도로 재판정하며 과거 기록은 유지한다. */
     private void rejudgeFrom(Long challengeId, LocalDate effectiveDate, int dailyLimit) {
         challengeDayRepository.findByChallenge_IdAndDayDateGreaterThanEqual(challengeId, effectiveDate)
                 .forEach(day -> day.rejudge(
@@ -448,12 +386,12 @@ public class ChallengeService {
     }
 
     /**
-     * 진행 중 챌린지가 "실제로" 있는가 — 만료 미확정분을 먼저 확정한 뒤 판단한다. 생성·휴식 시작의 409
-     * 게이트가 함께 쓰는 창구다. **"진행 중인가"는 existsInProgress 직접 호출 말고 이 창구로 물을 것** —
-     * 저장 status만 보면 결과 화면을 안 연 만료 챌린지가 생성·휴식을 잘못 막는다. 확정 저장 때문에 쓰기 트랜잭션.
+     * 만료된 진행 상태를 지연 확정한 뒤 실제 진행 여부를 반환한다.
+     * 생성과 휴식 시작은 직접 exists 조회하지 않고 이 경로를 사용한다.
      */
     @Transactional
     public boolean hasActiveChallenge(Long userId) {
+        userOperationLock.lock(userId);
         return finalizeExpiredAndCheckActiveChallenge(userId);
     }
 
@@ -462,19 +400,11 @@ public class ChallengeService {
         return challengeRepository.existsInProgress(userId);
     }
 
-    /**
-     * 기간이 끝났는데 아직 확정 전인 챌린지를 확정 — 판정을 돌리는 배치가 없어서 endDate가 지나도 다음
-     * 조회가 올 때까지 행은 IN_PROGRESS로 남는다(lazy 확정). 재료(일별 기록)가 이미 다 있어 늦게 계산해도 답은 같다.
-     * 확정을 먼저 실행하는 경로는 결과·히스토리 조회와 생성·휴식 시작 게이트다 — 홈 현황(getCurrent)만 일부러 빠져 있다.
-     */
+    /** 배치가 없으므로 접근 시점에 만료 상태를 확정한다. */
     private void finalizeExpiredInProgress(Long userId) {
         challengeRepository.findInProgress(userId).ifPresent(this::finalizeIfExpired);
     }
 
-    /**
-     * 기간이 끝났는데 확정 전이면 그 자리에서 확정 — 히스토리·포기가 같은 규칙을 쓰도록 뽑아낸 단일 출처.
-     * save가 없는 건 더티 체킹이 커밋 때 UPDATE를 내보내기 때문(upsertDay와 동일).
-     */
     private void finalizeIfExpired(Challenge c) {
         if (c.isInProgress() && isExpired(c)) {
             ChallengeSummary s = ChallengeCalculator.summarizeForResult(
@@ -484,31 +414,18 @@ public class ChallengeService {
         }
     }
 
-    /**
-     * 기간이 지났는지만 판정하고 상태는 안 바꾼다 — 포기가 만료 챌린지를 롤백 없이 걸러내는 데 쓴다.
-     * 기간 마지막 날은 아직 만료가 아니다(getResult·finalizeIfExpired의 경계와 동일).
-     */
     private boolean isExpired(Challenge c) {
         return LocalDate.now(clock).isAfter(c.getEndDate());
     }
 
-    /**
-     * 이 챌린지의 날짜별 한도 표. 조정 이력이 0건이면 지금 한도 하나짜리와 같은 표가 되므로,
-     * 조정을 안 쓴 챌린지의 계산 결과는 조정 기능 도입 전과 동일하다.
-     */
     private DailyLimitTimeline timelineOf(Challenge c) {
         return DailyLimitTimeline.of(c,
                 challengeAdjustmentRepository.findByChallenge_IdOrderByEffectiveDateAscIdAsc(c.getId()));
     }
 
     /**
-     * 진행 중인 내 챌린지 — 존재·소유(404/403)를 먼저 보고 진행 중 여부(409)를 본다.
-     * 진행 중 챌린지만 바꿀 수 있는 세 기능(포기·집중 카테고리·목표 조정)의 공통 입구다.
-     *
-     * 만료됐지만 아직 확정 안 된 챌린지도 막는다 — 안 막으면 기간을 다 채워 SUCCESS여야 할 결과가
-     * 포기 FAIL로 굳거나(GIVEN_UP은 재계산 제외라 되돌릴 수 없다), 끝난 기간의 목표를 올려 결과를 뒤집을 수 있다.
-     * 그 만료분을 여기서 확정하지 않고 만료 여부만 읽는 이유(나연 리뷰 반영): 상태를 바꾼 뒤 409를 던지면
-     * 예외가 RuntimeException이라 확정까지 롤백돼, 응답은 409인데 DB는 IN_PROGRESS로 남는다.
+     * 만료 상태를 바꾸지 않고 409로 거절한다.
+     * 먼저 확정한 뒤 예외를 던지면 확정까지 함께 롤백된다.
      */
     private Challenge loadInProgressOwned(Long userId, Long challengeId) {
         Challenge c = loadOwned(userId, challengeId);
@@ -536,26 +453,20 @@ public class ChallengeService {
         return c;
     }
 
-    /**
-     * 채점이 끝난 마지막 날 — 집계와 스트릭은 여기까지만 센다. endDate(고정 종료일)와 달리 오늘을 따라
-     * 움직이는 커서다(보통 어제, 오늘 기록을 보냈으면 오늘, 끝난 챌린지는 endDate에서 멈춤).
-     * 오늘을 기록 있을 때만 포함하는 이유: 안 그러면 매일 아침 오늘이 미리 '성공'으로 집계된다(미입력일=0원=성공 규칙 탓).
-     */
+    /** 오늘 기록이 있을 때만 오늘을 포함해 미입력을 선제 성공으로 세지 않는다. */
     private static LocalDate lastJudgedDate(Challenge c, LocalDate today, boolean todayRecorded) {
         LocalDate last = todayRecorded ? today : today.minusDays(1);
-        return last.isAfter(c.getEndDate()) ? c.getEndDate() : last; // 종료일을 넘지 않게 — 둘 중 이른 날
+        return last.isAfter(c.getEndDate()) ? c.getEndDate() : last;
     }
 
-    /** 경과 일수 (시작일 당일 = 1, 기간 내로 클램프). */
     private int elapsedDays(Challenge c, LocalDate today) {
         if (today.isBefore(c.getStartDate())) {
             return 0;
         }
         LocalDate last = today.isAfter(c.getEndDate()) ? c.getEndDate() : today;
-        return (int) (ChronoUnit.DAYS.between(c.getStartDate(), last) + 1); // 시작일 당일이 0이라 +1 해서 "1일차"
+        return (int) (ChronoUnit.DAYS.between(c.getStartDate(), last) + 1);
     }
 
-    /** 남은 일수 (오늘 제외, 종료 후 0). */
     private int remainingDays(Challenge c, LocalDate today) {
         if (today.isAfter(c.getEndDate())) {
             return 0;

--- a/src/main/java/Hampouch/server/domain/expense/service/ExpenseService.java
+++ b/src/main/java/Hampouch/server/domain/expense/service/ExpenseService.java
@@ -8,7 +8,6 @@ import Hampouch.server.domain.expense.repository.ExpenseRepository;
 import Hampouch.server.domain.expense.repository.NoSpendDayRepository;
 import Hampouch.server.domain.user.entity.User;
 import Hampouch.server.domain.user.repository.UserRepository;
-import Hampouch.server.domain.user.service.UserOperationLock;
 import Hampouch.server.global.common.exception.CustomException;
 import Hampouch.server.global.common.exception.domain.ExpenseErrorCode;
 import Hampouch.server.global.common.exception.domain.UserErrorCode;
@@ -36,18 +35,17 @@ public class ExpenseService {
     private final UserRepository userRepository;
     private final ExpenseImageService expenseImageService; // create()의 imageKey 검증(HeadObject)에 재사용
     private final ExpenseDetailAccess expenseDetailAccess; // updateMemo()의 get-or-create 동시성 경쟁 방지(#8)
-    private final UserOperationLock userOperationLock;
     private final Clock clock; //buildSummary()가 dailyAverage 계산 시 오늘까지 경과일수를 구하기 위한 기준
     // 한국 시간 기준으로 통일 된 Bean 활용
 
     /**
      * POST /expenses.
-     * 유저 행을 먼저 잠근 뒤 같은 날짜의 챌린지 잠금을 잡는다. 모든 지출 쓰기가 이 순서를 공유해야
-     * 챌린지 자동 취소·최종 종료와 교차할 때도 잠금 순서가 뒤집히지 않는다.
+     * userRepository.getReferenceById()로 실제 SELECT 없이 프록시만 받는다 — userId는 인증 필터를 통과한 값이라
+     * 존재를 다시 확인할 필요가 없고, Expense.user는 어차피 FK 값만 있으면 됨
+     * (설계 트레이드오프, findById 대비 쿼리 1회 절약).
      */
     @Transactional
     public ExpenseCreateResponse create(Long userId, ExpenseCreateRequest request) {
-        userOperationLock.lock(userId);
         validateExpenseChangeAllowed(userId, request.date());
 
         User user = userRepository.getReferenceById(userId);
@@ -69,7 +67,6 @@ public class ExpenseService {
      */
     @Transactional
     public void recordNoSpend(Long userId, NoSpendRecordRequest request) {
-        userOperationLock.lock(userId);
         validateExpenseChangeAllowed(userId, request.date());
         if (expenseRepository.existsByUser_IdAndExpenseDateAndStatus(
                 userId, request.date(), ExpenseStatus.ACTIVE)) {
@@ -109,7 +106,6 @@ public class ExpenseService {
      */
     @Transactional
     public ExpenseCreateResponse update(Long userId, Long expenseId, ExpenseUpdateRequest request) {
-        userOperationLock.lock(userId);
         Expense expense = loadOwned(userId, expenseId);
         validateExpenseChangeAllowed(userId, expense.getExpenseDate(), request.date());
 

--- a/src/main/java/Hampouch/server/domain/expense/service/ExpenseService.java
+++ b/src/main/java/Hampouch/server/domain/expense/service/ExpenseService.java
@@ -8,6 +8,7 @@ import Hampouch.server.domain.expense.repository.ExpenseRepository;
 import Hampouch.server.domain.expense.repository.NoSpendDayRepository;
 import Hampouch.server.domain.user.entity.User;
 import Hampouch.server.domain.user.repository.UserRepository;
+import Hampouch.server.domain.user.service.UserOperationLock;
 import Hampouch.server.global.common.exception.CustomException;
 import Hampouch.server.global.common.exception.domain.ExpenseErrorCode;
 import Hampouch.server.global.common.exception.domain.UserErrorCode;
@@ -32,6 +33,7 @@ public class ExpenseService {
     private final ExpenseDetailRepository expenseDetailRepository;
     private final NoSpendDayRepository noSpendDayRepository;
     private final ExpenseDateLockQuery expenseDateLockQuery;
+    private final UserOperationLock userOperationLock;
     private final UserRepository userRepository;
     private final ExpenseImageService expenseImageService; // create()의 imageKey 검증(HeadObject)에 재사용
     private final ExpenseDetailAccess expenseDetailAccess; // updateMemo()의 get-or-create 동시성 경쟁 방지(#8)
@@ -40,12 +42,12 @@ public class ExpenseService {
 
     /**
      * POST /expenses.
-     * userRepository.getReferenceById()로 실제 SELECT 없이 프록시만 받는다 — userId는 인증 필터를 통과한 값이라
-     * 존재를 다시 확인할 필요가 없고, Expense.user는 어차피 FK 값만 있으면 됨
-     * (설계 트레이드오프, findById 대비 쿼리 1회 절약).
+     * 사용자 행을 먼저 잠근 뒤 챌린지 기간 행을 잠가 종료 경로와 user → challenge 순서를 맞춘다.
+     * getReferenceById()는 이미 잠근 사용자를 연관관계 프록시로만 연결한다.
      */
     @Transactional
     public ExpenseCreateResponse create(Long userId, ExpenseCreateRequest request) {
+        userOperationLock.lock(userId);
         validateExpenseChangeAllowed(userId, request.date());
 
         User user = userRepository.getReferenceById(userId);
@@ -67,6 +69,7 @@ public class ExpenseService {
      */
     @Transactional
     public void recordNoSpend(Long userId, NoSpendRecordRequest request) {
+        userOperationLock.lock(userId);
         validateExpenseChangeAllowed(userId, request.date());
         if (expenseRepository.existsByUser_IdAndExpenseDateAndStatus(
                 userId, request.date(), ExpenseStatus.ACTIVE)) {
@@ -106,6 +109,7 @@ public class ExpenseService {
      */
     @Transactional
     public ExpenseCreateResponse update(Long userId, Long expenseId, ExpenseUpdateRequest request) {
+        userOperationLock.lock(userId);
         Expense expense = loadOwned(userId, expenseId);
         validateExpenseChangeAllowed(userId, expense.getExpenseDate(), request.date());
 
@@ -134,6 +138,7 @@ public class ExpenseService {
      */
     @Transactional
     public void delete(Long userId, Long expenseId) {
+        userOperationLock.lock(userId);
         Expense expense = loadOwned(userId, expenseId);
         validateExpenseChangeAllowed(userId, expense.getExpenseDate());
         LocalDate deletedDate = expense.getExpenseDate();

--- a/src/main/java/Hampouch/server/domain/expense/service/ExpenseService.java
+++ b/src/main/java/Hampouch/server/domain/expense/service/ExpenseService.java
@@ -8,6 +8,7 @@ import Hampouch.server.domain.expense.repository.ExpenseRepository;
 import Hampouch.server.domain.expense.repository.NoSpendDayRepository;
 import Hampouch.server.domain.user.entity.User;
 import Hampouch.server.domain.user.repository.UserRepository;
+import Hampouch.server.domain.user.service.UserOperationLock;
 import Hampouch.server.global.common.exception.CustomException;
 import Hampouch.server.global.common.exception.domain.ExpenseErrorCode;
 import Hampouch.server.global.common.exception.domain.UserErrorCode;
@@ -35,17 +36,18 @@ public class ExpenseService {
     private final UserRepository userRepository;
     private final ExpenseImageService expenseImageService; // create()의 imageKey 검증(HeadObject)에 재사용
     private final ExpenseDetailAccess expenseDetailAccess; // updateMemo()의 get-or-create 동시성 경쟁 방지(#8)
+    private final UserOperationLock userOperationLock;
     private final Clock clock; //buildSummary()가 dailyAverage 계산 시 오늘까지 경과일수를 구하기 위한 기준
     // 한국 시간 기준으로 통일 된 Bean 활용
 
     /**
      * POST /expenses.
-     * userRepository.getReferenceById()로 실제 SELECT 없이 프록시만 받는다 — userId는 인증 필터를 통과한 값이라
-     * 존재를 다시 확인할 필요가 없고, Expense.user는 어차피 FK 값만 있으면 됨
-     * (설계 트레이드오프, findById 대비 쿼리 1회 절약).
+     * 유저 행을 먼저 잠근 뒤 같은 날짜의 챌린지 잠금을 잡는다. 모든 지출 쓰기가 이 순서를 공유해야
+     * 챌린지 자동 취소·최종 종료와 교차할 때도 잠금 순서가 뒤집히지 않는다.
      */
     @Transactional
     public ExpenseCreateResponse create(Long userId, ExpenseCreateRequest request) {
+        userOperationLock.lock(userId);
         validateExpenseChangeAllowed(userId, request.date());
 
         User user = userRepository.getReferenceById(userId);
@@ -67,6 +69,7 @@ public class ExpenseService {
      */
     @Transactional
     public void recordNoSpend(Long userId, NoSpendRecordRequest request) {
+        userOperationLock.lock(userId);
         validateExpenseChangeAllowed(userId, request.date());
         if (expenseRepository.existsByUser_IdAndExpenseDateAndStatus(
                 userId, request.date(), ExpenseStatus.ACTIVE)) {
@@ -106,6 +109,7 @@ public class ExpenseService {
      */
     @Transactional
     public ExpenseCreateResponse update(Long userId, Long expenseId, ExpenseUpdateRequest request) {
+        userOperationLock.lock(userId);
         Expense expense = loadOwned(userId, expenseId);
         validateExpenseChangeAllowed(userId, expense.getExpenseDate(), request.date());
 

--- a/src/main/java/Hampouch/server/domain/rest/service/UserRestService.java
+++ b/src/main/java/Hampouch/server/domain/rest/service/UserRestService.java
@@ -7,6 +7,7 @@ import Hampouch.server.domain.rest.dto.RestStartRequest;
 import Hampouch.server.domain.rest.dto.RestStartResponse;
 import Hampouch.server.domain.rest.entity.UserRest;
 import Hampouch.server.domain.rest.repository.UserRestRepository;
+import Hampouch.server.domain.user.service.UserOperationLock;
 import Hampouch.server.global.common.exception.CustomException;
 import Hampouch.server.global.common.exception.domain.ChallengeErrorCode;
 import Hampouch.server.global.common.exception.domain.CommonErrorCode;
@@ -29,15 +30,17 @@ public class UserRestService {
     private final UserRestRepository userRestRepository;
     // 진행 중 챌린지 판단은 ChallengeService가 단일 출처라 서비스째 주입한다 — 반대 방향은 리포지토리만 쓰므로 순환은 안 생긴다.
     private final ChallengeService challengeService;
+    private final UserOperationLock userOperationLock;
     private final Clock clock; // "지금"의 단일 출처(Asia/Seoul)
 
     /**
      * 휴식 시작(명세 §1) — 진입점이 결과 화면뿐이라 진행 중 챌린지가 있으면 409, 이미 휴식 중이어도 409.
      * 챌린지 검사를 hasActiveChallenge로 하는 이유: 저장 status만 보면 결과 화면을 안 열어 IN_PROGRESS로
      * 남은 만료 챌린지가 휴식 시작을 잘못 막는다.
-     */
+    */
     @Transactional
     public RestStartResponse start(Long userId, RestStartRequest req) {
+        // hasActiveChallenge가 사용자 락을 잡고, 이 바깥 트랜잭션이 끝날 때까지 유지한다.
         if (challengeService.hasActiveChallenge(userId)) {
             throw new CustomException(ChallengeErrorCode.CHALLENGE_ALREADY_IN_PROGRESS);
         }
@@ -63,6 +66,7 @@ public class UserRestService {
      */
     @Transactional
     public RestResumeResponse resume(Long userId, RestResumeRequest req) {
+        userOperationLock.lock(userId);
         LocalDate today = LocalDate.now(clock);
         UserRest rest = userRestRepository.findActiveOn(userId, today)
                 .orElseThrow(() -> new CustomException(RestErrorCode.REST_NOT_ACTIVE));

--- a/src/main/java/Hampouch/server/domain/user/repository/UserRepository.java
+++ b/src/main/java/Hampouch/server/domain/user/repository/UserRepository.java
@@ -2,11 +2,19 @@ package Hampouch.server.domain.user.repository;
 
 import Hampouch.server.domain.user.entity.AuthProvider;
 import Hampouch.server.domain.user.entity.User;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT u FROM User u WHERE u.id = :id")
+    Optional<User> findByIdForUpdate(@Param("id") Long id);
 
     Optional<User> findByEmail(String email);
 

--- a/src/main/java/Hampouch/server/domain/user/service/UserOperationLock.java
+++ b/src/main/java/Hampouch/server/domain/user/service/UserOperationLock.java
@@ -1,0 +1,24 @@
+package Hampouch.server.domain.user.service;
+
+import Hampouch.server.domain.user.repository.UserRepository;
+import Hampouch.server.global.common.exception.CustomException;
+import Hampouch.server.global.common.exception.domain.UserErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/** 동일 사용자의 챌린지·휴식 상태 변경을 직렬화하는 조정 락. */
+@Component
+@RequiredArgsConstructor
+public class UserOperationLock {
+
+    private final UserRepository userRepository;
+
+    /** 호출자의 쓰기 트랜잭션이 끝날 때까지 사용자 단위 상태 변경을 직렬화한다. */
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void lock(Long userId) {
+        userRepository.findByIdForUpdate(userId)
+                .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/src/test/java/Hampouch/server/domain/challenge/ChallengeConcurrencyMySqlTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/ChallengeConcurrencyMySqlTest.java
@@ -8,8 +8,7 @@ import Hampouch.server.domain.challenge.entity.EndReason;
 import Hampouch.server.domain.challenge.repository.ChallengeAdjustmentRepository;
 import Hampouch.server.domain.challenge.repository.ChallengeRepository;
 import Hampouch.server.domain.challenge.service.ChallengeService;
-import Hampouch.server.domain.rest.dto.RestStartRequest;
-import Hampouch.server.domain.rest.dto.RestStartResponse;
+import Hampouch.server.domain.rest.dto.*;
 import Hampouch.server.domain.rest.entity.UserRest;
 import Hampouch.server.domain.rest.repository.UserRestRepository;
 import Hampouch.server.domain.rest.service.UserRestService;
@@ -155,6 +154,33 @@ class ChallengeConcurrencyMySqlTest {
         assertThat(outcomes.first().succeeded()).isTrue();
         assertConflict(outcomes.second(), ChallengeErrorCode.CHALLENGE_ALREADY_IN_PROGRESS);
         assertThat(challengeRepository.findInProgress(user.getId())).isPresent();
+        assertThat(userRestRepository.findActiveOn(user.getId(), today)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("활성 휴식 중 챌린지 생성이 먼저 시작되고 휴식 연장이 겹치면 연장은 생성 커밋을 기다린 뒤 REST_NOT_ACTIVE로 끝나고 활성 휴식이 남지 않는다")
+    void keepsRestClosedWhenChallengeCreationPrecedesExtension() throws Exception {
+        User user = newUser("challenge-rest-extension");
+        LocalDate today = today();
+        UserRest rest = userRestRepository.saveAndFlush(UserRest.start(user.getId(), today, 7));
+
+        OrderedRace<CreateChallengeResponse, RestResumeResponse> outcomes = orderedRace(
+                () -> challengeService.create(user.getId(), createRequest(today, 70000)),
+                () -> userRestService.resume(
+                        user.getId(), new RestResumeRequest(ResumeWhen.EXTEND, 3)));
+
+        assertThat(outcomes.secondWasBlocked()).isTrue();
+        assertThat(outcomes.first().succeeded()).isTrue();
+        assertThat(outcomes.second().error()).isInstanceOfSatisfying(CustomException.class,
+                error -> {
+                    assertThat(error.getErrorCode()).isEqualTo(RestErrorCode.REST_NOT_ACTIVE);
+                    assertThat(error.getErrorCode().getHttpStatus().value()).isEqualTo(404);
+                });
+        Challenge active = challengeRepository.findInProgress(user.getId()).orElseThrow();
+        UserRest reloaded = userRestRepository.findById(rest.getId()).orElseThrow();
+        assertThat(active.getBudgetTotal()).isEqualTo(70000);
+        assertThat(reloaded.getActualResumeDate()).isEqualTo(today);
+        assertThat(reloaded.getPlannedResumeDate()).isEqualTo(today.plusDays(7));
         assertThat(userRestRepository.findActiveOn(user.getId(), today)).isEmpty();
     }
 

--- a/src/test/java/Hampouch/server/domain/challenge/ChallengeConcurrencyMySqlTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/ChallengeConcurrencyMySqlTest.java
@@ -1,0 +1,406 @@
+package Hampouch.server.domain.challenge;
+
+import Hampouch.server.domain.challenge.dto.*;
+import Hampouch.server.domain.challenge.entity.Challenge;
+import Hampouch.server.domain.challenge.entity.ChallengeAdjustment;
+import Hampouch.server.domain.challenge.entity.ChallengeStatus;
+import Hampouch.server.domain.challenge.entity.EndReason;
+import Hampouch.server.domain.challenge.repository.ChallengeAdjustmentRepository;
+import Hampouch.server.domain.challenge.repository.ChallengeRepository;
+import Hampouch.server.domain.challenge.service.ChallengeService;
+import Hampouch.server.domain.rest.dto.RestStartRequest;
+import Hampouch.server.domain.rest.dto.RestStartResponse;
+import Hampouch.server.domain.rest.entity.UserRest;
+import Hampouch.server.domain.rest.repository.UserRestRepository;
+import Hampouch.server.domain.rest.service.UserRestService;
+import Hampouch.server.domain.user.entity.User;
+import Hampouch.server.domain.user.repository.UserRepository;
+import Hampouch.server.domain.user.service.UserOperationLock;
+import Hampouch.server.global.common.exception.BaseErrorCode;
+import Hampouch.server.global.common.exception.CustomException;
+import Hampouch.server.global.common.exception.domain.ChallengeErrorCode;
+import Hampouch.server.global.common.exception.domain.RestErrorCode;
+import Hampouch.server.global.mysql.MySqlContainerTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@MySqlContainerTest
+@Import(ChallengeConcurrencyMySqlTest.PausingUserLockConfig.class)
+class ChallengeConcurrencyMySqlTest {
+
+    private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
+
+    @Autowired
+    ChallengeService challengeService;
+    @Autowired
+    UserRestService userRestService;
+    @Autowired
+    ChallengeRepository challengeRepository;
+    @Autowired
+    ChallengeAdjustmentRepository challengeAdjustmentRepository;
+    @Autowired
+    UserRestRepository userRestRepository;
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    PausingUserOperationLock pausingUserOperationLock;
+
+    @Test
+    @DisplayName("동일 사용자 진행 중 챌린지 UNIQUE는 실제 MySQL 동시 INSERT 중 하나를 거절한다")
+    void activeChallengeUniqueRejectsConcurrentInsert() throws Exception {
+        User user = newUser("challenge-unique");
+        LocalDate today = today();
+
+        List<Outcome<Challenge>> outcomes = race(
+                () -> challengeRepository.saveAndFlush(challengeOf(user.getId(), 7, today, 70000)),
+                () -> challengeRepository.saveAndFlush(challengeOf(user.getId(), 7, today, 84000)));
+
+        assertConstraintRace(outcomes);
+        assertThat(challengeRepository.findAll().stream()
+                .filter(challenge -> challenge.isOwnedBy(user.getId()) && challenge.isInProgress()))
+                .hasSize(1);
+    }
+
+    @Test
+    @DisplayName("동일 챌린지 조정 순번 UNIQUE는 실제 MySQL 동시 INSERT 중 하나를 거절한다")
+    void adjustmentSequenceUniqueRejectsConcurrentInsert() throws Exception {
+        User user = newUser("adjustment-unique");
+        Challenge challenge = newChallenge(user.getId(), 7, today(), 70000);
+
+        List<Outcome<ChallengeAdjustment>> outcomes = race(
+                () -> challengeAdjustmentRepository.saveAndFlush(adjustmentOf(challenge, 77000)),
+                () -> challengeAdjustmentRepository.saveAndFlush(adjustmentOf(challenge, 84000)));
+
+        assertConstraintRace(outcomes);
+        assertThat(challengeAdjustmentRepository.findByChallenge_IdOrderByEffectiveDateAscIdAsc(challenge.getId()))
+                .singleElement().satisfies(adjustment -> assertThat(adjustment.getSequenceNumber()).isEqualTo(1));
+    }
+
+    @Test
+    @DisplayName("동일 사용자 미복귀 휴식 UNIQUE는 실제 MySQL 동시 INSERT 중 하나를 거절한다")
+    void unresumedRestUniqueRejectsConcurrentInsert() throws Exception {
+        User user = newUser("rest-unique");
+        LocalDate today = today();
+
+        List<Outcome<UserRest>> outcomes = race(
+                () -> userRestRepository.saveAndFlush(UserRest.start(user.getId(), today, 7)),
+                () -> userRestRepository.saveAndFlush(UserRest.start(user.getId(), today, 14)));
+
+        assertConstraintRace(outcomes);
+        assertThat(userRestRepository.findAll().stream()
+                .filter(rest -> rest.getUserId().equals(user.getId()) && rest.isActiveOn(today)))
+                .hasSize(1);
+    }
+
+    @Test
+    @DisplayName("같은 유저의 챌린지 생성 두 건은 하나만 성공하고 다른 한 건은 409이며 진행 중 행은 하나다")
+    void serializesConcurrentChallengeCreation() throws Exception {
+        User user = newUser("create");
+        LocalDate today = today();
+
+        OrderedRace<CreateChallengeResponse, CreateChallengeResponse> outcomes = orderedRace(
+                () -> challengeService.create(user.getId(), createRequest(today, 70000)),
+                () -> challengeService.create(user.getId(), createRequest(today, 84000)));
+
+        assertThat(outcomes.secondWasBlocked()).isTrue();
+        assertThat(outcomes.first().succeeded()).isTrue();
+        assertConflict(outcomes.second(), ChallengeErrorCode.CHALLENGE_ALREADY_IN_PROGRESS);
+        Challenge active = challengeRepository.findInProgress(user.getId()).orElseThrow();
+        assertThat(active.getBudgetTotal()).isEqualTo(70000);
+    }
+
+    @Test
+    @DisplayName("같은 유저의 휴식 시작 두 건은 하나만 성공하고 다른 한 건은 409이며 활성 휴식은 하나다")
+    void serializesConcurrentRestStart() throws Exception {
+        User user = newUser("rest");
+
+        OrderedRace<RestStartResponse, RestStartResponse> outcomes = orderedRace(
+                () -> userRestService.start(user.getId(), new RestStartRequest(7)),
+                () -> userRestService.start(user.getId(), new RestStartRequest(14)));
+
+        assertThat(outcomes.secondWasBlocked()).isTrue();
+        assertThat(outcomes.first().succeeded()).isTrue();
+        assertConflict(outcomes.second(), RestErrorCode.REST_ALREADY_ACTIVE);
+        assertThat(userRestRepository.findActiveOn(user.getId(), today())).isPresent();
+    }
+
+    @Test
+    @DisplayName("챌린지 생성과 휴식 시작이 겹쳐도 진행 중 챌린지와 활성 휴식은 공존하지 않는다")
+    void keepsChallengeAndRestMutuallyExclusive() throws Exception {
+        User user = newUser("challenge-rest");
+        LocalDate today = today();
+
+        OrderedRace<CreateChallengeResponse, RestStartResponse> outcomes = orderedRace(
+                () -> challengeService.create(user.getId(), createRequest(today, 70000)),
+                () -> userRestService.start(user.getId(), new RestStartRequest(7)));
+
+        assertThat(outcomes.secondWasBlocked()).isTrue();
+        assertThat(outcomes.first().succeeded()).isTrue();
+        assertConflict(outcomes.second(), ChallengeErrorCode.CHALLENGE_ALREADY_IN_PROGRESS);
+        assertThat(challengeRepository.findInProgress(user.getId())).isPresent();
+        assertThat(userRestRepository.findActiveOn(user.getId(), today)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("같은 챌린지의 마지막 목표 조정 두 건은 하나만 성공하고 예산과 이력은 같은 결과를 가리킨다")
+    void serializesConcurrentGoalAdjustment() throws Exception {
+        User user = newUser("adjust");
+        Challenge challenge = newChallenge(user.getId(), 7, today(), 70000);
+
+        OrderedRace<AdjustGoalResponse, AdjustGoalResponse> outcomes = orderedRace(
+                () -> challengeService.adjustGoal(user.getId(), challenge.getId(), new AdjustGoalRequest(null, 77000)),
+                () -> challengeService.adjustGoal(user.getId(), challenge.getId(), new AdjustGoalRequest(null, 84000)));
+
+        assertThat(outcomes.secondWasBlocked()).isTrue();
+        assertThat(outcomes.first().succeeded()).isTrue();
+        assertConflict(outcomes.second(), ChallengeErrorCode.ADJUSTMENT_LIMIT_EXCEEDED);
+        Challenge reloaded = challengeRepository.findById(challenge.getId()).orElseThrow();
+        List<ChallengeAdjustment> adjustments = challengeAdjustmentRepository
+                .findByChallenge_IdOrderByEffectiveDateAscIdAsc(challenge.getId());
+        assertThat(adjustments).singleElement().satisfies(adjustment -> {
+            assertThat(adjustment.getSequenceNumber()).isEqualTo(1);
+            assertThat(reloaded.getBudgetTotal()).isEqualTo(adjustment.getNewBudgetTotal());
+            assertThat(reloaded.getDailyLimit()).isEqualTo(adjustment.getNewDailyLimit());
+        });
+    }
+
+    @Test
+    @DisplayName("목표 조정과 포기가 겹치면 포기 상태가 유지되고 조정 이력과 최종 예산은 한 직렬 순서로 일치한다")
+    void serializesGoalAdjustmentAndGiveUp() throws Exception {
+        User user = newUser("adjust-give-up");
+        Challenge challenge = newChallenge(user.getId(), 7, today(), 70000);
+
+        OrderedRace<AdjustGoalResponse, GiveUpResponse> outcomes = orderedRace(
+                () -> challengeService.adjustGoal(user.getId(), challenge.getId(), new AdjustGoalRequest(null, 84000)),
+                () -> challengeService.giveUp(user.getId(), challenge.getId()));
+
+        assertThat(outcomes.secondWasBlocked()).isTrue();
+        assertThat(outcomes.first().succeeded()).isTrue();
+        assertThat(outcomes.second().succeeded()).isTrue();
+        Challenge reloaded = challengeRepository.findById(challenge.getId()).orElseThrow();
+        List<ChallengeAdjustment> adjustments = challengeAdjustmentRepository
+                .findByChallenge_IdOrderByEffectiveDateAscIdAsc(challenge.getId());
+        assertThat(reloaded.getStatus()).isEqualTo(ChallengeStatus.FAIL);
+        assertThat(reloaded.getEndReason()).isEqualTo(EndReason.GIVEN_UP);
+        assertThat(adjustments).singleElement().satisfies(adjustment -> {
+            assertThat(reloaded.getBudgetTotal()).isEqualTo(adjustment.getNewBudgetTotal());
+            assertThat(reloaded.getDailyLimit()).isEqualTo(adjustment.getNewDailyLimit());
+        });
+    }
+
+    @Test
+    @DisplayName("결과 확정이 사용자 락을 먼저 잡으면 최종 종료는 그 커밋 후 확정된 상태를 닫는다")
+    void serializesResultFinalizationAndClose() throws Exception {
+        User user = newUser("result-close");
+        LocalDate today = today();
+        Challenge challenge = newChallenge(user.getId(), 7, today.minusDays(7), 70000);
+
+        OrderedRace<ResultResponse, CloseResponse> outcomes = orderedRace(
+                () -> challengeService.getResult(user.getId(), challenge.getId()),
+                () -> challengeService.close(user.getId(), challenge.getId()));
+
+        assertThat(outcomes.secondWasBlocked()).isTrue();
+        assertThat(outcomes.first().succeeded()).isTrue();
+        assertThat(outcomes.second().succeeded()).isTrue();
+        Challenge reloaded = challengeRepository.findById(challenge.getId()).orElseThrow();
+        assertThat(reloaded.getStatus()).isEqualTo(ChallengeStatus.SUCCESS);
+        assertThat(reloaded.isClosed()).isTrue();
+    }
+
+    private CreateChallengeRequest createRequest(LocalDate startDate, int budgetTotal) {
+        return new CreateChallengeRequest(7, budgetTotal, startDate, false, null, List.of("카페"));
+    }
+
+    private Challenge newChallenge(Long userId, int durationDays, LocalDate startDate, int budgetTotal) {
+        return challengeRepository.save(challengeOf(userId, durationDays, startDate, budgetTotal));
+    }
+
+    private Challenge challengeOf(Long userId, int durationDays, LocalDate startDate, int budgetTotal) {
+        return Challenge.builder()
+                .userId(userId)
+                .durationDays(durationDays)
+                .startDate(startDate)
+                .budgetTotal(budgetTotal)
+                .dailyLimit(budgetTotal / durationDays)
+                .build();
+    }
+
+    private ChallengeAdjustment adjustmentOf(Challenge challenge, int newBudgetTotal) {
+        return ChallengeAdjustment.builder()
+                .challenge(challenge)
+                .sequenceNumber(1)
+                .effectiveDate(today())
+                .previousBudgetTotal(70000)
+                .newBudgetTotal(newBudgetTotal)
+                .previousDailyLimit(10000)
+                .newDailyLimit(newBudgetTotal / 7)
+                .build();
+    }
+
+    private User newUser(String scenario) {
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        return userRepository.save(User.createLocalUser(
+                scenario + "-" + suffix + "@hampouch.test", "encoded", "동시성" + suffix));
+    }
+
+    private LocalDate today() {
+        return LocalDate.now(SEOUL);
+    }
+
+    private <T> List<Outcome<T>> race(Callable<? extends T> first, Callable<? extends T> second) throws Exception {
+        CyclicBarrier barrier = new CyclicBarrier(2);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<Outcome<T>> firstFuture = executor.submit(() -> runAfterBarrier(barrier, first));
+            Future<Outcome<T>> secondFuture = executor.submit(() -> runAfterBarrier(barrier, second));
+            return List.of(firstFuture.get(15, TimeUnit.SECONDS), secondFuture.get(15, TimeUnit.SECONDS));
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private <T> Outcome<T> runAfterBarrier(CyclicBarrier barrier, Callable<? extends T> request) {
+        try {
+            barrier.await(5, TimeUnit.SECONDS);
+            return new Outcome<>(request.call(), null);
+        } catch (Throwable error) {
+            return new Outcome<>(null, error);
+        }
+    }
+
+    private <T> Outcome<T> capture(Callable<? extends T> request) {
+        try {
+            return new Outcome<>(request.call(), null);
+        } catch (Throwable error) {
+            return new Outcome<>(null, error);
+        }
+    }
+
+    private <F, S> OrderedRace<F, S> orderedRace(
+            Callable<? extends F> first, Callable<? extends S> second) throws Exception {
+        pausingUserOperationLock.pauseNextLock();
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch secondStarted = new CountDownLatch(1);
+        try {
+            Future<Outcome<F>> firstFuture = executor.submit(() -> capture(first));
+            assertThat(pausingUserOperationLock.awaitLock()).isTrue();
+            Future<Outcome<S>> secondFuture = executor.submit(() -> {
+                secondStarted.countDown();
+                return capture(second);
+            });
+            assertThat(secondStarted.await(5, TimeUnit.SECONDS)).isTrue();
+            boolean secondWasBlocked;
+            try {
+                secondFuture.get(500, TimeUnit.MILLISECONDS);
+                secondWasBlocked = false;
+            } catch (TimeoutException expected) {
+                secondWasBlocked = true;
+            } finally {
+                pausingUserOperationLock.release();
+            }
+            return new OrderedRace<>(
+                    firstFuture.get(15, TimeUnit.SECONDS),
+                    secondFuture.get(15, TimeUnit.SECONDS),
+                    secondWasBlocked);
+        } finally {
+            pausingUserOperationLock.release();
+            executor.shutdownNow();
+        }
+    }
+
+    private Outcome<?> singleFailure(List<? extends Outcome<?>> outcomes) {
+        return outcomes.stream().filter(outcome -> !outcome.succeeded()).findFirst().orElseThrow();
+    }
+
+    private void assertConflict(Outcome<?> outcome, BaseErrorCode expected) {
+        assertThat(outcome.error()).isInstanceOfSatisfying(CustomException.class,
+                error -> {
+                    assertThat(error.getErrorCode()).isEqualTo(expected);
+                    assertThat(error.getErrorCode().getHttpStatus().value()).isEqualTo(409);
+                });
+    }
+
+    private void assertConstraintRace(List<? extends Outcome<?>> outcomes) {
+        assertThat(outcomes.stream().filter(Outcome::succeeded).count()).isEqualTo(1);
+        assertThat(singleFailure(outcomes).error()).isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class PausingUserLockConfig {
+
+        @Bean
+        @Primary
+        PausingUserOperationLock pausingUserOperationLock(UserRepository userRepository) {
+            return new PausingUserOperationLock(userRepository);
+        }
+    }
+
+    static class PausingUserOperationLock extends UserOperationLock {
+
+        private final AtomicBoolean pauseNext = new AtomicBoolean();
+        private volatile CountDownLatch locked = new CountDownLatch(0);
+        private volatile CountDownLatch release = new CountDownLatch(0);
+
+        PausingUserOperationLock(UserRepository userRepository) {
+            super(userRepository);
+        }
+
+        public synchronized void pauseNextLock() {
+            locked = new CountDownLatch(1);
+            release = new CountDownLatch(1);
+            pauseNext.set(true);
+        }
+
+        public boolean awaitLock() throws InterruptedException {
+            return locked.await(10, TimeUnit.SECONDS);
+        }
+
+        public void release() {
+            release.countDown();
+        }
+
+        @Override
+        @Transactional(propagation = Propagation.MANDATORY)
+        public void lock(Long userId) {
+            super.lock(userId);
+            if (!pauseNext.compareAndSet(true, false)) {
+                return;
+            }
+            locked.countDown();
+            try {
+                if (!release.await(10, TimeUnit.SECONDS)) {
+                    throw new IllegalStateException("사용자 잠금 일시정지가 제한 시간 안에 해제되지 않았습니다.");
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("사용자 잠금 일시정지가 중단됐습니다.", e);
+            }
+        }
+    }
+
+    private record OrderedRace<F, S>(Outcome<F> first, Outcome<S> second, boolean secondWasBlocked) {
+    }
+
+    private record Outcome<T>(T value, Throwable error) {
+        boolean succeeded() {
+            return error == null;
+        }
+    }
+}

--- a/src/test/java/Hampouch/server/domain/challenge/ChallengeConcurrencyMySqlTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/ChallengeConcurrencyMySqlTest.java
@@ -8,6 +8,12 @@ import Hampouch.server.domain.challenge.entity.EndReason;
 import Hampouch.server.domain.challenge.repository.ChallengeAdjustmentRepository;
 import Hampouch.server.domain.challenge.repository.ChallengeRepository;
 import Hampouch.server.domain.challenge.service.ChallengeService;
+import Hampouch.server.domain.expense.dto.ExpenseUpdateRequest;
+import Hampouch.server.domain.expense.entity.Expense;
+import Hampouch.server.domain.expense.entity.ExpenseCategory;
+import Hampouch.server.domain.expense.entity.ExpenseEmotion;
+import Hampouch.server.domain.expense.repository.ExpenseRepository;
+import Hampouch.server.domain.expense.service.ExpenseService;
 import Hampouch.server.domain.rest.dto.*;
 import Hampouch.server.domain.rest.entity.UserRest;
 import Hampouch.server.domain.rest.repository.UserRestRepository;
@@ -51,11 +57,15 @@ class ChallengeConcurrencyMySqlTest {
     @Autowired
     UserRestService userRestService;
     @Autowired
+    ExpenseService expenseService;
+    @Autowired
     ChallengeRepository challengeRepository;
     @Autowired
     ChallengeAdjustmentRepository challengeAdjustmentRepository;
     @Autowired
     UserRestRepository userRestRepository;
+    @Autowired
+    ExpenseRepository expenseRepository;
     @Autowired
     UserRepository userRepository;
     @Autowired
@@ -250,8 +260,37 @@ class ChallengeConcurrencyMySqlTest {
         assertThat(reloaded.isClosed()).isTrue();
     }
 
+    @Test
+    @DisplayName("지출 수정과 최종 종료는 사용자 행부터 잠가 교착 없이 한 순서로 완료된다")
+    void serializesExpenseUpdateAndCloseWithoutDeadlock() throws Exception {
+        User user = newUser("expense-close");
+        LocalDate today = today();
+        LocalDate expenseDate = today.minusDays(3);
+        Expense expense = expenseRepository.save(Expense.of(
+                "점심", 8000, ExpenseCategory.CAFE, ExpenseEmotion.STRESS, expenseDate, user));
+        Challenge challenge = newChallenge(user.getId(), 7, today.minusDays(7), 70000);
+        challenge.applyResult(ChallengeStatus.SUCCESS);
+        challengeRepository.save(challenge);
+
+        OrderedRace<?, CloseResponse> outcomes = orderedRace(
+                () -> expenseService.update(user.getId(), expense.getId(), expenseUpdateRequest(expenseDate)),
+                () -> challengeService.close(user.getId(), challenge.getId()));
+
+        assertThat(outcomes.secondWasBlocked()).isTrue();
+        assertThat(outcomes.first().succeeded()).isTrue();
+        assertThat(outcomes.second().succeeded()).isTrue();
+        assertThat(expenseRepository.findById(expense.getId()).orElseThrow().getPrice()).isEqualTo(99000);
+        assertThat(challengeRepository.findById(challenge.getId()).orElseThrow().isClosed()).isTrue();
+    }
+
     private CreateChallengeRequest createRequest(LocalDate startDate, int budgetTotal) {
         return new CreateChallengeRequest(7, budgetTotal, startDate, false, null, List.of("카페"));
+    }
+
+    private ExpenseUpdateRequest expenseUpdateRequest(LocalDate date) {
+        return new ExpenseUpdateRequest(
+                "저녁", 99000, ExpenseCategory.CAFE, null,
+                ExpenseEmotion.STRESS, null, date, null);
     }
 
     private Challenge newChallenge(Long userId, int durationDays, LocalDate startDate, int budgetTotal) {

--- a/src/test/java/Hampouch/server/domain/challenge/ChallengeFlowIntegrationTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/ChallengeFlowIntegrationTest.java
@@ -3,7 +3,9 @@ package Hampouch.server.domain.challenge;
 import Hampouch.server.domain.challenge.entity.*;
 import Hampouch.server.domain.challenge.repository.ChallengeDayRepository;
 import Hampouch.server.domain.challenge.repository.ChallengeRepository;
+import Hampouch.server.domain.user.entity.User;
 import Hampouch.server.domain.user.entity.UserRole;
+import Hampouch.server.domain.user.repository.UserRepository;
 import Hampouch.server.global.jwt.JwtProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,6 +20,7 @@ import tools.jackson.databind.ObjectMapper;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.contains;
@@ -41,6 +44,8 @@ class ChallengeFlowIntegrationTest {
     ChallengeRepository challengeRepository;
     @Autowired
     ChallengeDayRepository challengeDayRepository;
+    @Autowired
+    UserRepository userRepository;
     // 집중 카테고리는 리포지토리도 조회 API도 없어 저장된 행을 직접 읽는다
     @Autowired
     JdbcTemplate jdbc;
@@ -50,6 +55,13 @@ class ChallengeFlowIntegrationTest {
     /** 실제 서명이 붙은 액세스 토큰의 Authorization 헤더 값 — 로그인 API를 거치지 않고 발급만 빌려 쓴다. */
     private String bearer(Long userId) {
         return "Bearer " + jwtProvider.createAccessToken(userId, UserRole.USER);
+    }
+
+    private Long newUser() {
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        User user = User.createLocalUser(
+                "challenge-flow-" + suffix + "@hampouch.test", "encoded", "챌린지" + suffix);
+        return userRepository.save(user).getId();
     }
 
     @Test
@@ -78,7 +90,7 @@ class ChallengeFlowIntegrationTest {
     @Test
     @DisplayName("목표 금액을 조정하면 목표와 앞으로의 하루 한도가 함께 오르고 이미 초과로 판정된 지난 날의 기록은 그대로 남는다")
     void adjustRaisesLimitWithoutRewritingPastDays() throws Exception {
-        long user = 7701L;
+        long user = newUser();
         LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
         // 지난 날이 있어야 소급 여부를 볼 수 있어 시작일이 과거인 챌린지를 직접 넣는다(생성 API는 @FutureOrPresent라 과거 시작을 막는다)
         Challenge ch = challengeRepository.save(Challenge.builder()
@@ -116,6 +128,7 @@ class ChallengeFlowIntegrationTest {
     @Test
     @DisplayName("생성부터 일별 입력(성공·초과), 현황, 캘린더 조회까지 전체 흐름이 실제 스택으로 끝까지 동작한다")
     void fullFlow() throws Exception {
+        Long user = newUser();
         // 서버의 "오늘"은 ClockConfig(Asia/Seoul) 기준 — 머신 시간대(CI는 UTC)로 만들면 KST 새벽(00~09시)에
         // 두 날짜가 갈라져, 아래 3)의 "내일 기록은 집계 미포함" 전제가 깨진다(내일이 서버의 오늘이 됨). 미니 통합과 동일 처리.
         LocalDate start = LocalDate.now(ZoneId.of("Asia/Seoul")); // @FutureOrPresent 통과
@@ -123,7 +136,7 @@ class ChallengeFlowIntegrationTest {
 
         // 1) 생성: 7일 / 70,000 → dailyLimit 10,000
         String created = mvc.perform(post("/api/challenges")
-                        .header("Authorization", bearer(1L))
+                        .header("Authorization", bearer(user))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"durationDays\":7,\"budgetTotal\":70000,\"startDate\":\"" + start
                                 + "\",\"weakCategories\":[\"카페음료\"]}"))
@@ -136,14 +149,14 @@ class ChallengeFlowIntegrationTest {
 
         // 2) 일별 입력: 성공 1일(8,000) + 초과 1일(15,000)
         mvc.perform(post("/api/challenges/" + id + "/days")
-                        .header("Authorization", bearer(1L))
+                        .header("Authorization", bearer(user))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"date\":\"" + start + "\",\"spentAmount\":8000}"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.status").value("SUCCESS"))
                 .andExpect(jsonPath("$.data.dailyLimit").value(10000));
         mvc.perform(post("/api/challenges/" + id + "/days")
-                        .header("Authorization", bearer(1L))
+                        .header("Authorization", bearer(user))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"date\":\"" + day2 + "\",\"spentAmount\":15000}"))
                 .andExpect(status().isOk())
@@ -151,7 +164,7 @@ class ChallengeFlowIntegrationTest {
 
         // 3) 현황: 응답 형태 {code, message, data:{challenge, progress, ...}} + 집계.
         //    홈 집계는 판정 완료 구간(시작~오늘)까지만(0714 확정) — 내일(day2)의 초과 기록은 아직 미포함.
-        mvc.perform(get("/api/challenges/current").header("Authorization", bearer(1L)))
+        mvc.perform(get("/api/challenges/current").header("Authorization", bearer(user)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.challenge.dailyLimit").value(10000))
                 .andExpect(jsonPath("$.data.challenge.status").value("IN_PROGRESS"))
@@ -161,7 +174,7 @@ class ChallengeFlowIntegrationTest {
 
         // 4) 캘린더: 이번 달에 시작일 기록(SUCCESS) 포함
         mvc.perform(get("/api/challenges/" + id + "/calendar")
-                        .header("Authorization", bearer(1L))
+                        .header("Authorization", bearer(user))
                         .param("year", String.valueOf(start.getYear()))
                         .param("month", String.valueOf(start.getMonthValue())))
                 .andExpect(status().isOk())
@@ -171,7 +184,7 @@ class ChallengeFlowIntegrationTest {
     @Test
     @DisplayName("기간이 끝난 챌린지는 최종 종료를 누르기 전까지 일별 기록을 고칠 수 있고, 누르는 순간 성패가 확정되며 그 뒤의 기록 수정과 재종료는 409로 막힌다")
     void closeFinalizesResultAndLocksRecords() throws Exception {
-        long user = 50_001L;
+        long user = newUser();
         LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
         // 기간이 끝난 챌린지는 생성 API로 못 만든다(통합 테스트는 시계를 못 돌림) → 어제 끝난 챌린지를 직접 심는다
         Challenge ch = challengeRepository.save(Challenge.builder()
@@ -226,7 +239,7 @@ class ChallengeFlowIntegrationTest {
     @Test
     @DisplayName("현재 챌린지 조회가 3일 연속 미입력을 감지하면 요청 종료 후 DB에도 자동 취소 상태가 남는다")
     void currentAutoCancelCommitsAfterRequest() throws Exception {
-        Long user = 67_001L;
+        Long user = newUser();
         LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
         Challenge challenge = challengeRepository.save(Challenge.builder()
                 .userId(user)
@@ -250,8 +263,7 @@ class ChallengeFlowIntegrationTest {
     @DisplayName("지난 챌린지 리스트가 실제 스택에서 종료된 것만 최근 종료 순으로 집계와 함께 내려오고, 만료 후 미확정 챌린지도 조회 시점에 확정돼 실린다")
     void historyFlow() throws Exception {
         // 종료된 챌린지는 API로 못 만든다(기간 경과가 필요한데 통합 테스트는 시계를 못 돌림) → 리포지토리로 직접 심는다.
-        // fullFlow(유저 1)와 데이터가 안 섞이게 전용 유저(4) 사용 — 미니 통합 테스트와 같은 관례.
-        Long user = 4L;
+        Long user = newUser();
 
         // 5/1~5/14 SUCCESS 종료, 기록 0건 → actualSpent 0, savedAmount = 14일 × 20000 전액
         Challenge success = challengeRepository.save(Challenge.builder()
@@ -298,8 +310,7 @@ class ChallengeFlowIntegrationTest {
     @Test
     @DisplayName("집중 카테고리를 교체하면 저장돼 있던 카테고리 행이 실제로 지워지고 요청에 담아 보낸 카테고리만 행으로 남으며, 교체 전후에 겹치는 카테고리가 있어도 같은 챌린지에 같은 카테고리 두 줄을 막는 제약에 걸리지 않는다")
     void focusCategoriesFlow() throws Exception {
-        // 앞의 세 테스트(유저 1·4·5)와 데이터가 안 섞이게 전용 유저 사용
-        Long user = 6L;
+        Long user = newUser();
         LocalDate start = LocalDate.now(ZoneId.of("Asia/Seoul")); // 위 테스트들과 동일 처리(서버의 "오늘" = Asia/Seoul)
 
         // 1) 온보딩에서 고른 집중 카테고리 2개로 생성
@@ -363,8 +374,7 @@ class ChallengeFlowIntegrationTest {
     @Test
     @DisplayName("진행 중 챌린지를 포기하면 즉시 FAIL로 확정돼 홈에서 사라지고 결과 조회가 열리며, 이후 지출을 고쳐도 SUCCESS로 되살아나지 않는다")
     void giveUpFlow() throws Exception {
-        // fullFlow(유저 1)·historyFlow(유저 4)와 데이터가 안 섞이게 전용 유저 사용
-        Long user = 5L;
+        Long user = newUser();
         // 서버의 "오늘"은 ClockConfig(Asia/Seoul) 기준 — 머신 시간대(CI는 UTC)로 만들면 KST 새벽(00~09시)에
         // 두 날짜가 갈라져 @FutureOrPresent·기간 검증이 흔들린다. 미니 통합 테스트와 동일 처리.
         LocalDate start = LocalDate.now(ZoneId.of("Asia/Seoul"));
@@ -420,7 +430,7 @@ class ChallengeFlowIntegrationTest {
     @Test
     @DisplayName("만료 챌린지의 결과 조회가 총지출이 목표를 넘으면 FAIL로, 넘지 않으면 SUCCESS로 확정하고 그 상태가 요청 종료 후 새 DB 조회에서도 남아 있다")
     void resultFinalizationCommitsAfterRequest() throws Exception {
-        Long user = 83_001L;
+        Long user = newUser();
 
         // 6/1~6/7 목표 70,000 — 6/3 하루 80,000 지출로 총지출이 목표를 넘어 FAIL감
         Challenge fail = challengeRepository.save(Challenge.builder()
@@ -450,7 +460,7 @@ class ChallengeFlowIntegrationTest {
     @Test
     @DisplayName("같은 날짜로 일별 지출을 다시 보내면 새 행 없이 기존 기록이 고쳐지고, 바뀐 금액과 판정이 요청 종료 후 새 DB 조회에서도 남아 있다")
     void upsertDayUpdateCommitsAfterRequest() throws Exception {
-        Long user = 83_002L;
+        Long user = newUser();
         LocalDate start = LocalDate.now(ZoneId.of("Asia/Seoul")); // 서버의 "오늘"(Asia/Seoul) — 위 테스트들과 동일 처리
 
         String created = mvc.perform(post("/api/challenges")
@@ -486,7 +496,7 @@ class ChallengeFlowIntegrationTest {
     @Test
     @DisplayName("만료로 FAIL 확정된 챌린지의 지출을 고쳐 총지출이 목표 안으로 들어오면 결과가 SUCCESS로 재계산되고, 그 재계산이 요청 종료 후 새 DB 조회에서도 남아 있다")
     void dayEditRecalculationCommitsAfterRequest() throws Exception {
-        Long user = 83_003L;
+        Long user = newUser();
         LocalDate overDay = LocalDate.of(2026, 6, 3);
 
         // 6/1~6/7 목표 70,000에 6/3 80,000 지출 → 만료 FAIL로 확정된 상태를 심는다.

--- a/src/test/java/Hampouch/server/domain/challenge/service/ChallengeServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/service/ChallengeServiceTest.java
@@ -12,6 +12,7 @@ import Hampouch.server.domain.expense.service.ExpenseSpendingQuery;
 import Hampouch.server.domain.expense.service.PeriodSpending;
 import Hampouch.server.domain.rest.entity.UserRest;
 import Hampouch.server.domain.rest.repository.UserRestRepository;
+import Hampouch.server.domain.user.service.UserOperationLock;
 import Hampouch.server.global.common.exception.CustomException;
 import Hampouch.server.global.common.exception.domain.ChallengeErrorCode;
 import Hampouch.server.global.common.exception.domain.CommonErrorCode;
@@ -58,6 +59,8 @@ class ChallengeServiceTest {
     UserRestRepository userRestRepository; // 휴식(#8) 연동분 — 목이 기본으로 빈 Optional을 돌려줘 기존 시나리오(휴식 없음)는 스텁 없이 그대로 통과
     @Mock
     ChallengeAdjustmentRepository challengeAdjustmentRepository; // 조정(#7) — 목 기본값이 count 0·빈 리스트라 조정 없는 시나리오는 스텁 없이 통과
+    @Mock
+    UserOperationLock userOperationLock;
 
     @BeforeEach
     void defaultExpenseInput() {
@@ -71,7 +74,8 @@ class ChallengeServiceTest {
     private ChallengeService serviceAt(LocalDate today) {
         Clock clock = Clock.fixed(today.atTime(12, 0).atZone(SEOUL).toInstant(), SEOUL);
         return new ChallengeService(challengeRepository, challengeDayRepository,
-                expenseService, expenseSpendingQuery, challengeAdjustmentRepository, userRestRepository, clock);
+                expenseService, expenseSpendingQuery, challengeAdjustmentRepository, userRestRepository,
+                userOperationLock, clock);
     }
 
     @Test

--- a/src/test/java/Hampouch/server/domain/expense/ExpenseTransactionIntegrationTest.java
+++ b/src/test/java/Hampouch/server/domain/expense/ExpenseTransactionIntegrationTest.java
@@ -17,14 +17,15 @@ import Hampouch.server.domain.user.entity.User;
 import Hampouch.server.domain.user.repository.UserRepository;
 import Hampouch.server.global.common.exception.CustomException;
 import Hampouch.server.global.common.exception.domain.ExpenseErrorCode;
+import Hampouch.server.global.mysql.MySqlContainerTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -34,7 +35,7 @@ import java.util.concurrent.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@SpringBootTest
+@MySqlContainerTest
 @Import(ExpenseTransactionIntegrationTest.PausingLockQueryConfig.class)
 class ExpenseTransactionIntegrationTest {
 
@@ -52,6 +53,8 @@ class ExpenseTransactionIntegrationTest {
     ChallengeRepository challengeRepository;
     @Autowired
     PausingExpenseDateLockQuery pausingExpenseDateLockQuery;
+    @Autowired
+    TransactionTemplate transactionTemplate;
 
     @Test
     @DisplayName("무지출 기록과 지출 생성·수정·삭제가 끝날 때마다 DB를 다시 조회해도 행 상태와 마지막 기록일이 유지된다")
@@ -159,6 +162,55 @@ class ExpenseTransactionIntegrationTest {
             assertThat(closeWasBlocked).isTrue();
             assertThat(expenseRepository.findById(expense.getId()).orElseThrow().getPrice()).isEqualTo(99000);
             assertThat(challengeRepository.findById(challenge.getId()).orElseThrow().isClosed()).isTrue();
+        } finally {
+            pausingExpenseDateLockQuery.release();
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    @DisplayName("지출 변경이 잡은 챌린지 행 잠금은 실제 MySQL에서 같은 행의 FOR UPDATE를 트랜잭션 종료까지 기다리게 한다")
+    void mysqlChallengeRowLockBlocksCompetingTransaction() throws Exception {
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        LocalDate expenseDate = today.minusDays(3);
+        User user = userRepository.save(User.createLocalUser(
+                "expense-mysql-row-lock@hampouch.test", "encoded", "MySQL행잠금"));
+        Long userId = user.getId();
+        Expense expense = expenseRepository.save(Expense.of(
+                "점심", 8000, ExpenseCategory.CAFE, ExpenseEmotion.STRESS, expenseDate, user));
+        Challenge challenge = Challenge.builder()
+                .userId(userId).durationDays(7).startDate(today.minusDays(7))
+                .budgetTotal(70000).dailyLimit(10000).build();
+        challenge.applyResult(ChallengeStatus.SUCCESS);
+        challengeRepository.save(challenge);
+
+        pausingExpenseDateLockQuery.pauseNextCheck();
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<?> updateFuture = executor.submit(() ->
+                    expenseService.update(userId, expense.getId(), updateRequest("저녁", 99000, expenseDate)));
+            assertThat(pausingExpenseDateLockQuery.awaitCheck()).isTrue();
+
+            CountDownLatch contenderStarted = new CountDownLatch(1);
+            Future<?> contender = executor.submit(() -> transactionTemplate.executeWithoutResult(status -> {
+                contenderStarted.countDown();
+                challengeRepository.findByIdForUpdate(challenge.getId()).orElseThrow();
+            }));
+            assertThat(contenderStarted.await(5, TimeUnit.SECONDS)).isTrue();
+            boolean contenderWasBlocked;
+            try {
+                contender.get(500, TimeUnit.MILLISECONDS);
+                contenderWasBlocked = false;
+            } catch (TimeoutException expected) {
+                contenderWasBlocked = true;
+            } finally {
+                pausingExpenseDateLockQuery.release();
+            }
+
+            updateFuture.get(5, TimeUnit.SECONDS);
+            contender.get(5, TimeUnit.SECONDS);
+            assertThat(contenderWasBlocked).isTrue();
+            assertThat(expenseRepository.findById(expense.getId()).orElseThrow().getPrice()).isEqualTo(99000);
         } finally {
             pausingExpenseDateLockQuery.release();
             executor.shutdownNow();

--- a/src/test/java/Hampouch/server/domain/expense/ExpenseTransactionIntegrationTest.java
+++ b/src/test/java/Hampouch/server/domain/expense/ExpenseTransactionIntegrationTest.java
@@ -17,15 +17,14 @@ import Hampouch.server.domain.user.entity.User;
 import Hampouch.server.domain.user.repository.UserRepository;
 import Hampouch.server.global.common.exception.CustomException;
 import Hampouch.server.global.common.exception.domain.ExpenseErrorCode;
-import Hampouch.server.global.mysql.MySqlContainerTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
-import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -35,7 +34,7 @@ import java.util.concurrent.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@MySqlContainerTest
+@SpringBootTest
 @Import(ExpenseTransactionIntegrationTest.PausingLockQueryConfig.class)
 class ExpenseTransactionIntegrationTest {
 
@@ -53,8 +52,6 @@ class ExpenseTransactionIntegrationTest {
     ChallengeRepository challengeRepository;
     @Autowired
     PausingExpenseDateLockQuery pausingExpenseDateLockQuery;
-    @Autowired
-    TransactionTemplate transactionTemplate;
 
     @Test
     @DisplayName("무지출 기록과 지출 생성·수정·삭제가 끝날 때마다 DB를 다시 조회해도 행 상태와 마지막 기록일이 유지된다")
@@ -162,55 +159,6 @@ class ExpenseTransactionIntegrationTest {
             assertThat(closeWasBlocked).isTrue();
             assertThat(expenseRepository.findById(expense.getId()).orElseThrow().getPrice()).isEqualTo(99000);
             assertThat(challengeRepository.findById(challenge.getId()).orElseThrow().isClosed()).isTrue();
-        } finally {
-            pausingExpenseDateLockQuery.release();
-            executor.shutdownNow();
-        }
-    }
-
-    @Test
-    @DisplayName("지출 변경이 잡은 챌린지 행 잠금은 실제 MySQL에서 같은 행의 FOR UPDATE를 트랜잭션 종료까지 기다리게 한다")
-    void mysqlChallengeRowLockBlocksCompetingTransaction() throws Exception {
-        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
-        LocalDate expenseDate = today.minusDays(3);
-        User user = userRepository.save(User.createLocalUser(
-                "expense-mysql-row-lock@hampouch.test", "encoded", "MySQL행잠금"));
-        Long userId = user.getId();
-        Expense expense = expenseRepository.save(Expense.of(
-                "점심", 8000, ExpenseCategory.CAFE, ExpenseEmotion.STRESS, expenseDate, user));
-        Challenge challenge = Challenge.builder()
-                .userId(userId).durationDays(7).startDate(today.minusDays(7))
-                .budgetTotal(70000).dailyLimit(10000).build();
-        challenge.applyResult(ChallengeStatus.SUCCESS);
-        challengeRepository.save(challenge);
-
-        pausingExpenseDateLockQuery.pauseNextCheck();
-        ExecutorService executor = Executors.newFixedThreadPool(2);
-        try {
-            Future<?> updateFuture = executor.submit(() ->
-                    expenseService.update(userId, expense.getId(), updateRequest("저녁", 99000, expenseDate)));
-            assertThat(pausingExpenseDateLockQuery.awaitCheck()).isTrue();
-
-            CountDownLatch contenderStarted = new CountDownLatch(1);
-            Future<?> contender = executor.submit(() -> transactionTemplate.executeWithoutResult(status -> {
-                contenderStarted.countDown();
-                challengeRepository.findByIdForUpdate(challenge.getId()).orElseThrow();
-            }));
-            assertThat(contenderStarted.await(5, TimeUnit.SECONDS)).isTrue();
-            boolean contenderWasBlocked;
-            try {
-                contender.get(500, TimeUnit.MILLISECONDS);
-                contenderWasBlocked = false;
-            } catch (TimeoutException expected) {
-                contenderWasBlocked = true;
-            } finally {
-                pausingExpenseDateLockQuery.release();
-            }
-
-            updateFuture.get(5, TimeUnit.SECONDS);
-            contender.get(5, TimeUnit.SECONDS);
-            assertThat(contenderWasBlocked).isTrue();
-            assertThat(expenseRepository.findById(expense.getId()).orElseThrow().getPrice()).isEqualTo(99000);
         } finally {
             pausingExpenseDateLockQuery.release();
             executor.shutdownNow();

--- a/src/test/java/Hampouch/server/domain/expense/service/ExpenseServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/expense/service/ExpenseServiceTest.java
@@ -8,6 +8,7 @@ import Hampouch.server.domain.expense.repository.ExpenseRepository;
 import Hampouch.server.domain.expense.repository.NoSpendDayRepository;
 import Hampouch.server.domain.user.entity.User;
 import Hampouch.server.domain.user.repository.UserRepository;
+import Hampouch.server.domain.user.service.UserOperationLock;
 import Hampouch.server.global.common.exception.CustomException;
 import Hampouch.server.global.common.exception.domain.ExpenseErrorCode;
 import org.junit.jupiter.api.DisplayName;
@@ -49,6 +50,8 @@ class ExpenseServiceTest {
     @Mock
     ExpenseDateLockQuery expenseDateLockQuery;
     @Mock
+    UserOperationLock userOperationLock;
+    @Mock
     UserRepository userRepository;
     @Mock
     ExpenseImageService expenseImageService;
@@ -62,7 +65,8 @@ class ExpenseServiceTest {
     /** 오늘을 직접 고정해야 하는 케이스(주간/월간 요약의 dailyAverage 계산)용 */
     private ExpenseService serviceAt(LocalDate today) {
         Clock clock = Clock.fixed(today.atTime(12, 0).atZone(SEOUL).toInstant(), SEOUL);
-        return new ExpenseService(expenseRepository, expenseDetailRepository, noSpendDayRepository, expenseDateLockQuery, userRepository, expenseImageService, expenseDetailAccess, clock);
+        return new ExpenseService(expenseRepository, expenseDetailRepository, noSpendDayRepository,
+                expenseDateLockQuery, userOperationLock, userRepository, expenseImageService, expenseDetailAccess, clock);
     }
 
     // ---------- create ----------

--- a/src/test/java/Hampouch/server/domain/expense/service/ExpenseServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/expense/service/ExpenseServiceTest.java
@@ -8,7 +8,6 @@ import Hampouch.server.domain.expense.repository.ExpenseRepository;
 import Hampouch.server.domain.expense.repository.NoSpendDayRepository;
 import Hampouch.server.domain.user.entity.User;
 import Hampouch.server.domain.user.repository.UserRepository;
-import Hampouch.server.domain.user.service.UserOperationLock;
 import Hampouch.server.global.common.exception.CustomException;
 import Hampouch.server.global.common.exception.domain.ExpenseErrorCode;
 import org.junit.jupiter.api.DisplayName;
@@ -55,8 +54,6 @@ class ExpenseServiceTest {
     ExpenseImageService expenseImageService;
     @Mock
     ExpenseDetailAccess expenseDetailAccess;
-    @Mock
-    UserOperationLock userOperationLock;
 
     private ExpenseService service() {
         return serviceAt(LocalDate.of(2026, 6, 6));
@@ -65,8 +62,7 @@ class ExpenseServiceTest {
     /** 오늘을 직접 고정해야 하는 케이스(주간/월간 요약의 dailyAverage 계산)용 */
     private ExpenseService serviceAt(LocalDate today) {
         Clock clock = Clock.fixed(today.atTime(12, 0).atZone(SEOUL).toInstant(), SEOUL);
-        return new ExpenseService(expenseRepository, expenseDetailRepository, noSpendDayRepository, expenseDateLockQuery,
-                userRepository, expenseImageService, expenseDetailAccess, userOperationLock, clock);
+        return new ExpenseService(expenseRepository, expenseDetailRepository, noSpendDayRepository, expenseDateLockQuery, userRepository, expenseImageService, expenseDetailAccess, clock);
     }
 
     // ---------- create ----------

--- a/src/test/java/Hampouch/server/domain/expense/service/ExpenseServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/expense/service/ExpenseServiceTest.java
@@ -8,6 +8,7 @@ import Hampouch.server.domain.expense.repository.ExpenseRepository;
 import Hampouch.server.domain.expense.repository.NoSpendDayRepository;
 import Hampouch.server.domain.user.entity.User;
 import Hampouch.server.domain.user.repository.UserRepository;
+import Hampouch.server.domain.user.service.UserOperationLock;
 import Hampouch.server.global.common.exception.CustomException;
 import Hampouch.server.global.common.exception.domain.ExpenseErrorCode;
 import org.junit.jupiter.api.DisplayName;
@@ -54,6 +55,8 @@ class ExpenseServiceTest {
     ExpenseImageService expenseImageService;
     @Mock
     ExpenseDetailAccess expenseDetailAccess;
+    @Mock
+    UserOperationLock userOperationLock;
 
     private ExpenseService service() {
         return serviceAt(LocalDate.of(2026, 6, 6));
@@ -62,7 +65,8 @@ class ExpenseServiceTest {
     /** 오늘을 직접 고정해야 하는 케이스(주간/월간 요약의 dailyAverage 계산)용 */
     private ExpenseService serviceAt(LocalDate today) {
         Clock clock = Clock.fixed(today.atTime(12, 0).atZone(SEOUL).toInstant(), SEOUL);
-        return new ExpenseService(expenseRepository, expenseDetailRepository, noSpendDayRepository, expenseDateLockQuery, userRepository, expenseImageService, expenseDetailAccess, clock);
+        return new ExpenseService(expenseRepository, expenseDetailRepository, noSpendDayRepository, expenseDateLockQuery,
+                userRepository, expenseImageService, expenseDetailAccess, userOperationLock, clock);
     }
 
     // ---------- create ----------

--- a/src/test/java/Hampouch/server/domain/rest/RestFlowIntegrationTest.java
+++ b/src/test/java/Hampouch/server/domain/rest/RestFlowIntegrationTest.java
@@ -6,7 +6,9 @@ import Hampouch.server.domain.challenge.repository.ChallengeRepository;
 import Hampouch.server.domain.challenge.service.ChallengeService;
 import Hampouch.server.domain.rest.entity.UserRest;
 import Hampouch.server.domain.rest.repository.UserRestRepository;
+import Hampouch.server.domain.user.entity.User;
 import Hampouch.server.domain.user.entity.UserRole;
+import Hampouch.server.domain.user.repository.UserRepository;
 import Hampouch.server.global.jwt.JwtProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,6 +20,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.hasKey;
@@ -43,6 +46,8 @@ class RestFlowIntegrationTest {
     @Autowired
     UserRestRepository userRestRepository;
     @Autowired
+    UserRepository userRepository;
+    @Autowired
     ChallengeService challengeService;
     @Autowired
     JwtProvider jwtProvider;
@@ -52,11 +57,17 @@ class RestFlowIntegrationTest {
         return "Bearer " + jwtProvider.createAccessToken(userId, UserRole.USER);
     }
 
+    private Long newUser() {
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        User user = User.createLocalUser(
+                "rest-flow-" + suffix + "@hampouch.test", "encoded", "휴식" + suffix);
+        return userRepository.save(user).getId();
+    }
+
     @Test
     @DisplayName("직전 챌린지가 끝난 유저가 휴식을 시작하면 홈이 휴식 화면으로 바뀌고, 유저가 조금 더 쉬기로 복귀 예정일을 미룬 뒤 새 챌린지를 만들면 휴식이 자동으로 닫히며 홈이 챌린지 화면으로 돌아온다")
     void restFlow() throws Exception {
-        // 챌린지·미니 통합 테스트(유저 1·4·5)와 데이터가 안 섞이게 전용 유저 사용
-        Long user = 7L;
+        Long user = newUser();
         // 서버의 "오늘"은 ClockConfig(Asia/Seoul) 기준 — 머신 시간대(CI는 UTC)로 만들면 KST 새벽에 날짜가 갈라진다
         LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
 
@@ -144,7 +155,7 @@ class RestFlowIntegrationTest {
     @Test
     @DisplayName("복귀 예정일이 한참 지나도록 안 들어오던 유저가 돌아와 조금 더 쉬기를 고르면 새 복귀 예정일이 오늘 뒤로 잡힌다 — 지나간 예정일에 더하면 새 예정일도 과거라 복귀 팝업이 다시 떠서 더 쉬기가 무한 반복된다")
     void resumeExtendAfterLongAbsenceCountsFromToday() throws Exception {
-        Long user = 10L;
+        Long user = newUser();
         LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
         // 19일 전에 3일짜리 휴식을 걸어 예정일이 16일 전에 지나간 상태 — 복귀 API를 한 번도 안 불러 아직 활성이다
         userRestRepository.save(UserRest.start(user, today.minusDays(19), 3));
@@ -163,7 +174,7 @@ class RestFlowIntegrationTest {
     @Test
     @DisplayName("기간이 끝났는데 미확정으로 남은 챌린지가 있어도 휴식 시작이 409로 막히지 않고, 그 챌린지는 진행 중 챌린지가 있는지 확인하는 과정에서 확정돼 DB에 남는다")
     void restStartFinalizesExpiredChallenge() throws Exception {
-        Long user = 8L;
+        Long user = newUser();
         LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
         // 10일 전 시작한 7일짜리 — 4일 전에 만료됐지만 결과 화면을 안 열어 IN_PROGRESS로 남은 상태
         Challenge expired = challengeRepository.save(Challenge.builder()
@@ -183,7 +194,7 @@ class RestFlowIntegrationTest {
     @Test
     @DisplayName("진행 중 챌린지 존재 판단을 다른 트랜잭션 없이 단독으로 불러도 만료 챌린지 확정이 DB에 실제로 저장된다 — 쓰기 트랜잭션 선언이 빠지면 확정이 조용히 증발하는 회귀 방지")
     void hasActiveChallengeStandaloneCommitsFinalization() {
-        Long user = 9L;
+        Long user = newUser();
         LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
         Challenge expired = challengeRepository.save(Challenge.builder()
                 .userId(user).durationDays(7).startDate(today.minusDays(10))
@@ -206,7 +217,7 @@ class RestFlowIntegrationTest {
     @Test
     @DisplayName("지금 바로 복귀를 고르면 실제 복귀일이 오늘로 응답되고, 요청 종료 후 새 DB 조회에서도 오늘로 남아 활성 휴식에서 빠진다")
     void resumeNowCommitsActualResumeDate() throws Exception {
-        Long user = 83_010L;
+        Long user = newUser();
         LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
         UserRest rest = userRestRepository.save(UserRest.start(user, today.minusDays(2), 7));
 
@@ -226,7 +237,7 @@ class RestFlowIntegrationTest {
     @Test
     @DisplayName("내일 복귀를 고르면 실제 복귀일이 내일로 저장되고, 오늘은 아직 휴식 중이라 활성 휴식으로 계속 잡힌다")
     void resumeTomorrowCommitsActualResumeDate() throws Exception {
-        Long user = 83_011L;
+        Long user = newUser();
         LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
         UserRest rest = userRestRepository.save(UserRest.start(user, today.minusDays(2), 7));
 

--- a/src/test/java/Hampouch/server/domain/rest/service/UserRestServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/rest/service/UserRestServiceTest.java
@@ -4,6 +4,7 @@ import Hampouch.server.domain.challenge.service.ChallengeService;
 import Hampouch.server.domain.rest.dto.*;
 import Hampouch.server.domain.rest.entity.UserRest;
 import Hampouch.server.domain.rest.repository.UserRestRepository;
+import Hampouch.server.domain.user.service.UserOperationLock;
 import Hampouch.server.global.common.exception.CustomException;
 import Hampouch.server.global.common.exception.domain.ChallengeErrorCode;
 import Hampouch.server.global.common.exception.domain.CommonErrorCode;
@@ -42,10 +43,12 @@ class UserRestServiceTest {
     UserRestRepository userRestRepository;
     @Mock
     ChallengeService challengeService;
+    @Mock
+    UserOperationLock userOperationLock;
 
     private UserRestService serviceAt(LocalDate today) {
         Clock clock = Clock.fixed(today.atTime(12, 0).atZone(SEOUL).toInstant(), SEOUL);
-        return new UserRestService(userRestRepository, challengeService, clock);
+        return new UserRestService(userRestRepository, challengeService, userOperationLock, clock);
     }
 
     /** 스프링이 하이버네이트 제약 위반을 감싸 올려보내는 실제 모양 — 서비스가 제약 이름으로 원인을 가르므로 이름 없는 예외로는 검증이 안 된다. */


### PR DESCRIPTION
## 📎연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) closes #[issue number]

- Closes #177

## 📄 작업 내용 요약
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.

- 동일 사용자의 챌린지·휴식 상태 변경이 사용자 행 비관적 락을 공유하도록 `UserOperationLock`을 추가했습니다.
- 챌린지 생성·목표 조정·포기·결과 확정·최종 종료와 휴식 시작·재개 경쟁을 하나의 처리 순서로 직렬화했습니다.
- 실제 MySQL에서 조건부 UNIQUE와 서비스 경쟁 요청의 응답 및 최종 DB 상태를 검증하는 동시성 테스트를 추가했습니다.

## 👀 중요 변경 사항
> API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요

- API 요청·응답 계약은 변경되지 않습니다.
- 같은 사용자의 챌린지·휴식 쓰기 요청은 트랜잭션 종료까지 사용자 행 락을 공유하며, 챌린지 행도 잠글 때는 사용자 행을 먼저 잠급니다.
- 지출 쓰기와의 공통 사용자 락 적용 및 교차 검증은 #149에서 별도로 추적합니다.

## 🔖 Uncompleted Tasks
> 후속 작업 예정인 사항이 있다면 작성해주세요.

- #149에서 지출 쓰기와 챌린지 상태 변경의 공통 사용자 락 및 교차 동시성 검증을 진행합니다.

## 📢 To Reviewers
> Reviewer가 주로 확인해주었으면 하는 부분을 적어주세요.

- 사용자 행 락의 적용 범위와 `사용자 행 → 챌린지 행` 잠금 순서를 확인해주세요.
- `ChallengeConcurrencyMySqlTest`가 실제 요청 대기뿐 아니라 각 응답과 최종 DB 상태까지 단언하는지 확인해주세요.
- PR 전 격리 실측에서는 JWT·컨트롤러를 통과한 동시 HTTP 요청 40건이 5xx·전송 오류 없이 끝났고, 모든 최종 DB 상태가 하나의 처리 순서와 일치했습니다.