### PR TITLE
fix(security): HttpCore5 HTTP 헤더 파싱 DoS 취약점 해소 (#190) [base: develop]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,8 @@ buildscript {
 	configurations.classpath {
 		resolutionStrategy.force(
 				'org.apache.commons:commons-lang3:3.20.0',
+				'org.apache.httpcomponents.core5:httpcore5:5.4.3',
+				'org.apache.httpcomponents.core5:httpcore5-h2:5.4.3',
 				'tools.jackson:jackson-bom:3.1.5',
 				'tools.jackson.core:jackson-core:3.1.5',
 				'tools.jackson.core:jackson-databind:3.1.5'
@@ -17,6 +19,7 @@ plugins {
 }
 
 // Spring Boot 4.1.0 BOM의 취약 버전을 각 보안 권고의 패치 버전으로 올린다.
+ext['httpcore5.version'] = '5.4.3'
 ext['jackson-2-bom.version'] = '2.21.5'
 ext['jackson-bom.version'] = '3.1.5'
 ext['netty.version'] = '4.2.16.Final'
@@ -97,6 +100,46 @@ tasks.named('test') {
 		excludeTags 'mysql'
 	}
 	systemProperty 'user.timezone', 'Asia/Seoul'
+}
+
+def expectedHttpCoreVersion = '5.4.3'
+def httpCoreCoordinates = [
+		'org.apache.httpcomponents.core5:httpcore5',
+		'org.apache.httpcomponents.core5:httpcore5-h2'
+]
+def httpCoreVerificationConfigurations = [
+		runtimeClasspath: configurations.getByName('runtimeClasspath'),
+		buildscriptClasspath: buildscript.configurations.getByName('classpath')
+]
+
+tasks.register('verifyHttpCore5Version') {
+	group = 'verification'
+	description = 'Verifies patched HttpCore5 versions in runtime and build classpaths.'
+
+	doLast {
+		httpCoreVerificationConfigurations.each { pathName, configuration ->
+			def resolvedVersions = configuration.incoming.resolutionResult.allComponents
+					.findAll { it.moduleVersion != null }
+					.collectEntries {
+						def module = it.moduleVersion
+						[("${module.group}:${module.name}".toString()): module.version]
+					}
+
+			httpCoreCoordinates.each { coordinate ->
+				def resolvedVersion = resolvedVersions[coordinate]
+				if (resolvedVersion != expectedHttpCoreVersion) {
+					throw new GradleException(
+							"${pathName} resolves ${coordinate} to ${resolvedVersion ?: 'missing'}, " +
+									"expected ${expectedHttpCoreVersion}"
+					)
+				}
+			}
+		}
+	}
+}
+
+tasks.named('check') {
+	dependsOn tasks.named('verifyHttpCore5Version')
 }
 
 def verifyDocker = tasks.register('verifyDocker', Exec) {


### PR DESCRIPTION
## 📎연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) closes #[issue number]

- Closes #190

## 📄 작업 내용 요약
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.

- Spring Boot BOM이 해석하는 `httpcore5`, `httpcore5-h2` 런타임 버전을 보안 패치가 포함된 5.4.3으로 고정했습니다.
- Spring Boot Gradle 플러그인의 buildscript classpath에서도 두 모듈을 5.4.3으로 강제했습니다.
- `verifyHttpCore5Version` 검증 태스크를 추가하고 `check`에 연결해 두 classpath 중 하나라도 누락되거나 5.4.3이 아니면 CI가 실패하도록 했습니다.

## 👀 중요 변경 사항
> API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요

- API 계약과 DB 스키마 변경은 없습니다.
- 기존 `./gradlew clean build`가 런타임·빌드스크립트 의존성을 모두 해석하며 HttpCore5 버전을 검증합니다.

## 🔖 Uncompleted Tasks
> 후속 작업 예정인 사항이 있다면 작성해주세요.

- 머지 후 Dependency Submission 성공과 [Dependabot 경고 #16](https://github.com/Hampouch/Hampouch-Server/security/dependabot/16) 종료 여부를 확인합니다.

## 📢 To Reviewers
> Reviewer가 주로 확인해주었으면 하는 부분을 적어주세요.

- 런타임 BOM과 buildscript classpath 양쪽 모두에서 `httpcore5`, `httpcore5-h2`가 5.4.3으로 고정되는지 확인 부탁드립니다.
- `verifyHttpCore5Version`이 `check`를 통해 PR CI에서 실행되는지 확인 부탁드립니다.