### PR TITLE
fix(security): Security and quality 경고 16건 해소 [base: develop]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,25 @@
+// GitHub 의존성 그래프에 포함되는 Spring Boot Gradle 플러그인의 빌드 전용 전이 의존성도 패치한다.
+buildscript {
+	configurations.classpath {
+		resolutionStrategy.force(
+				'org.apache.commons:commons-lang3:3.20.0',
+				'tools.jackson:jackson-bom:3.1.5',
+				'tools.jackson.core:jackson-core:3.1.5',
+				'tools.jackson.core:jackson-databind:3.1.5'
+		)
+	}
+}
+
 plugins {
 	id 'java'
 	id 'org.springframework.boot' version '4.1.0'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
+
+// Spring Boot 4.1.0 BOM의 취약 버전을 각 보안 권고의 패치 버전으로 올린다.
+ext['jackson-2-bom.version'] = '2.21.5'
+ext['jackson-bom.version'] = '3.1.5'
+ext['netty.version'] = '4.2.16.Final'
 
 group = 'Hampouch'
 version = '0.0.1-SNAPSHOT'


### PR DESCRIPTION
## 📎연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) closes #[issue number]

- close: #184

## 📄 작업 내용 요약
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.

- Spring Boot 4.1.0 BOM이 선택하던 Netty를 `4.2.16.Final`로 올렸습니다.
- Jackson 2 BOM을 `2.21.5`, Jackson 3 BOM과 Gradle 플러그인 전이 의존성을 `3.1.5`로 올렸습니다.
- Spring Boot Gradle 플러그인의 빌드 전용 Commons Lang를 `3.20.0`으로 고정했습니다.
- CodeQL의 CSRF 비활성화 경고 1건은 무상태 Bearer JWT와 쿠키 미사용 근거를 남겨 false positive로 처리했습니다.

## 👀 중요 변경 사항
> API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요

- 제품 API와 DB 스키마 변경은 없습니다.
- `buildscript` classpath까지 강제 버전을 적용해 GitHub dependency graph에 잡힌 빌드 전용 취약 의존성도 함께 교체합니다.
- 런타임은 Netty `4.2.16.Final`, Jackson 2 `2.21.5`, Jackson 3 `3.1.5`로 해석됩니다.

## 🔖 Uncompleted Tasks
> 후속 작업 예정인 사항이 있다면 작성해주세요.

- PR의 `dependency-review`, Gradle, MySQL, Docker, Repository Quality CI 결과를 확인합니다.
- develop 병합 후 Dependency Submission이 갱신한 그래프에서 Dependabot 경고 15건이 닫히는지 확인합니다.

## 📢 To Reviewers
> Reviewer가 주로 확인해주었으면 하는 부분을 적어주세요.

- Spring Boot BOM override와 `buildscript` 강제 버전이 런타임·빌드 전용 경고를 모두 덮는지 확인 부탁드립니다.
