### PR TITLE
ci: 테스트 실패 원인을 GitHub Actions 화면에서 바로 확인하도록 출력 개선 [base: develop]

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -13,4 +13,10 @@
 
 정적 검사는 `quality.yml`, 의존성 변경 차단과 반복 가능한 애플리케이션·스크립트 기능 검증은 `ci.yml`의 독립 job, 운영 Compose와 관측성 통합 검증은 `observability.yml`이 담당한다. PR 화면에서 실패 영역을 바로 구분할 수 있도록 CI 검증은 병렬 실행하고, 필수 검사 이름을 유지하는 `CI / build`가 모든 결과를 최종 집계한다. 같은 검사를 여러 워크플로에서 반복하지 않는다.
 
+## 테스트 실패 확인
+
+`gradle-test`와 `mysql-test`가 실패하면 해당 job의 Gradle 실행 로그에서 실패한 테스트명, 예외 메시지, 원인 체인과 스택 트레이스를 바로 확인한다. 성공 테스트와 표준 출력은 추가로 노출하지 않으며, Gradle 명령을 별도 요약 단계로 감싸지 않아 테스트의 종료 코드가 그대로 job 실패로 반영된다.
+
+전체 테스트 리포트는 실패한 job의 `gradle-test-report` 또는 `mysql-test-report` 아티팩트에서 확인한다. Actions 로그로 원인을 먼저 좁히고, 전체 출력과 테스트별 상세 내역이 필요할 때 HTML 리포트를 사용한다.
+
 CI와 배포 검증은 GitHub 러너와 실제 EC2에서 실행한다. 로컬에서는 Actionlint와 ShellCheck 같은 정적 검사만 확인하고 JUnit·Docker Compose·API 검증을 반복하지 않는다.

--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,17 @@ tasks.register('mysqlTest', Test) {
 	systemProperty 'user.timezone', 'Asia/Seoul'
 }
 
+tasks.withType(Test).configureEach {
+	testLogging {
+		events 'failed'
+		exceptionFormat = 'full'
+		showExceptions = true
+		showCauses = true
+		showStackTraces = true
+		showStandardStreams = false
+	}
+}
+
 tasks.withType(JavaCompile).configureEach {
 	options.compilerArgs << '-parameters'
 }


### PR DESCRIPTION
## 📎연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) closes #[issue number]

- Closes #183

## 📄 작업 내용 요약
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.

- 모든 Gradle `Test` 작업에서 실패한 테스트만 이름과 전체 예외·원인 체인·스택 트레이스로 출력하도록 설정했습니다.
- 성공 로그 노이즈와 표준 출력은 늘리지 않고, 기존 테스트 리포트 artifact 업로드와 실패 종료 코드는 유지했습니다.
- Actions 화면에서 실패 로그와 HTML 리포트 artifact를 확인하는 절차를 `.github/CI.md`에 문서화했습니다.

## 👀 중요 변경 사항
> API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요

- 설정은 기본 `test`와 `mysqlTest`를 포함한 모든 `Test` 작업에 동일하게 적용됩니다.
- 애플리케이션 코드·API 계약·DB 스키마는 변경하지 않습니다.

## 🔖 Uncompleted Tasks
> 후속 작업 예정인 사항이 있다면 작성해주세요.

- 의도적 실패 케이스의 실제 Actions 출력 확인은 테스트용 실패 커밋이 필요한 후속 검증으로 남아 있습니다.

## 📢 To Reviewers
> Reviewer가 주로 확인해주었으면 하는 부분을 적어주세요.

- 실패 원인을 Actions 로그에서 바로 찾을 수 있으면서 성공 로그 노이즈는 늘지 않는지 확인해주세요.
- 기존 `gradle-test-report`와 `mysql-test-report` artifact 경로가 유지되는지 확인해주세요.