### PR TITLE
Fix: 지출 경쟁 요청의 User.lastUpdated 정합성·잠금 구간 보완

### DIFF
--- a/src/main/java/Hampouch/server/domain/expense/controller/ExpenseController.java
+++ b/src/main/java/Hampouch/server/domain/expense/controller/ExpenseController.java
@@ -13,22 +13,15 @@ import java.net.URI;
 import java.time.LocalDate;
 import java.time.YearMonth;
 
-/**
- * 지출 생성·조회·수정·삭제와 '오늘은 안 썼어요' 날짜 기록 API.
- * 유저 식별은 @LoginUserId(SecurityContext의 인증된 principal, JwtFilter가 채워둠)로 주입받는다
- * AuthController.logout()/deleteMe()와 동일 패턴
- */
 @RestController
 @RequestMapping(ExpenseController.BASE_PATH)
 @RequiredArgsConstructor
 public class ExpenseController {
 
-    /** 클래스 매핑과 Location 헤더 조립이 공유하는 기본 경로. */
     static final String BASE_PATH = "/api/expenses";
 
     private final ExpenseService expenseService;
 
-    /** POST /api/expenses — 201 + Location 헤더(ChallengeController.create()와 동일 컨벤션). */
     @PostMapping
     public ResponseEntity<ApiResponse<ExpenseCreateResponse>> create(
             @LoginUserId Long userId,
@@ -39,7 +32,6 @@ public class ExpenseController {
                 .body(ApiResponse.success(res));
     }
 
-    /** PUT /api/expenses/no-spend — 선택한 날짜에 '오늘은 안 썼어요'를 기록한다. */
     @PutMapping("/no-spend")
     public ResponseEntity<ApiResponse<Void>> recordNoSpend(
             @LoginUserId Long userId,
@@ -48,7 +40,6 @@ public class ExpenseController {
         return ResponseEntity.ok(ApiResponse.success());
     }
 
-    /** GET /api/expenses/{expenseId} — 상세 조회. */
     @GetMapping("/{expenseId}")
     public ApiResponse<ExpenseDetailResponse> getDetail(
             @LoginUserId Long userId,
@@ -56,10 +47,6 @@ public class ExpenseController {
         return ApiResponse.success(expenseService.getDetail(userId, expenseId));
     }
 
-    /**
-     * PUT /api/expenses/{expenseId} — 200 OK, 별도 Location 없음.
-     * imageKey는 받지 않는다(ExpenseUpdateRequest 자체 Javadoc 참조) — 이미지 교체는 PATCH .../photos 전용.
-     */
     @PutMapping("/{expenseId}")
     public ApiResponse<ExpenseCreateResponse> update(
             @LoginUserId Long userId,
@@ -68,10 +55,7 @@ public class ExpenseController {
         return ApiResponse.success(expenseService.update(userId, expenseId, request));
     }
 
-    /**
-     * DELETE /api/expenses/{expenseId} — 소프트 삭제(Expense.delete()). 반환 데이터가 없어
-     * UserController.deleteMe()와 동일하게 메시지만 담은 ApiResponse<Void>로 응답.
-     */
+    //soft delete
     @DeleteMapping("/{expenseId}")
     public ResponseEntity<ApiResponse<Void>> delete(
             @LoginUserId Long userId,
@@ -80,11 +64,6 @@ public class ExpenseController {
         return ResponseEntity.ok(ApiResponse.success("지출 내역이 삭제되었습니다.", null));
     }
 
-    /**
-     * GET /api/expenses/day — 캘린더 일간 조회. date는 쿼리 파라미터(?date=2026-07-18),
-     * 화면 진입 자체가 특정 날짜를 골라 들어오는 흐름이라 생략 불가(RecommendedMiniChallengeController의
-     * durationDays처럼 선택적인 필터가 아님) — required 기본값(true) 그대로 사용.
-     */
     @GetMapping("/day")
     public ApiResponse<ExpenseDayListResponse> getDayList(
             @LoginUserId Long userId,
@@ -92,10 +71,6 @@ public class ExpenseController {
         return ApiResponse.success(expenseService.getDayList(userId, date));
     }
 
-    /**
-     * GET /api/expenses/summary/week — standardDate(?standardDate=2026-06-05)가 속한 주(일~토)의 합계·일별 내역.
-     * getDayList()와 동일하게 화면 진입 자체가 날짜를 고르고 들어오는 흐름이라 standardDate 생략 불가.
-     */
     @GetMapping("/summary/week")
     public ApiResponse<ExpenseSummaryResponse> getWeekSummary(
             @LoginUserId Long userId,
@@ -103,7 +78,6 @@ public class ExpenseController {
         return ApiResponse.success(expenseService.getWeekSummary(userId, standardDate));
     }
 
-    /** GET /api/expenses/summary/month — standardMonth(?standardMonth=2026-06) 해당 월의 합계·일별 내역 */
     @GetMapping("/summary/month")
     public ApiResponse<ExpenseSummaryResponse> getMonthSummary(
             @LoginUserId Long userId,

--- a/src/main/java/Hampouch/server/domain/expense/controller/ExpenseImageController.java
+++ b/src/main/java/Hampouch/server/domain/expense/controller/ExpenseImageController.java
@@ -11,21 +11,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-/**
- * 지출 이미지 업로드 3종(presign, 반영, 삭제)
- * ExpenseController와 분리한 이유: 이미지 업로드는 S3 연동이라 관심사가 다르고,
- * 커밋 단위/리뷰 단위를 지출 CRUD와 독립적으로 가져가기 위함.
- */
 @RestController
 @RequiredArgsConstructor
 public class ExpenseImageController {
 
     private final ExpenseImageService expenseImageService;
 
-    /**
-     * POST /api/expenses/photos/presigned — presigned URL 발급. expenseId는 query param(선택)으로,
-     * 지출 생성 전 업로드는 생략하고 기존 지출 이미지 교체 시에만 실어 보낸다.
-     */
     @PostMapping("/api/expenses/photos/presigned")
     public ResponseEntity<ApiResponse<ExpenseImagePresignResponse>> presign(
             @LoginUserId Long userId,
@@ -33,7 +24,6 @@ public class ExpenseImageController {
             @Valid @RequestBody ExpenseImagePresignRequest request) {
         return ResponseEntity.ok(ApiResponse.success("업로드 URL이 발급되었습니다.", expenseImageService.presign(userId, expenseId, request)));    }
 
-    /** PATCH /api/expenses/{expenseId}/photos — 업로드 완료된 이미지를 지출 상세에 반영. */
     @PatchMapping("/api/expenses/{expenseId}/photos")
     public ResponseEntity<ApiResponse<Void>> attach(
             @LoginUserId Long userId,
@@ -43,7 +33,6 @@ public class ExpenseImageController {
         return ResponseEntity.ok(ApiResponse.success("사진이 변경되었습니다.", null));
     }
 
-    /** DELETE /api/expenses/{expenseId}/photos — 첨부된 이미지 제거(메모는 유지). */
     @DeleteMapping("/api/expenses/{expenseId}/photos")
     public ResponseEntity<ApiResponse<Void>> remove(
             @LoginUserId Long userId,

--- a/src/main/java/Hampouch/server/domain/expense/dto/ExpenseAnalysisItem.java
+++ b/src/main/java/Hampouch/server/domain/expense/dto/ExpenseAnalysisItem.java
@@ -32,7 +32,7 @@ public record ExpenseAnalysisItem(
                 expense.getExpenseDate(),
                 expense.getName(),
                 expense.getCategory(),
-                expense.getCustomCategory(), // 문자열 컬럼 그대로(이슈 #61) — ETC가 아니면 null이라 NON_NULL 생략 동작 동일
+                expense.getCustomCategory(),
                 expense.getEmotion(),
                 expense.getCustomEmotion(),
                 expense.getPrice()

--- a/src/main/java/Hampouch/server/domain/expense/dto/ExpenseCreateRequest.java
+++ b/src/main/java/Hampouch/server/domain/expense/dto/ExpenseCreateRequest.java
@@ -6,11 +6,7 @@ import jakarta.validation.constraints.*;
 
 import java.time.LocalDate;
 
-/**
- * 지출 생성 요청(POST /expenses) DTO
- * name/category/emotion은 선택 입력 — price/date만 계속 필수.
- * imageKey는 create()에서만 실제로 반영
- */
+/** 지출 생성 요청(POST /expenses) — name/category/emotion은 선택, price/date만 필수. */
 public record ExpenseCreateRequest(
 
         @Size(max = 90)
@@ -23,35 +19,31 @@ public record ExpenseCreateRequest(
         ExpenseCategory category,
 
         @Size(max = 50)
-        String customCategory, // category=ETC일 때만 사용하는 자유 입력 태그 — 그 외엔 null이어야 함
+        String customCategory, // category = ETC일 때 외엔 null
 
-        ExpenseEmotion emotion, // 건너뛰면 null — category와 동일한 흡수 규칙
+        ExpenseEmotion emotion,
 
         @Size(max = 50)
-        String customEmotion, // emotion=ETC일 때만 사용 — 위와 동일한 이유로 nullable
+        String customEmotion, // emotion = ETC일 때 외엔 null
 
-        @NotNull @PastOrPresent // 미래 날짜의 지출 입력 방지 — 오늘까지만 허용
+        @NotNull @PastOrPresent
         LocalDate date,
 
         @Size(max = 300)
-        String memo, // — create()/update() 둘 다 반영. 빈 문자열/null이면 저장하지 않음
+        String memo,
 
         @Pattern(regexp = "^expenses/\\d+/[A-Za-z0-9\\-]+\\.(jpg|png|webp)$", message = "올바른 이미지 key 형식이 아닙니다.")
-        String imageKey // POST /expenses/photos/presigned로 미리 발급받은 key. create()에서만 사용
+        String imageKey
 ) {
 
-    /**
-     * category와 customCategory의 존재 여부가 항상 같아야 함(둘 다 있거나 둘 다 없거나) — XOR 관계를 단일 == 비교로 표현.
-     * category가 null이면 (null == ETC)가 false, hasCustomCategory도 false여야 통과(customCategory == null)
-     * → category=ETC를 명시적으로 보냈는데 customCategory가 없는 경우와 구분되는 지점
-     */
+    /** category=ETC일 때만 customCategory가 있어야 함(둘 다 있거나 둘 다 없거나). */
     @AssertTrue(message = "category가 ETC일 때만 customCategory를 입력할 수 있습니다.")
     public boolean isCategoryConsistent() {
         boolean hasCustomCategory = customCategory != null && !customCategory.isBlank();
         return (category == ExpenseCategory.ETC) == hasCustomCategory;
     }
 
-    /** customCategory와 대칭 — emotion=null(건너뛰기)이면 customEmotion도 없어야 함 */
+    /** customCategory와 대칭 — emotion=ETC일 때만 customEmotion 존재. */
     @AssertTrue(message = "emotion이 ETC일 때만 customEmotion을 입력할 수 있습니다.")
     public boolean isEmotionConsistent() {
         boolean hasCustomEmotion = customEmotion != null && !customEmotion.isBlank();

--- a/src/main/java/Hampouch/server/domain/expense/dto/ExpenseCreateResponse.java
+++ b/src/main/java/Hampouch/server/domain/expense/dto/ExpenseCreateResponse.java
@@ -3,7 +3,7 @@ package Hampouch.server.domain.expense.dto;
 import Hampouch.server.domain.expense.entity.Expense;
 
 /**
- * 생성/수정 응답 — expenseId만 반환. PUT 응답도 이 DTO를 그대로 재사용(별도 UpdateResponse 불필요, CreateChallengeResponse 패턴과 동일).
+ * PUT /expenses/{expenseId} 공통 활용 DTO
  */
 public record ExpenseCreateResponse(
         Long expenseId

--- a/src/main/java/Hampouch/server/domain/expense/dto/ExpenseDayListResponse.java
+++ b/src/main/java/Hampouch/server/domain/expense/dto/ExpenseDayListResponse.java
@@ -8,12 +8,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import java.time.LocalDate;
 import java.util.List;
 
-/**
- * 하루치 지출 목록 조회 응답(GET /expenses/day).
- * totalAmount를 목록과 함께 내려주는 이유: 캘린더 일간 화면이 "그날 지출 리스트 + 합계"를 한 화면에서 같이 그리기 때문 —
- * 이 화면 한정으로는 summary 계열 API를 또 호출하게 하는 게 불필요한 라운드트립이라 판단.
- * 월간/주간 캘린더의 "여러 날짜 합계"는 이 DTO 책임 밖 — /expenses/summary 쪽에서 별도 설계 필요(TODO).
- */
+/** 하루치 지출 목록 응답(GET /expenses/day). totalAmount를 함께 내려 일간 화면이 summary API를 또 호출하지 않게 한다. */
 public record ExpenseDayListResponse(
         LocalDate date,
         int totalAmount,
@@ -21,12 +16,7 @@ public record ExpenseDayListResponse(
         List<ExpenseSummary> expenses
 ) {
 
-    /**
-     * 목록 한 줄 = 지출 1건 요약. category/emotion은 enum 그대로이고,
-     * customCategory/customEmotion 원문 대신 categoryLabel/emotionLabel(커스텀 태그일 때만 값 존재)을 내려줌.
-     * @JsonInclude(NON_NULL)은 categoryLabel/emotionLabel 필드에만 건다
-     * → 지출 건너뛰기를 통해 name이 null일 경우 해당 row가 완전히 생략되는 문제를 방지
-     */
+    /** 목록 한 줄 = 지출 1건 요약. categoryLabel/emotionLabel은 커스텀 태그일 때만 값이 있어 NON_NULL로 생략한다. */
     public record ExpenseSummary(
             Long expenseId,
             String name,
@@ -42,19 +32,14 @@ public record ExpenseDayListResponse(
                     expense.getName(),
                     expense.getPrice(),
                     expense.getCategory(),
-                    expense.getCustomCategory(), // 문자열 컬럼 그대로(이슈 #61) — ETC가 아니면 null이라 NON_NULL 생략 동작 동일
+                    expense.getCustomCategory(), // 문자열 컬럼 그대로 — ETC 아니면 null이라 NON_NULL 생략 동일
                     expense.getEmotion(),
                     expense.getCustomEmotion()
             );
         }
     }
 
-    /**
-     * expenses는 이미 특정 user_id + expense_date로 필터링된 리스트라고 가정(레포지토리 쿼리 책임, 이 팩토리는 변환만).
-     * totalAmount는 SUM을 별도 쿼리로 또 날리지 않고 이미 조회한 리스트를 stream으로 합산 —
-     * 하루 단위라 건수가 작아서 비용 무시 가능. 월/주 단위 집계처럼 건수가 커지면 SUM을 DB에 위임하는 게 맞고,
-     * 이 방식을 그대로 재사용하면 안 됨(리팩토링 시 주의).
-     */
+    /** totalAmount는 이미 조회한 리스트를 stream 합산 — 하루 단위라 비용 무시 가능(월/주 집계엔 재사용 금지). */
     public static ExpenseDayListResponse from(LocalDate date, List<Expense> expenses, boolean hasRecord) {
         int totalAmount = expenses.stream().mapToInt(Expense::getPrice).sum();
         List<ExpenseSummary> summaries = expenses.stream().map(ExpenseSummary::from).toList();

--- a/src/main/java/Hampouch/server/domain/expense/dto/ExpenseDetailResponse.java
+++ b/src/main/java/Hampouch/server/domain/expense/dto/ExpenseDetailResponse.java
@@ -7,11 +7,6 @@ import Hampouch.server.domain.expense.entity.ExpenseEmotion;
 
 import java.time.LocalDate;
 
-/**
- * 지출 상세 조회 응답(GET /expenses/{expenseId}).
- * 필드명은 엔티티 내부 명명(expenseDate 등 예약어 회피용 이름)이 아니라 API 명세(date/category/emotion)를 그대로 따름 —
- * 엔티티 컬럼명과 DTO/JSON 필드명은 별개라는 원칙.
- */
 public record ExpenseDetailResponse(
         Long expenseId,
         String name,
@@ -24,12 +19,7 @@ public record ExpenseDetailResponse(
         String memo, // detail이 없으면 null
         String imageUrl // detail 없으면 null
 ) {
-    /**
-     * customCategory/customEmotion은 엔티티의 문자열 컬럼 그대로 — ETC가 아니면 null이라 그대로 넘기면 됨.
-     * detail은 memo/이미지가 하나도 없는 지출이면 null로 들어오고, 그 경우 memo는 null로 응답한다.
-     * imageUrl은 엔티티에 저장된 값이 아니라 호출부(ExpenseService.getDetail())가 조회 시점에
-     * ExpenseImageService.presignGetUrl()로 새로 발급해 넘겨준 값을 그대로 싣는다.
-     */
+    /** detail이 없으면 memo는 null. imageUrl은 저장값이 아니라 호출부가 조회 시점에 새로 서명해 넘긴 값. */
     public static ExpenseDetailResponse from(Expense expense, ExpenseDetail detail, String imageUrl) {
         return new ExpenseDetailResponse(
                 expense.getId(),

--- a/src/main/java/Hampouch/server/domain/expense/dto/ExpenseImageAttachRequest.java
+++ b/src/main/java/Hampouch/server/domain/expense/dto/ExpenseImageAttachRequest.java
@@ -3,11 +3,7 @@ package Hampouch.server.domain.expense.dto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
-/**
- * PATCH /expenses/{expenseId}/photos 요청. imageKey 형식 자체는 여기서 @Pattern으로 걸러 VALIDATION_ERROR로
- * 빠지게 하고, 형식은 맞지만 실제 S3에 없는 키는 ExpenseImageService가 HeadObject로 확인해
- * EXPENSE_IMAGE_NOT_UPLOADED로 구분한다(명세의 두 에러 케이스와 대응).
- */
+/** PATCH /expenses/{expenseId}/photos 요청. 형식 오류는 @Pattern으로, 미업로드는 HeadObject로 구분(두 에러 케이스 대응). */
 public record ExpenseImageAttachRequest(
 
         @NotBlank(message = "imageKey는 필수입니다.")

--- a/src/main/java/Hampouch/server/domain/expense/dto/ExpenseImagePresignRequest.java
+++ b/src/main/java/Hampouch/server/domain/expense/dto/ExpenseImagePresignRequest.java
@@ -5,11 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Positive;
 
-/**
- * 지출 이미지 presigned URL 발급 요청(POST /expenses/photos/presigned, POST /expenses/{expenseId}/photos/presigned 공용).
- * 지출 이미지는 한 장만 첨부, community처럼 List<FileInfo> 배치로 감싸지 않고 단건 필드로 둔다.
- * size는 contentLength 미검증 시 업로드 크기 무제한 문제를 재현하지 않기 위해 추가함
- */
+/** presigned URL 발급 요청. 이미지는 한 장만 첨부해 단건 필드로 둔다. size는 업로드 크기 무제한 방지용. */
 public record ExpenseImagePresignRequest(
 
         @NotBlank(message = "파일 형식은 필수입니다.")

--- a/src/main/java/Hampouch/server/domain/expense/dto/ExpenseUpdateRequest.java
+++ b/src/main/java/Hampouch/server/domain/expense/dto/ExpenseUpdateRequest.java
@@ -6,10 +6,6 @@ import jakarta.validation.constraints.*;
 
 import java.time.LocalDate;
 
-/**
- * 지출 수정 요청(PUT /expenses/{id}).
- * ExpenseCreateRequest와 필드 구성이 거의 같지만 imageKey는 없다 — 수정 API는 그 필드 자체를 받지 않는다
- */
 public record ExpenseUpdateRequest(
 
         @Size(max = 90)
@@ -22,28 +18,26 @@ public record ExpenseUpdateRequest(
         ExpenseCategory category,
 
         @Size(max = 50)
-        String customCategory, // category=ETC일 때만 사용하는 자유 입력 태그 — 그 외엔 null이어야 함
+        String customCategory,
 
-        ExpenseEmotion emotion, // 건너뛰면 null — category와 동일한 흡수 규칙
+        ExpenseEmotion emotion,
 
         @Size(max = 50)
-        String customEmotion, // emotion=ETC일 때만 사용 — 위와 동일한 이유로 nullable
+        String customEmotion,
 
-        @NotNull @PastOrPresent // 미래 날짜의 지출 입력 방지 — 오늘까지만 허용
+        @NotNull @PastOrPresent
         LocalDate date,
 
         @Size(max = 300)
-        String memo // 빈 문자열/null이면 저장하지 않음(정규화는 서비스 계층에서)
+        String memo
 ) {
 
-    /** ExpenseCreateRequest.isCategoryConsistent()와 동일 규칙 */
     @AssertTrue(message = "category가 ETC일 때만 customCategory를 입력할 수 있습니다.")
     public boolean isCategoryConsistent() {
         boolean hasCustomCategory = customCategory != null && !customCategory.isBlank();
         return (category == ExpenseCategory.ETC) == hasCustomCategory;
     }
 
-    /** ExpenseCreateRequest.isEmotionConsistent()와 동일 규칙 */
     @AssertTrue(message = "emotion이 ETC일 때만 customEmotion을 입력할 수 있습니다.")
     public boolean isEmotionConsistent() {
         boolean hasCustomEmotion = customEmotion != null && !customEmotion.isBlank();

--- a/src/main/java/Hampouch/server/domain/expense/dto/NoSpendRecordRequest.java
+++ b/src/main/java/Hampouch/server/domain/expense/dto/NoSpendRecordRequest.java
@@ -5,7 +5,6 @@ import jakarta.validation.constraints.PastOrPresent;
 
 import java.time.LocalDate;
 
-/** '오늘은 안 썼어요'를 기록할 날짜. */
 public record NoSpendRecordRequest(
         @NotNull
         @PastOrPresent

--- a/src/main/java/Hampouch/server/domain/expense/entity/Expense.java
+++ b/src/main/java/Hampouch/server/domain/expense/entity/Expense.java
@@ -12,16 +12,11 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
-/**
- * 지출 1건(사용자가 직접 입력한 식비 지출 기록). 금액은 0원 이상.
- * name은 null 허용. category/emotion은 건너뛰어도 컬럼 자체는 NOT NULL로 유지 및 ETC 흡수
- * ETC로 Enum을 설정해야 분석 집계가 null 케이스를 추가로 신경 쓸 필요가 없다.
- */
+/** 지출 1건. name은 null 허용, category/emotion은 건너뛰면 ETC로 흡수(컬럼은 NOT NULL 유지). */
 @Getter // 변경은 아래 도메인 메서드(assignCustomCategory 등)로만 허용
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-// 지출 조회는 전부 (유저, 날짜, 상태) 조합으로 들어오는데 자동으로 생기는 인덱스는 FK인 user_id 하나뿐이라,
-// 인덱스가 없으면 그 유저의 누적 지출을 전부 훑은 뒤 날짜·상태로 거르게 되어 비용이 누적 건수에 비례해 자란다.
+// 조회가 항상 (유저, 날짜, 상태) 조합이라 복합 인덱스 필요 — FK 인덱스(user_id)만으론 전체 스캔됨
 @Table(name = "expense",
         indexes = @Index(name = "idx_expense_user_date_status", columnList = "user_id, expense_date, status"))
 @EntityListeners(AuditingEntityListener.class) // 저장 직전 @CreatedDate/@LastModifiedDate를 자동 채움
@@ -48,10 +43,10 @@ public class Expense {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private ExpenseStatus status; // soft delete용 상태 플래그 — @SQLDelete/@Where 매직 대신 명시적 status 필드로 처리
+    private ExpenseStatus status; // soft delete 플래그(명시적 필드, @SQLDelete 안 씀)
 
     @Column(nullable = false, name = "expense_date")
-    private LocalDate expenseDate; // 컬럼명을 expense_date로 명시한 이유: MySQL 예약어 date와 충돌 회피. DTO(JSON)에서는 date로 노출
+    private LocalDate expenseDate; // date는 MySQL 예약어라 컬럼명은 expense_date, DTO는 date로 노출
 
     @CreatedDate
     @Column(nullable = false, name = "created_at")
@@ -74,8 +69,7 @@ public class Expense {
     private Expense(String name, int price, ExpenseCategory category, ExpenseEmotion emotion, LocalDate expenseDate, User user) {
         this.name = name;
         this.price = price;
-        // 카테고리/이유를 건너뛰면 null이 아니라 ETC로 흡수한다. 컬럼은 계속 NOT NULL로 유지
-        // 미분류를 나타내는 값을 ETC에 통합, 분석 집계 시 해당 지출도 통계 조회가 가능하도록.
+        // null이면 ETC로 흡수(컬럼은 NOT NULL 유지)
         this.category = category != null ? category : ExpenseCategory.ETC;
         this.emotion = emotion != null ? emotion : ExpenseEmotion.ETC;
         this.expenseDate = expenseDate;
@@ -83,19 +77,12 @@ public class Expense {
         this.status = ExpenseStatus.ACTIVE; // 생성 시점엔 항상 ACTIVE
     }
 
-    /**
-     * private 생성자 대신 정적 팩토리를 노출한 이유: status 기본값(ACTIVE) 강제, customCategory/customEmotion은
-     * 생성 시점엔 항상 null이라는 계약을 이름으로 드러내기 위함.
-     */
+    /** 정적 팩토리 — status=ACTIVE 강제, custom*는 항상 null로 시작. */
     public static Expense of(String name, int price, ExpenseCategory category, ExpenseEmotion emotion, LocalDate expenseDate, User user) {
         return new Expense(name, price, category, emotion, expenseDate, user);
     }
 
-    /**
-     * 커스텀 카테고리 태그 기록/해제. category의 Enum value가 ETC가 아니면 커스텀 값을 가질 수 없다
-     * category=ETC ↔ customCategory 존재 여부 일관성은 DTO(@AssertTrue)에서 이미 검증됐다고 전제 — 여기선 그 전제가
-     * 깨진 채로(=코드 버그로) 호출되는 경우만 즉시 잡아낸다(IllegalArgumentException으로 catch).
-     */
+    /** category≠ETC면 customCategory를 가질 수 없음(DTO에서 이미 검증됨 — 여기선 방어적 체크). */
     public void assignCustomCategory(String customCategory) {
         if (category != ExpenseCategory.ETC && customCategory != null) {
             throw new IllegalArgumentException("category가 ETC가 아니면 customCategory를 기록할 수 없음: " + category);
@@ -111,15 +98,12 @@ public class Expense {
         this.customEmotion = customEmotion;
     }
 
-    /** 소유권 검증 — 서비스 계층에서 조회 직후 호출해 EXPENSE_FORBIDDEN 판단에 사용. */
+    /** 소유권 검증(EXPENSE_FORBIDDEN 판단용). */
     public boolean isOwnedBy(Long userId) {
         return this.user.getId().equals(userId);
     }
 
-    /**
-     * PUT /expenses/{expenseId} — user/status/createdAt은 손대지 않음(귀속·삭제상태·최초생성시각은 수정 대상 아님).
-     * customCategory/customEmotion은 여기서 건드리지 않는다 — assignCustomCategory/assignCustomEmotion과 책임을 분리
-     */
+    /** PUT /expenses/{expenseId} — user/status/createdAt은 유지, custom*는 별도 메서드 책임. */
     public void update(String name, int price, ExpenseCategory category, ExpenseEmotion emotion, LocalDate expenseDate) {
         this.name = name;
         this.price = price;

--- a/src/main/java/Hampouch/server/domain/expense/entity/ExpenseCategory.java
+++ b/src/main/java/Hampouch/server/domain/expense/entity/ExpenseCategory.java
@@ -5,12 +5,7 @@ import lombok.RequiredArgsConstructor;
 
 import java.util.Arrays;
 
-/**
- * 지출 카테고리. 확정 7종 + ETC(직접 입력) — 온보딩 챌린지의 약한 카테고리 선택지와 동일한 7종을 그대로 사용
- * (ChallengeWeakCategory와 목록 일치, ERD 확정).
- * label은 화면 표시용 한글 명칭 — customCategory 중복 검사(ExpenseErrorCode.EXPENSE_CUSTOM_CATEGORY_NAME_DUPLICATED)도
- * enum value가 아니라 이 라벨과 비교해야 실제로 의미 있는 검사가 됨.
- */
+/** 지출 카테고리 7종 + ETC(직접 입력). label은 화면 표시용이자 customCategory 중복 검사 기준. */
 @Getter
 @RequiredArgsConstructor
 public enum ExpenseCategory {
@@ -22,11 +17,11 @@ public enum ExpenseCategory {
     GROCERY("장보기"),
     DESSERT("간식"),
     DRINKING("술자리"),
-    ETC("직접 입력"); // ETC일 땐 실제 화면엔 이 라벨 대신 customCategory 값이 노출됨(GET /expenses/day 응답 예시 기준) — 이 라벨은 fallback/내부 비교용
+    ETC("직접 입력");
 
     private final String label;
 
-    /** customCategory 입력값이 내장 카테고리 라벨과 이름이 겹치는지 확인 — 중복 검사에 사용. */
+    /** customCategory 중복 검사. */
     public static boolean isReservedLabel(String text) {
         return Arrays.stream(values()).anyMatch(c -> c.label.equals(text));
     }

--- a/src/main/java/Hampouch/server/domain/expense/entity/ExpenseDetail.java
+++ b/src/main/java/Hampouch/server/domain/expense/entity/ExpenseDetail.java
@@ -7,27 +7,21 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicUpdate;
 
 /**
- * 지출 1건의 부가 정보. memo/이미지가 하나도 없는 지출이 더 많을 걸 감안해, Expense가 생성될 때 무조건 같이 만들지 않고
- * 실제로 memo나 이미지가 들어올 때만 생성되는 진짜 optional 1:1 관계로 둔다
- * (그래서 조회는 항상 findByExpenseId(Optional)를 거친다 — ExpenseDetailRepository 참고).
- * PK를 expense_id와 공유한 이유: 지출 1건당 상세 최대 1건 제약을 직접적으로 강제하기 위함.
+ * 지출 1건의 부가 정보(memo/이미지). 하나라도 있을 때만 생성되는 진짜 optional 1:1 — 조회는 항상 Optional.
+ * PK를 expense_id와 공유해 지출당 상세 최대 1건을 강제한다.
  */
 @Getter
 @Entity
-@DynamicUpdate // updateMemo/attachImage/removeImage가 매번 전체 컬럼을 UPDATE하지 않고 실제로 바뀐 컬럼만 반영하도록
+@DynamicUpdate // 바뀐 컬럼만 UPDATE
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "expense_detail")
 public class ExpenseDetail {
 
     @Id
     @Column(name = "expense_id")
-    private Long expenseId; // PK이자 FK — @MapsId로 Expense.id와 항상 동일하게 유지됨(JPA가 자동 동기화)
+    private Long expenseId; // PK=FK, @MapsId로 Expense.id와 동기화
 
-    /**
-     * optional = false: expense_detail은 expense 없이 존재할 수 없는 자식 — Expense 쪽에는 역참조 필드를 두지 않는다
-     * (Expense는 목록/분석 API에서 훨씬 자주 조회되는데, 거기에 지연로딩이라도 참조를 얹으면 실수로 N+1을
-     * 유발하기 쉬워 의존 방향을 ExpenseDetail → Expense 단방향으로만 유지).
-     */
+    /** Expense 쪽엔 역참조를 안 둔다 — 더 자주 조회되는 Expense에 N+1 위험을 얹지 않기 위해 단방향 유지. */
     @OneToOne(fetch = FetchType.LAZY, optional = false)
     @MapsId
     @JoinColumn(name = "expense_id")
@@ -44,12 +38,6 @@ public class ExpenseDetail {
         this.memo = memo;
     }
 
-    /**
-     * 정적 팩토리 하나만 공개 통로로 둔 이유: memo만 받고 이미지 필드는 항상 null로 시작한다는 계약 명시
-     * 이미지는 attachImage()로만 채워짐, PATCH .../photos 전용 경로.
-     * 호출부(ExpenseService/ExpenseImageService)가 memo/imageKey 둘 다 없을 때는 이 팩토리 자체를
-     * 호출하지 않을 책임을 진다
-     */
     public static ExpenseDetail of(Expense expense, String memo) {
         return new ExpenseDetail(expense, memo);
     }

--- a/src/main/java/Hampouch/server/domain/expense/entity/ExpenseEmotion.java
+++ b/src/main/java/Hampouch/server/domain/expense/entity/ExpenseEmotion.java
@@ -12,15 +12,15 @@ import java.util.Arrays;
 @RequiredArgsConstructor
 public enum ExpenseEmotion {
 
-    STRESS("스트레스"),          // 스트레스 해소
+    STRESS("스트레스"),
     COMPENSATION("보상"),
-    CONVENIENCE("귀찮아서"),        // 요리/장보기 대신 간편 소비 — LAZINESS 대신 완곡하게 표현
+    CONVENIENCE("귀찮아서"),
     IMPULSE("그냥 먹고 싶어서"),
-    ETC("직접 입력");                 // ETC일 땐 실제 화면엔 이 라벨 대신 customEmotion 값이 노출됨 — 이 라벨은 fallback/내부 비교용
+    ETC("직접 입력");
 
     private final String label;
 
-    /** customEmotion 입력값이 내장 감정 라벨과 이름이 겹치는지 확인 — 중복 검사에 사용. */
+    /** customEmotion 중복 검사. */
     public static boolean isReservedLabel(String text) {
         return Arrays.stream(values()).anyMatch(e -> e.label.equals(text));
     }

--- a/src/main/java/Hampouch/server/domain/expense/entity/ExpenseStatus.java
+++ b/src/main/java/Hampouch/server/domain/expense/entity/ExpenseStatus.java
@@ -1,9 +1,6 @@
 package Hampouch.server.domain.expense.entity;
 
-/**
- * 지출의 활성/삭제 상태. DELETE API는 물리 삭제 대신 status=DELETED로 처리하는 soft delete
- * 삭제 이력을 남기고, 조회 시 반드시 status=ACTIVE로 필터링해야 삭제된 지출이 목록/합계 계산에 섞여 들어가지 않는다.
- */
+/** 지출 활성/삭제 상태 — soft delete. 조회 시 반드시 ACTIVE로 필터링. */
 public enum ExpenseStatus {
 
     ACTIVE,

--- a/src/main/java/Hampouch/server/domain/expense/repository/ExpenseDetailRepository.java
+++ b/src/main/java/Hampouch/server/domain/expense/repository/ExpenseDetailRepository.java
@@ -5,10 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-/**
- * expense_detail은 expense_id를 PK로 공유하는 진짜 optional 1:1.,
- * findById 대신 findByExpenseId로 이름을 맞춰 Expense의 PK로 찾는다는 의도를 드러낸다.
- */
+/** expense_detail은 expense_id를 PK로 공유하는 optional 1:1 — findByExpenseId로 의도를 드러낸다. */
 public interface ExpenseDetailRepository extends JpaRepository<ExpenseDetail, Long> {
 
     Optional<ExpenseDetail> findByExpenseId(Long expenseId);

--- a/src/main/java/Hampouch/server/domain/expense/repository/ExpenseRepository.java
+++ b/src/main/java/Hampouch/server/domain/expense/repository/ExpenseRepository.java
@@ -10,20 +10,13 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
-/**
- * status를 항상 조건에 포함시키는 이유: Expense는 soft delete 대상이라 findById만 쓰면
- * 이미 삭제된 행이 그대로 조회, EXPENSE_NOT_FOUND를 내야 할 상황에서 삭제된 데이터를 return
- * loadOwned 시 반드시 findByIdAndStatus를 활용해야 함.
- */
+//조회 시 항상 status 조건 포함 */
 public interface ExpenseRepository extends JpaRepository<Expense, Long> {
 
-    /** 단건 조회(GET/PUT/DELETE 공통 진입점) — service의 loadOwned가 이걸로 조회 후 isOwnedBy로 소유권 검증. */
+    /** 단건 조회 — loadOwned가 조회 후 isOwnedBy로 소유권 검증. */
     Optional<Expense> findByIdAndStatus(Long id, ExpenseStatus status);
 
-    /**
-     * GET /expenses/day — 특정 유저의 특정 날짜 지출 목록, 삭제분 제외.
-     * ChallengeDayRepository의 언더스코어 경로 컨벤션과 동일(User_Id = user 연관관계를 타고 들어간 id).
-     */
+    /** GET /expenses/day — 특정 유저의 특정 날짜 지출 목록. */
     List<Expense> findByUser_IdAndExpenseDateAndStatus(Long userId, LocalDate expenseDate, ExpenseStatus status);
 
     /**
@@ -40,32 +33,18 @@ public interface ExpenseRepository extends JpaRepository<Expense, Long> {
     List<ExpenseDailyTotal> sumGroupedByDate(@Param("userId") Long userId, @Param("status") ExpenseStatus status,
                                               @Param("start") LocalDate start, @Param("end") LocalDate end);
 
-     /* Spring Data 파생 쿼리는 SUM 같은 집계를 지원하지 않아
-     * sumPriceByUserIdAndExpenseDateAndStatus를 @Query로 직접 작성하고, coalesce로 감싸 그 날짜에
-     * 지출이 하나도 없을 때도 null 대신 0을 반환하게 한다.
-     */
+    /* 파생 쿼리는 SUM 집계를 지원 안 해 @Query로 직접 작성 — coalesce로 지출 없을 때 null 대신 0 반환 */
     @Query("select coalesce(sum(e.price), 0) from Expense e "
             + "where e.user.id = :userId and e.expenseDate = :date and e.status = :status")
     int sumPriceByUserIdAndExpenseDateAndStatus(@Param("userId") Long userId, @Param("date") LocalDate date, @Param("status") ExpenseStatus status);
 
-    /**
-     * ExpenseService.getDaySpending()에서 DaySpending.hasRecord를 채우는 용도 — 합계(sum)만으로는
-     * 그 날짜에 기록 자체가 없음과 그 날짜 기록의 합계가 0원임을 구분할 수 없어 별도 존재 확인 쿼리로 둔다.
-     */
+    /** getDaySpending()의 hasRecord용 — 합계만으론 "기록 없음"과 "합계 0원"을 구분 못해 별도 존재 쿼리로 둔다. */
     boolean existsByUser_IdAndExpenseDateAndStatus(Long userId, LocalDate expenseDate, ExpenseStatus status);
 
-    /**
-     * ExpenseService.delete()가 User.lastUpdated를 되돌릴 기준을 찾는 용도
-     * 지금 삭제 중인 지출을 뺀 나머지 지출 중 expenseDate가 가장 최근인 1건을 찾는다.
-     * -> 3일 이상 지출 기록이 비면 무효화라는 규칙은 지출 발생 날짜를 기준으로
-     * 지운 지출이 유일한 지출이었다면 서비스가 User.lastUpdated를 User.createdAt로 대신 되돌린다.
-     */
+    /** delete()가 User.lastUpdated 재계산 기준을 찾는 용도 — 삭제 중인 지출을 제외한 최신 ACTIVE 지출 1건. */
     Optional<Expense> findTopByUser_IdAndStatusAndIdNotOrderByExpenseDateDesc(Long userId, ExpenseStatus status, Long id);
 
-    /**
-     * ExpenseService.refreshLastUpdated()가 expense를 update() 이후 User.lastUpdated를 다시 계산할 때 쓰는 용도.
-     * delete()가 쓰는 AndIdNot 버전과 달리, 방금 생성/수정된 지출도 그대로 포함해서 계산해야 하므로 제외 조건이 없다.
-     */
+    /** refreshLastUpdated()용 — delete()의 IdNot 버전과 달리 방금 수정된 지출도 포함해서 계산. */
     Optional<Expense> findTopByUser_IdAndStatusOrderByExpenseDateDesc(Long userId, ExpenseStatus status);
 
     /**

--- a/src/main/java/Hampouch/server/domain/expense/service/ExpenseDetailAccess.java
+++ b/src/main/java/Hampouch/server/domain/expense/service/ExpenseDetailAccess.java
@@ -8,15 +8,9 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 
 /**
- * ExpenseDetail get-or-create를 attach()/updateMemo() 양쪽이 공유하는 동시성 안전 진입점.
- * 먼저 findByExpenseId로 조회하고, 없으면 ExpenseDetailInserter(REQUIRES_NEW)로 insert를 시도한다.
- * 동시에 다른 요청이 먼저 insert에 성공했다면 이 insert는 PK 충돌(DataIntegrityViolationException)로
- * 실패하는데, 그 예외는 삼키고 현재(바깥) 트랜잭션의 영속성 컨텍스트로 다시 findByExpenseId를 호출해
- * 상대가 만든 행을 가져온다.
- * insert()가 만든 엔티티를 직접 반환받아 재사용하지 않고 항상 재조회하는 이유: REQUIRES_NEW는 별도
- * 트랜잭션 = 별도 영속성 컨텍스트라서, 그 메서드가 만든 엔티티는 커밋과 동시에 detach된다.
- * detach된 엔티티를 바깥 트랜잭션에서 수정해봐야 flush되지 않으므로, 성공/실패 여부와 무관하게 항상
- * 현재 트랜잭션에서 다시 조회해 관리 상태(managed)인 엔티티를 돌려준다.
+ * ExpenseDetail get-or-create 동시성 가드 — attach()/updateMemo()가 공유.
+ * 없으면 ExpenseDetailInserter(REQUIRES_NEW)로 insert, PK 충돌은 삼키고 재조회한다.
+ * insert 결과를 재사용 안 하는 이유: REQUIRES_NEW는 별도 컨텍스트라 커밋과 동시에 detach되기 때문.
  */
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/Hampouch/server/domain/expense/service/ExpenseDetailInserter.java
+++ b/src/main/java/Hampouch/server/domain/expense/service/ExpenseDetailInserter.java
@@ -9,13 +9,9 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * ExpenseDetail이 없을 때 새로 insert만 담당하는 컴포넌트 — REQUIRES_NEW로 별도 트랜잭션에서 실행한다.
- * attach()/updateMemo()는 findByExpenseId로 없음을 확인한 뒤 insert하는 get-or-create 패턴인데,
- * 두 요청이 동시에 같은 expenseId에 대해 없음을 보고 나란히 insert를 시도하면
- * PK 유니크 제약 위반이 날 수 있다.
- * saveAndFlush로 즉시 flush해서 제약 위반이 있다면 이 메서드 안에서 바로 터지게 하고,
- * REQUIRES_NEW라 이 insert 시도만 롤백되며 호출부(ExpenseDetailAccess, 나아가 바깥 트랜잭션)는 영향받지 않는다 —
- * 그래야 ExpenseDetailAccess가 실패를 잡고 재조회로 안전하게 복구할 수 있다.
+ * ExpenseDetail insert 전담 — REQUIRES_NEW로 별도 트랜잭션에서 실행한다.
+ * 두 요청이 동시에 없음을 보고 나란히 insert하면 PK 충돌이 날 수 있어, saveAndFlush로 즉시 터뜨리고
+ * REQUIRES_NEW라 이 insert만 롤백돼 바깥 트랜잭션은 영향받지 않는다(ExpenseDetailAccess가 재조회로 복구).
  */
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/Hampouch/server/domain/expense/service/ExpenseImageService.java
+++ b/src/main/java/Hampouch/server/domain/expense/service/ExpenseImageService.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.*;
@@ -109,7 +110,10 @@ public class ExpenseImageService {
      * S3 HeadObject로 실제 업로드까지 확인한다. 통과하지 못하면 예외를 던지고, 통과하면 그냥 반환한다 —
      * URL은 더 이상 여기서 만들지 않는다(조회 시점에 presignGetUrl()로 별도 발급).
      * ExpenseService.create()가 imageKey를 받을 때도 그대로 호출한다.
+     * NOT_SUPPORTED로 클래스 기본 readOnly 트랜잭션을 덮어써 호출부의 트랜잭션(있다면 attach())까지 일시 중단시킨다 —
+     * DB를 전혀 안 건드리는 S3 HeadObject 호출 동안 커넥션 풀을 붙잡아두지 않기 위해서다(#149).
      */
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public void validateOwnedAndUploaded(Long userId, String imageKey) {
         String ownerPrefix = KEY_PREFIX + userId + "/";
         if (!imageKey.startsWith(ownerPrefix)) {

--- a/src/main/java/Hampouch/server/domain/expense/service/ExpenseImageService.java
+++ b/src/main/java/Hampouch/server/domain/expense/service/ExpenseImageService.java
@@ -11,7 +11,9 @@ import Hampouch.server.global.common.exception.CustomException;
 import Hampouch.server.global.common.exception.domain.ExpenseErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -55,6 +57,11 @@ public class ExpenseImageService {
     @Value("${aws.s3.region}")
     private String region;
 
+    /** attach()가 S3 확인 뒤 attachLocked()를 프록시로 재호출하기 위한 자기 참조 — 같은 빈 안의 this.호출은 @Transactional을 우회한다. */
+    @Lazy
+    @Autowired
+    private ExpenseImageService self;
+
     /**
      * POST /expenses/photos/presigned — 생성 전 업로드는 expenseId 없이, 기존 지출 교체는 expenseId와 함께.
      * key에 userId 접두어를 심어 소유권 위조를 attach()/create()가 접두어 비교만으로 걸러낼 수 있게 한다.
@@ -66,12 +73,17 @@ public class ExpenseImageService {
         return presignInternal(userId, request);
     }
 
-    /** PATCH /expenses/{expenseId}/photos — get-or-create는 ExpenseDetailAccess에 위임, 교체 시 옛 S3 객체 정리(실패해도 요청은 성공). */
-    @Transactional
+    /** PATCH /expenses/{expenseId}/photos — S3 확인을 트랜잭션 밖에서 먼저 끝낸 뒤 self로 attachLocked()를 호출한다. */
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public void attach(Long userId, Long expenseId, String imageKey) {
-        Expense expense = loadOwned(userId, expenseId);
         validateOwnedAndUploaded(userId, imageKey);
+        self.attachLocked(userId, expenseId, imageKey);
+    }
 
+    /** get-or-create는 ExpenseDetailAccess에 위임, 교체 시 옛 S3 객체 정리(실패해도 요청은 성공). imageKey 검증은 attach()가 이미 끝냈다. */
+    @Transactional
+    public void attachLocked(Long userId, Long expenseId, String imageKey) {
+        Expense expense = loadOwned(userId, expenseId);
         ExpenseDetail detail = expenseDetailAccess.getOrCreate(expense);
         String oldImageKey = detail.getImageKey();
         detail.attachImage(imageKey);

--- a/src/main/java/Hampouch/server/domain/expense/service/ExpenseImageService.java
+++ b/src/main/java/Hampouch/server/domain/expense/service/ExpenseImageService.java
@@ -28,12 +28,9 @@ import java.util.UUID;
 
 /**
  * 지출 이미지 presign 발급 + 업로드 반영/삭제/조회.
- * 단일 image upload 및 PATCH 단계에서 HeadObject로 실제 업로드 여부를 확인
- * imageUrl은 DB에 영구 저장하지 않는다 — 버킷이 완전 공개가 아니라 고정 URL을 저장해봐야 만료·권한 문제로
- * 실제로는 못 여는 링크가 될 수 있어서, 조회 시점마다 presignGetUrl()로 새 서명 URL을 발급한다
- * validateOwnedAndUploaded()는 이 서비스의 attach()뿐 아니라 ExpenseService.create()도 그대로 재사용한다 —
- * imageKey 소유권·업로드 여부를 검증하는 로직이 PATCH 경로와 생성 경로에서 중복되지 않도록.
- * ExpenseService를 의존하지 않고 ExpenseRepository로 직접 소유권을 확인하여 순환 참조 방지.
+ * imageUrl은 DB에 저장하지 않는다 — 조회 시점마다 presignGetUrl()로 새로 서명한다.
+ * validateOwnedAndUploaded()는 attach()와 ExpenseService.create()가 공유한다.
+ * ExpenseService를 의존하지 않고 ExpenseRepository로 직접 소유권을 확인해 순환 참조를 피한다.
  */
 @Slf4j
 @Service
@@ -59,10 +56,8 @@ public class ExpenseImageService {
     private String region;
 
     /**
-     * POST /expenses/photos/presigned — expenseId는 query param(선택). 지출 생성 전 업로드는 expenseId 없이,
-     * 기존 지출 이미지 교체는 expenseId를 실어 보내는 방식으로 경로 하나에 합쳤다.
-     * key에 userId를 접두어로 심어두는 이유: 다른 유저가 자기가 발급받지 않은 imageKey를 그대로 흉내내
-     * 남의 지출에 붙이려는 시도를, attach()/create() 쪽에서 접두어 비교만으로 걸러낼 수 있게 하기 위함.
+     * POST /expenses/photos/presigned — 생성 전 업로드는 expenseId 없이, 기존 지출 교체는 expenseId와 함께.
+     * key에 userId 접두어를 심어 소유권 위조를 attach()/create()가 접두어 비교만으로 걸러낼 수 있게 한다.
      */
     public ExpenseImagePresignResponse presign(Long userId, Long expenseId, ExpenseImagePresignRequest request) {
         if (expenseId != null) {
@@ -71,11 +66,7 @@ public class ExpenseImageService {
         return presignInternal(userId, request);
     }
 
-    /**
-     * PATCH /expenses/{expenseId}/photos — 없으면 새로 만들고, 있으면 attachImage()로 갱신(get-or-create).
-     * 기존에 다른 이미지가 붙어있었다면 교체 후 그 옛 S3 객체를 정리한다 — 실패해도 요청 자체는 성공 처리.
-     * get-or-create는 동시 요청 경쟁에 안전한 ExpenseDetailAccess에 위임한다.
-     */
+    /** PATCH /expenses/{expenseId}/photos — get-or-create는 ExpenseDetailAccess에 위임, 교체 시 옛 S3 객체 정리(실패해도 요청은 성공). */
     @Transactional
     public void attach(Long userId, Long expenseId, String imageKey) {
         Expense expense = loadOwned(userId, expenseId);
@@ -89,10 +80,7 @@ public class ExpenseImageService {
         }
     }
 
-    /**
-     * DELETE /expenses/{expenseId}/photos — 상세 행 자체가 없으면 할 일이 없어 그냥 성공 처리(멱등).
-     * DB 필드를 비우는 것과 별개로 실제 S3 객체도 지운다 — 안 지우면 버킷에 고아 객체가 계속 쌓인다.
-     */
+    /** DELETE /expenses/{expenseId}/photos — 상세 행 없으면 멱등 성공. DB 필드와 별개로 S3 객체도 지운다(안 지우면 고아 객체 누적). */
     @Transactional
     public void remove(Long userId, Long expenseId) {
         loadOwned(userId, expenseId);
@@ -106,12 +94,8 @@ public class ExpenseImageService {
     }
 
     /**
-     * imageKey가 이 userId 소유인지 접두어(expenses/{userId}/...)로 먼저 확인하고,
-     * S3 HeadObject로 실제 업로드까지 확인한다. 통과하지 못하면 예외를 던지고, 통과하면 그냥 반환한다 —
-     * URL은 더 이상 여기서 만들지 않는다(조회 시점에 presignGetUrl()로 별도 발급).
-     * ExpenseService.create()가 imageKey를 받을 때도 그대로 호출한다.
-     * NOT_SUPPORTED로 클래스 기본 readOnly 트랜잭션을 덮어써 호출부의 트랜잭션(있다면 attach())까지 일시 중단시킨다 —
-     * DB를 전혀 안 건드리는 S3 HeadObject 호출 동안 커넥션 풀을 붙잡아두지 않기 위해서다(#149).
+     * imageKey 소유권(접두어)과 S3 HeadObject 실제 업로드 여부를 확인 — attach()/create()가 공유.
+     * NOT_SUPPORTED로 호출부 트랜잭션을 일시 중단시켜, S3 호출 동안 DB 커넥션을 붙잡지 않는다.
      */
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public void validateOwnedAndUploaded(Long userId, String imageKey) {
@@ -127,11 +111,8 @@ public class ExpenseImageService {
     }
 
     /**
-     * GET /expenses/{expenseId} 응답에 실을 이미지 조회 URL을 그때그때 새로 서명해서 만든다.
-     * ExpenseDetail.imageKey는 DB에 저장돼 있지만 imageUrl은 저장하지 않으므로, 조회할 때마다 호출부
-     * (ExpenseService.getDetail())가 이 메서드로 새 URL을 받아 응답에 채워 넣는다.
-     * 여기서 소유권을 다시 검증하지 않는 이유: imageKey는 이미 owner의 ExpenseDetail 행에서 나온 값이고,
-     * 호출부가 loadOwned()로 지출 자체의 소유권을 이미 확인한 뒤에만 이 메서드를 호출하기 때문.
+     * getDetail() 응답용 이미지 조회 URL을 조회 시점마다 새로 서명한다(imageUrl은 저장 안 함).
+     * 소유권 재검증은 안 함 — 호출부가 loadOwned()로 이미 확인한 뒤에만 부른다는 전제.
      */
     public String presignGetUrl(String imageKey) {
         GetObjectRequest objectRequest = GetObjectRequest.builder()
@@ -193,7 +174,7 @@ public class ExpenseImageService {
         }
     }
 
-    /** 옛 이미지 정리 실패로 본 요청(교체/삭제)까지 실패시키지 않기 위해 예외를 삼키고 경고 로그만 남긴다. */
+    /** 정리 실패로 본 요청까지 실패시키지 않도록 예외를 삼키고 경고 로그만 남긴다. */
     private void deleteObjectSafely(String imageKey) {
         try {
             s3Client.deleteObject(DeleteObjectRequest.builder().bucket(bucket).key(imageKey).build());

--- a/src/main/java/Hampouch/server/domain/expense/service/ExpenseService.java
+++ b/src/main/java/Hampouch/server/domain/expense/service/ExpenseService.java
@@ -13,7 +13,10 @@ import Hampouch.server.global.common.exception.CustomException;
 import Hampouch.server.global.common.exception.domain.ExpenseErrorCode;
 import Hampouch.server.global.common.exception.domain.UserErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
@@ -41,12 +44,38 @@ public class ExpenseService {
     // 한국 시간 기준으로 통일 된 Bean 활용
 
     /**
+     * create()가 S3 확인 뒤 createLocked()를 프록시로 재호출해 트랜잭션 경계를 새로 열기 위한 자기 참조(#149).
+     * @RequiredArgsConstructor의 생성자 주입에 넣으면 @Lazy가 Lombok이 만든 생성자 파라미터로 복사되지 않아
+     * 순환 참조로 즉시 실패한다 — 그래서 이 필드만 예외적으로 필드 주입을 쓴다
+     */
+    @Lazy
+    @Autowired
+    private ExpenseService self;
+
+    /**
      * POST /expenses.
+     * imageKey가 있으면 S3 HeadObject 확인(ExpenseImageService.validateOwnedAndUploaded)을 트랜잭션·사용자 락을
+     * 잡기 전에 끝낸다(#149) — 그래야 S3 지연 시간만큼 사용자 행 잠금과 DB 커넥션이 묶이지 않는다.
+     * 확인 후에는 self(프록시)를 통해 createLocked()를 호출해야 그 메서드의 @Transactional이 실제로 적용된다
+     * (this.createLocked(...)로 부르면 자기 자신 호출이라 프록시를 우회해 트랜잭션이 안 걸린다).
+     */
+    @Transactional(propagation = Propagation.NOT_SUPPORTED) // 클래스 기본 readOnly 트랜잭션을 물려받지 않게 명시로 끊는다 —
+    // 안 그러면 createLocked()가 REQUIRED로 이 트랜잭션에 그냥 합류해 readOnly가 그대로 이어져 쓰기가 커밋 안 된다.
+    public ExpenseCreateResponse create(Long userId, ExpenseCreateRequest request) {
+        if (request.imageKey() != null) {
+            expenseImageService.validateOwnedAndUploaded(userId, request.imageKey());
+        }
+        return self.createLocked(userId, request);
+    }
+
+    /**
      * 사용자 행을 먼저 잠근 뒤 챌린지 기간 행을 잠가 종료 경로와 user → challenge 순서를 맞춘다.
      * getReferenceById()는 이미 잠근 사용자를 연관관계 프록시로만 연결한다.
+     * imageKey 검증은 create()가 이 메서드를 부르기 전에 이미 끝냈으므로 createDetailIfPresent()는 재검증하지 않는다.
+     * create()를 거치지 않는 직접 호출을 막을 이유는 없어 public으로 둔다(서비스 내부 전용이라 컨트롤러는 create()만 쓴다).
      */
     @Transactional
-    public ExpenseCreateResponse create(Long userId, ExpenseCreateRequest request) {
+    public ExpenseCreateResponse createLocked(Long userId, ExpenseCreateRequest request) {
         userOperationLock.lock(userId);
         validateExpenseChangeAllowed(userId, request.date());
 
@@ -58,7 +87,7 @@ public class ExpenseService {
         attachCustomTags(expense, request.category(), request.customCategory(), request.emotion(), request.customEmotion());
 
         Expense saved = expenseRepository.save(expense);
-        createDetailIfPresent(userId, saved, request.memo(), request.imageKey());
+        createDetailIfPresent(saved, request.memo(), request.imageKey());
         noSpendDayRepository.deleteByUser_IdAndRecordDate(userId, request.date());
         return ExpenseCreateResponse.from(saved);
     }
@@ -278,19 +307,17 @@ public class ExpenseService {
 
     /**
      * memo·imageKey 중 하나라도 있을 때만 ExpenseDetail을 만든다
-     * imageKey가 오면 presign만 거친 값이라 ExpenseImageService.validateOwnedAndUploaded()로 소유권(#4)과
-     * S3 HeadObject 실제 업로드 여부까지 거쳐야 신뢰할 수 있다
-     * (PATCH /expenses/{expenseId}/photos와 동일한 검증 지점 재사용).
+     * imageKey의 소유권(#4)·S3 HeadObject 실제 업로드 여부 검증은 create()가 이 메서드를 부르기 전에
+     * 사용자 락 밖에서 이미 끝냈으므로(#149) 여기서는 재검증하지 않고 그대로 붙인다.
      * imageUrl은 더 이상 여기서 만들지 않는다 — getDetail() 조회 시점에 presignGetUrl()로 새로 발급(#6).
      */
-    private void createDetailIfPresent(Long userId, Expense expense, String memo, String imageKey) {
+    private void createDetailIfPresent(Expense expense, String memo, String imageKey) {
         boolean hasMemo = memo != null && !memo.isBlank();
         if (!hasMemo && imageKey == null) {
             return;
         }
         ExpenseDetail detail = ExpenseDetail.of(expense, hasMemo ? memo : null);
         if (imageKey != null) {
-            expenseImageService.validateOwnedAndUploaded(userId, imageKey);
             detail.attachImage(imageKey);
         }
         expenseDetailRepository.save(detail);

--- a/src/main/java/Hampouch/server/domain/expense/service/ExpenseService.java
+++ b/src/main/java/Hampouch/server/domain/expense/service/ExpenseService.java
@@ -24,12 +24,9 @@ import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
 
-/**
- * 지출 생성·조회·수정·삭제와 '오늘은 안 썼어요' 날짜 기록 API의 서비스 계층.
- */
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true) // 기본은 읽기 전용 — 쓰기 메서드만 개별적으로 @Transactional로 덮어씀(ChallengeService와 동일 컨벤션)
+@Transactional(readOnly = true)
 public class ExpenseService {
 
     private final ExpenseRepository expenseRepository;
@@ -38,29 +35,18 @@ public class ExpenseService {
     private final ExpenseDateLockQuery expenseDateLockQuery;
     private final UserOperationLock userOperationLock;
     private final UserRepository userRepository;
-    private final ExpenseImageService expenseImageService; // create()의 imageKey 검증(HeadObject)에 재사용
-    private final ExpenseDetailAccess expenseDetailAccess; // updateMemo()의 get-or-create 동시성 경쟁 방지(#8)
-    private final Clock clock; //buildSummary()가 dailyAverage 계산 시 오늘까지 경과일수를 구하기 위한 기준
-    // 한국 시간 기준으로 통일 된 Bean 활용
+    private final ExpenseImageService expenseImageService;
+    private final ExpenseDetailAccess expenseDetailAccess;
+    private final Clock clock;
 
-    /**
-     * create()가 S3 확인 뒤 createLocked()를 프록시로 재호출해 트랜잭션 경계를 새로 열기 위한 자기 참조(#149).
-     * @RequiredArgsConstructor의 생성자 주입에 넣으면 @Lazy가 Lombok이 만든 생성자 파라미터로 복사되지 않아
-     * 순환 참조로 즉시 실패한다 — 그래서 이 필드만 예외적으로 필드 주입을 쓴다
-     */
+    /** create()가 S3 확인 뒤 createLocked()를 프록시로 재호출하기 위한 자기 참조
+     *  @Lazy는 생성자 주입에 복사 안 돼 필드 주입을 쓴다. */
     @Lazy
     @Autowired
     private ExpenseService self;
 
-    /**
-     * POST /expenses.
-     * imageKey가 있으면 S3 HeadObject 확인(ExpenseImageService.validateOwnedAndUploaded)을 트랜잭션·사용자 락을
-     * 잡기 전에 끝낸다(#149) — 그래야 S3 지연 시간만큼 사용자 행 잠금과 DB 커넥션이 묶이지 않는다.
-     * 확인 후에는 self(프록시)를 통해 createLocked()를 호출해야 그 메서드의 @Transactional이 실제로 적용된다
-     * (this.createLocked(...)로 부르면 자기 자신 호출이라 프록시를 우회해 트랜잭션이 안 걸린다).
-     */
-    @Transactional(propagation = Propagation.NOT_SUPPORTED) // 클래스 기본 readOnly 트랜잭션을 물려받지 않게 명시로 끊는다 —
-    // 안 그러면 createLocked()가 REQUIRED로 이 트랜잭션에 그냥 합류해 readOnly가 그대로 이어져 쓰기가 커밋 안 된다.
+    /** POST /expenses. imageKey가 있으면 S3 확인을 트랜잭션·사용자 락 밖에서 먼저 끝낸 뒤 self로 createLocked()를 호출. */
+    @Transactional(propagation = Propagation.NOT_SUPPORTED) // 클래스 기본 readOnly 트랜잭션을 물려받지 않기 위함
     public ExpenseCreateResponse create(Long userId, ExpenseCreateRequest request) {
         if (request.imageKey() != null) {
             expenseImageService.validateOwnedAndUploaded(userId, request.imageKey());
@@ -68,12 +54,7 @@ public class ExpenseService {
         return self.createLocked(userId, request);
     }
 
-    /**
-     * 사용자 행을 먼저 잠근 뒤 챌린지 기간 행을 잠가 종료 경로와 user → challenge 순서를 맞춘다.
-     * getReferenceById()는 이미 잠근 사용자를 연관관계 프록시로만 연결한다.
-     * imageKey 검증은 create()가 이 메서드를 부르기 전에 이미 끝냈으므로 createDetailIfPresent()는 재검증하지 않는다.
-     * create()를 거치지 않는 직접 호출을 막을 이유는 없어 public으로 둔다(서비스 내부 전용이라 컨트롤러는 create()만 쓴다).
-     */
+    /** 사용자 행부터 잠근 뒤 챌린지 기간 행을 잠가 종료 경로와 순서를 맞춘다. imageKey 검증은 create()가 이미 끝냈다. */
     @Transactional
     public ExpenseCreateResponse createLocked(Long userId, ExpenseCreateRequest request) {
         userOperationLock.lock(userId);
@@ -116,10 +97,7 @@ public class ExpenseService {
         noSpendDayRepository.save(NoSpendDay.of(user, request.date()));
     }
 
-    /**
-     * GET /expenses/{expenseId}.
-     * imageUrl은 DB에 저장된 값이 아니라 imageKey가 있을 때만 그때그때 presignGetUrl()로 새로 서명해서 채운다(#6).
-     */
+    /** GET /expenses/{expenseId}. imageUrl은 imageKey가 있을 때만 그때그때 presignGetUrl()로 서명해서 채운다. */
     public ExpenseDetailResponse getDetail(Long userId, Long expenseId) {
         Expense expense = loadOwned(userId, expenseId);
         ExpenseDetail detail = expenseDetailRepository.findByExpenseId(expenseId).orElse(null);
@@ -130,11 +108,8 @@ public class ExpenseService {
     }
 
     /**
-     * PUT /expenses/{expenseId}. ExpenseCreateRequest/Response를 그대로 재사용(두 DTO의 자체 Javadoc 참조).
-     * attachCustomTags를 매번 다시 호출하는 이유는 Expense.update() Javadoc과 동일 — category/emotion이 ETC에서
-     * 다른 값으로(또는 그 반대로) 바뀌었을 수 있어 customCategory/customEmotion을 매번 새 상태 기준으로 재확정해야 함.
-     * 날짜 검증은 기존 날짜·새 날짜 둘 다 대상으로 수행(락 순서를 보장하기 위해 항상 이른 날짜부터) —
-     * 기존 지출의 이미지 교체는 presign+PATCH /expenses/{expenseId}/photos 전용 흐름으로만
+     * PUT /expenses/{expenseId}. attachCustomTags는 매번 다시 호출 — category/emotion이 ETC 안팎으로 바뀔 수 있어서.
+     * 날짜 검증은 기존·새 날짜 둘 다 이른 순으로. 이미지 교체는 전용 API로만
      */
     @Transactional
     public ExpenseCreateResponse update(Long userId, Long expenseId, ExpenseUpdateRequest request) {
@@ -159,12 +134,7 @@ public class ExpenseService {
         return ExpenseCreateResponse.from(expense);
     }
 
-    /**
-     * DELETE /expenses/{expenseId} — 소프트 삭제(Expense.delete()), 물리 삭제 아님.
-     * 삭제 대상의 expenseDate가 현재 User.lastUpdated에 해당하는 expense일 수 있으므로,
-     * 그 경우에만 남은 ACTIVE 지출과 무지출 날짜 기록 중 가장 최근 날짜로 재계산한다.
-     * 둘 다 없으면 null로 되돌린다.
-     */
+    /** DELETE /expenses/{expenseId} — soft delete. 삭제 대상이 현재 lastUpdated 날짜면 남은 기록 중 최신 날짜로 재계산(없으면 null). */
     @Transactional
     public void delete(Long userId, Long expenseId) {
         userOperationLock.lock(userId);
@@ -186,12 +156,7 @@ public class ExpenseService {
         }
     }
 
-    /**
-     * User.lastUpdated를 ACTIVE 지출과 무지출 날짜 기록 중 가장 최근 날짜로 다시 계산해서 반영.
-     * update()가 수정 대상 지출의 기존 날짜 == 현재 lastUpdated인 경우에만 호출
-     * 두 기록이 모두 없으면 delete()와 동일하게 null로 되돌린다(계정 생성일로 대체하면 create()의
-     * null 초기값과 다시 모순이 생김).
-     */
+    /** lastUpdated를 남은 ACTIVE 지출·무지출 기록 중 최신 날짜로 재계산 — update()가 수정 대상의 기존 날짜==lastUpdated일 때만 호출. 둘 다 없으면 null. */
     private void refreshLastUpdated(User user) {
         LocalDate latestExpenseDate = expenseRepository
                 .findTopByUser_IdAndStatusOrderByExpenseDateDesc(user.getId(), ExpenseStatus.ACTIVE)
@@ -238,29 +203,19 @@ public class ExpenseService {
         return ExpenseSummaryResponse.of(periodStart, periodEnd, dailyTotals, LocalDate.now(clock));
     }
 
-    /**
-     * Challenge 도메인이 그 날짜에 기록이 있었는지만 물을 때 호출.
-     * 미입력 판정은 하루씩 거슬러 오르며 최대 3일을 확인하므로, 이 자리에서 getDaySpending()을 부르면
-     * 읽지도 않는 합계 쿼리가 홈 조회 한 번에 그 일수만큼 덧붙는다.
-     */
+    /** Challenge 도메인이 그 날짜 기록 존재 여부 확인 시 호출 */
     public boolean hasDayRecord(Long userId, LocalDate date) {
         return expenseRepository.existsByUser_IdAndExpenseDateAndStatus(userId, date, ExpenseStatus.ACTIVE)
                 || noSpendDayRepository.existsByUser_IdAndRecordDate(userId, date);
     }
 
-    /**
-     * Challenge 도메인이 일별 예산 초과 여부를 판단할 때 호출
-     * 특정 유저의 특정 날짜 ACTIVE 지출 합계(원)와 그 날짜에 기록 자체가 있었는지를 반환
-     */
+    /** Challenge 도메인의 일별 예산 초과 판단용 */
     public DaySpending getDaySpending(Long userId, LocalDate date) {
         int totalAmount = expenseRepository.sumPriceByUserIdAndExpenseDateAndStatus(userId, date, ExpenseStatus.ACTIVE);
         return new DaySpending(totalAmount, hasDayRecord(userId, date));
     }
 
-    /** GET/PUT/DELETE 공통 조회 진입점 — ChallengeService.loadOwned()와 동일한 이름/구조.
-     *  ExpenseStatus = DELETED인 Expense의 경우 실제로는 table 상에 존재하지만 사용자에게는 삭제된 것으로 인식되도록
-     *  CustomException 설정 X
-     */
+    /** GET/PUT/DELETE 공통 조회 진입점. DELETED 지출은 존재해도 EXPENSE_NOT_FOUND로 처리. */
     private Expense loadOwned(Long userId, Long expenseId) {
         Expense expense = expenseRepository.findByIdAndStatus(expenseId, ExpenseStatus.ACTIVE)
                 .orElseThrow(() -> new CustomException(ExpenseErrorCode.EXPENSE_NOT_FOUND));
@@ -270,10 +225,7 @@ public class ExpenseService {
         return expense;
     }
 
-    /**
-     * 최종 종료된 챌린지 기간 잠금(#50) — 유저가 결과 팝업에서 [챌린지 종료]를 누른 뒤에는 그 기간의
-     * 기록을 더 못 바꾼다. 수정·삭제뿐 아니라 생성·무지출 기록도 모두 그 기간의 기록을 바꾼다.
-     */
+    /** 최종 종료된 챌린지 기간 잠금 — 종료 후엔 그 기간 기록을 생성·수정·삭제·무지출 무엇도 못 바꾼다. */
     private void validateExpenseChangeAllowed(Long userId, LocalDate date) {
         if (expenseDateLockQuery.isExpenseChangeProhibited(userId, date)) {
             throw new CustomException(ExpenseErrorCode.EXPENSE_CHALLENGE_CLOSED);
@@ -289,10 +241,7 @@ public class ExpenseService {
         }
     }
 
-    /**
-     * category/emotion이 ETC일 때만 커스텀 태그 문자열을 기록하고, 그 외엔 명시적으로 null 해제
-     * EXPENSE_CUSTOM_*_NAME_DUPLICATED는 내장 enum 라벨(예약어)과의 충돌 전용 에러코드
-     */
+    /** category/emotion이 ETC일 때만 커스텀 태그를 기록, 그 외엔 명시적으로 null 해제. */
     private void attachCustomTags(Expense expense, ExpenseCategory category, String customCategoryName,
                                   ExpenseEmotion emotion, String customEmotionName) {
         if (category == ExpenseCategory.ETC && ExpenseCategory.isReservedLabel(customCategoryName)) {
@@ -305,12 +254,7 @@ public class ExpenseService {
         expense.assignCustomEmotion(emotion == ExpenseEmotion.ETC ? customEmotionName : null);
     }
 
-    /**
-     * memo·imageKey 중 하나라도 있을 때만 ExpenseDetail을 만든다
-     * imageKey의 소유권(#4)·S3 HeadObject 실제 업로드 여부 검증은 create()가 이 메서드를 부르기 전에
-     * 사용자 락 밖에서 이미 끝냈으므로(#149) 여기서는 재검증하지 않고 그대로 붙인다.
-     * imageUrl은 더 이상 여기서 만들지 않는다 — getDetail() 조회 시점에 presignGetUrl()로 새로 발급(#6).
-     */
+    /** memo·imageKey 중 하나라도 있을 때만 ExpenseDetail 생성 */
     private void createDetailIfPresent(Expense expense, String memo, String imageKey) {
         boolean hasMemo = memo != null && !memo.isBlank();
         if (!hasMemo && imageKey == null) {
@@ -334,8 +278,7 @@ public class ExpenseService {
                         detail -> detail.updateMemo(hasMemo ? memo : null),
                         () -> {
                             if (hasMemo) {
-                                // 없음을 본 두 요청이 동시에 각자 insert하면 PK(expense_id) 충돌이 날 수 있어
-                                // 동시성 안전 get-or-create(ExpenseDetailAccess)에 위임한다.
+                                // 동시 insert 경쟁 방지 — ExpenseDetailAccess에 위임
                                 expenseDetailAccess.getOrCreate(expense).updateMemo(memo);
                             }
                         }

--- a/src/test/java/Hampouch/server/domain/challenge/ChallengeConcurrencyMySqlTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/ChallengeConcurrencyMySqlTest.java
@@ -9,10 +9,12 @@ import Hampouch.server.domain.challenge.repository.ChallengeAdjustmentRepository
 import Hampouch.server.domain.challenge.repository.ChallengeRepository;
 import Hampouch.server.domain.challenge.service.ChallengeService;
 import Hampouch.server.domain.expense.dto.ExpenseUpdateRequest;
+import Hampouch.server.domain.expense.dto.NoSpendRecordRequest;
 import Hampouch.server.domain.expense.entity.Expense;
 import Hampouch.server.domain.expense.entity.ExpenseCategory;
 import Hampouch.server.domain.expense.entity.ExpenseEmotion;
 import Hampouch.server.domain.expense.repository.ExpenseRepository;
+import Hampouch.server.domain.expense.repository.NoSpendDayRepository;
 import Hampouch.server.domain.expense.service.ExpenseService;
 import Hampouch.server.domain.rest.dto.*;
 import Hampouch.server.domain.rest.entity.UserRest;
@@ -66,6 +68,8 @@ class ChallengeConcurrencyMySqlTest {
     UserRestRepository userRestRepository;
     @Autowired
     ExpenseRepository expenseRepository;
+    @Autowired
+    NoSpendDayRepository noSpendDayRepository;
     @Autowired
     UserRepository userRepository;
     @Autowired
@@ -300,6 +304,60 @@ class ChallengeConcurrencyMySqlTest {
         assertThat(outcomes.second().succeeded()).isTrue();
         assertThat(expenseRepository.findById(expense.getId()).orElseThrow().getPrice()).isEqualTo(99000);
         assertThat(challengeRepository.findById(challenge.getId()).orElseThrow().isClosed()).isTrue();
+    }
+
+    @Test
+    @DisplayName("미입력 자동 취소 판정이 무지출 기록보다 먼저 사용자 행을 잠그면, 그 기록을 못 본 채 자동 취소로 끝나고 기록 자체는 취소 커밋 뒤에도 그대로 반영된다")
+    void autoCancelEvaluationPrecedesNoSpendRecording() throws Exception {
+        User user = newUser("auto-cancel-first");
+        LocalDate today = today();
+        LocalDate missingDate = today.minusDays(1);
+        Challenge challenge = newChallenge(user.getId(), 14, today.minusDays(7), 140000);
+
+        OrderedRace<CurrentChallengeResponse, Void> outcomes = orderedRace(
+                () -> challengeService.getCurrent(user.getId()),
+                () -> {
+                    expenseService.recordNoSpend(user.getId(), new NoSpendRecordRequest(missingDate));
+                    return null;
+                });
+
+        assertThat(outcomes.secondWasBlocked()).isTrue();
+        assertThat(outcomes.first().succeeded()).isTrue();
+        assertThat(outcomes.first().value().expenseInputState()).isEqualTo(ExpenseInputState.AUTO_CANCELLED);
+        assertThat(outcomes.second().succeeded()).isTrue();
+
+        Challenge reloaded = challengeRepository.findById(challenge.getId()).orElseThrow();
+        assertThat(reloaded.getStatus()).isEqualTo(ChallengeStatus.VOID);
+        assertThat(reloaded.getEndReason()).isEqualTo(EndReason.MISSING_DAILY_INPUT);
+        assertThat(noSpendDayRepository.existsByUser_IdAndRecordDate(user.getId(), missingDate)).isTrue();
+        assertThat(userRepository.findById(user.getId()).orElseThrow().getLastUpdated()).isEqualTo(missingDate);
+    }
+
+    @Test
+    @DisplayName("무지출 기록이 미입력 자동 취소 판정보다 먼저 사용자 행을 잠그면, 판정은 그 기록을 보고 진행 중 상태를 유지한다")
+    void noSpendRecordingPrecedesAutoCancelEvaluation() throws Exception {
+        User user = newUser("no-spend-first-vs-cancel");
+        LocalDate today = today();
+        LocalDate missingDate = today.minusDays(1);
+        Challenge challenge = newChallenge(user.getId(), 14, today.minusDays(7), 140000);
+
+        OrderedRace<Void, CurrentChallengeResponse> outcomes = orderedRace(
+                () -> {
+                    expenseService.recordNoSpend(user.getId(), new NoSpendRecordRequest(missingDate));
+                    return null;
+                },
+                () -> challengeService.getCurrent(user.getId()));
+
+        assertThat(outcomes.secondWasBlocked()).isTrue();
+        assertThat(outcomes.first().succeeded()).isTrue();
+        assertThat(outcomes.second().succeeded()).isTrue();
+        assertThat(outcomes.second().value().expenseInputState()).isEqualTo(ExpenseInputState.NORMAL);
+
+        Challenge reloaded = challengeRepository.findById(challenge.getId()).orElseThrow();
+        assertThat(reloaded.getStatus()).isEqualTo(ChallengeStatus.IN_PROGRESS);
+        assertThat(reloaded.getEndReason()).isNull();
+        assertThat(noSpendDayRepository.existsByUser_IdAndRecordDate(user.getId(), missingDate)).isTrue();
+        assertThat(userRepository.findById(user.getId()).orElseThrow().getLastUpdated()).isEqualTo(missingDate);
     }
 
     private CreateChallengeRequest createRequest(LocalDate startDate, int budgetTotal) {

--- a/src/test/java/Hampouch/server/domain/expense/ExpenseImageTransactionBoundaryTest.java
+++ b/src/test/java/Hampouch/server/domain/expense/ExpenseImageTransactionBoundaryTest.java
@@ -1,0 +1,96 @@
+package Hampouch.server.domain.expense;
+
+import Hampouch.server.domain.expense.dto.ExpenseCreateRequest;
+import Hampouch.server.domain.expense.entity.Expense;
+import Hampouch.server.domain.expense.entity.ExpenseCategory;
+import Hampouch.server.domain.expense.entity.ExpenseEmotion;
+import Hampouch.server.domain.expense.repository.ExpenseRepository;
+import Hampouch.server.domain.expense.service.ExpenseImageService;
+import Hampouch.server.domain.expense.service.ExpenseService;
+import Hampouch.server.domain.user.entity.User;
+import Hampouch.server.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+
+import java.time.LocalDate;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * imageKey 검증(S3 HeadObject)이 실제로 트랜잭션 밖에서 실행되는지 단언한다.
+ * - 실제 프록시를 거치는 @SpringBootTest에서 S3 호출 시점의 TransactionSynchronizationManager 상태로 직접 확인.
+ */
+@SpringBootTest
+class ExpenseImageTransactionBoundaryTest {
+
+    @Autowired
+    ExpenseService expenseService;
+    @Autowired
+    ExpenseImageService expenseImageService;
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    ExpenseRepository expenseRepository;
+
+    @MockitoBean
+    S3Client s3Client;
+
+    @Test
+    @DisplayName("create()의 imageKey 검증(S3 HeadObject)은 트랜잭션이 시작되기 전에 실행된다")
+    void createValidatesImageKeyOutsideTransaction() {
+        User user = userRepository.saveAndFlush(User.createLocalUser(
+                "image-boundary-create@hampouch.test", "encoded", "이미지경계생성"));
+        String imageKey = "expenses/" + user.getId() + "/abc.jpg";
+        AtomicBoolean transactionActiveDuringS3Call = new AtomicBoolean(true);
+        when(s3Client.headObject(any(HeadObjectRequest.class))).thenAnswer(invocation -> {
+            transactionActiveDuringS3Call.set(TransactionSynchronizationManager.isActualTransactionActive());
+            return HeadObjectResponse.builder().build();
+        });
+
+        expenseService.create(user.getId(), request(imageKey));
+
+        assertThat(transactionActiveDuringS3Call).isFalse();
+    }
+
+    @Test
+    @DisplayName("attach()의 imageKey 검증(S3 HeadObject)은 트랜잭션이 시작되기 전에 실행된다")
+    void attachValidatesImageKeyOutsideTransaction() {
+        User user = userRepository.saveAndFlush(User.createLocalUser(
+                "image-boundary-attach@hampouch.test", "encoded", "이미지경계첨부"));
+        Expense expense = expenseRepository.saveAndFlush(Expense.of(
+                "점심", 8000, ExpenseCategory.CAFE, ExpenseEmotion.STRESS, LocalDate.of(2026, 8, 12), user));
+        String imageKey = "expenses/" + user.getId() + "/abc.jpg";
+        AtomicBoolean transactionActiveDuringS3Call = new AtomicBoolean(true);
+        when(s3Client.headObject(any(HeadObjectRequest.class))).thenAnswer(invocation -> {
+            transactionActiveDuringS3Call.set(TransactionSynchronizationManager.isActualTransactionActive());
+            return HeadObjectResponse.builder().build();
+        });
+
+        expenseImageService.attach(user.getId(), expense.getId(), imageKey);
+
+        assertThat(transactionActiveDuringS3Call).isFalse();
+    }
+
+    private ExpenseCreateRequest request(String imageKey) {
+        return new ExpenseCreateRequest(
+                "점심",
+                8000,
+                ExpenseCategory.CAFE,
+                null,
+                ExpenseEmotion.STRESS,
+                null,
+                LocalDate.of(2026, 8, 12),
+                null,
+                imageKey);
+    }
+}

--- a/src/test/java/Hampouch/server/domain/expense/ExpenseNoSpendConsistencyMySqlTest.java
+++ b/src/test/java/Hampouch/server/domain/expense/ExpenseNoSpendConsistencyMySqlTest.java
@@ -41,6 +41,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class ExpenseNoSpendConsistencyMySqlTest {
 
     private static final LocalDate RECORD_DATE = LocalDate.of(2026, 8, 12);
+    private static final LocalDate OLDEST_DATE = RECORD_DATE.minusDays(10);
+    private static final LocalDate MIDDLE_DATE = RECORD_DATE.minusDays(5);
 
     @Autowired
     ExpenseService expenseService;
@@ -180,12 +182,150 @@ class ExpenseNoSpendConsistencyMySqlTest {
         }
     }
 
+    @Test
+    @DisplayName("최신 지출 삭제가 먼저 사용자 행을 잠그면, 중간 날짜 지출 생성은 삭제가 되돌린 lastUpdated 위로 다시 전진시킨다")
+    void createWaitsForDeleteAndAdvancesLastUpdatedFromRecomputedFallback() throws Exception {
+        User user = saveUser("delete-then-create", "삭제후생성");
+        SeededExpenses seeded = seedOldestAndLatestExpenses(user);
+        LockPause pause = pauseFirstLock(user.getId());
+
+        try (ExecutorService executor = Executors.newFixedThreadPool(2)) {
+            try {
+                Future<?> deleteFuture = executor.submit(() -> expenseService.delete(user.getId(), seeded.latest().getId()));
+                assertThat(pause.firstLocked().await(5, TimeUnit.SECONDS)).isTrue();
+
+                Future<ExpenseCreateResponse> createFuture = executor.submit(() ->
+                        expenseService.create(user.getId(), request("중간 지출", MIDDLE_DATE)));
+                assertThat(pause.twoAttempts().await(5, TimeUnit.SECONDS)).isTrue();
+                assertBlocked(createFuture);
+
+                pause.release();
+                deleteFuture.get(5, TimeUnit.SECONDS);
+                ExpenseCreateResponse created = createFuture.get(5, TimeUnit.SECONDS);
+
+                assertThat(expenseRepository.findById(seeded.latest().getId()).orElseThrow().getStatus())
+                        .isEqualTo(ExpenseStatus.DELETED);
+                assertThat(expenseRepository.findById(created.expenseId()).orElseThrow().getStatus())
+                        .isEqualTo(ExpenseStatus.ACTIVE);
+                assertThat(userRepository.findById(user.getId()).orElseThrow().getLastUpdated())
+                        .isEqualTo(MIDDLE_DATE);
+            } finally {
+                pause.release();
+                executor.shutdownNow();
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("중간 날짜 지출 생성이 먼저 사용자 행을 잠그면, 최신 지출 삭제는 그 커밋을 보고 lastUpdated를 중간 날짜로 재계산한다")
+    void deleteWaitsForCreateAndRecomputesLastUpdatedIncludingNewExpense() throws Exception {
+        User user = saveUser("create-then-delete", "생성후삭제");
+        SeededExpenses seeded = seedOldestAndLatestExpenses(user);
+        LockPause pause = pauseFirstLock(user.getId());
+
+        try (ExecutorService executor = Executors.newFixedThreadPool(2)) {
+            try {
+                Future<ExpenseCreateResponse> createFuture = executor.submit(() ->
+                        expenseService.create(user.getId(), request("중간 지출", MIDDLE_DATE)));
+                assertThat(pause.firstLocked().await(5, TimeUnit.SECONDS)).isTrue();
+
+                Future<?> deleteFuture = executor.submit(() -> expenseService.delete(user.getId(), seeded.latest().getId()));
+                assertThat(pause.twoAttempts().await(5, TimeUnit.SECONDS)).isTrue();
+                assertBlocked(deleteFuture);
+
+                pause.release();
+                ExpenseCreateResponse created = createFuture.get(5, TimeUnit.SECONDS);
+                deleteFuture.get(5, TimeUnit.SECONDS);
+
+                assertThat(expenseRepository.findById(seeded.latest().getId()).orElseThrow().getStatus())
+                        .isEqualTo(ExpenseStatus.DELETED);
+                assertThat(expenseRepository.findById(created.expenseId()).orElseThrow().getStatus())
+                        .isEqualTo(ExpenseStatus.ACTIVE);
+                assertThat(userRepository.findById(user.getId()).orElseThrow().getLastUpdated())
+                        .isEqualTo(MIDDLE_DATE);
+            } finally {
+                pause.release();
+                executor.shutdownNow();
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("최신 지출 삭제가 먼저 사용자 행을 잠그면, 중간 날짜 무지출 기록은 삭제가 되돌린 lastUpdated 위로 다시 전진시킨다")
+    void noSpendWaitsForDeleteAndAdvancesLastUpdatedFromRecomputedFallback() throws Exception {
+        User user = saveUser("delete-then-no-spend", "삭제후무지출");
+        SeededExpenses seeded = seedOldestAndLatestExpenses(user);
+        LockPause pause = pauseFirstLock(user.getId());
+
+        try (ExecutorService executor = Executors.newFixedThreadPool(2)) {
+            try {
+                Future<?> deleteFuture = executor.submit(() -> expenseService.delete(user.getId(), seeded.latest().getId()));
+                assertThat(pause.firstLocked().await(5, TimeUnit.SECONDS)).isTrue();
+
+                Future<?> noSpendFuture = executor.submit(() ->
+                        expenseService.recordNoSpend(user.getId(), new NoSpendRecordRequest(MIDDLE_DATE)));
+                assertThat(pause.twoAttempts().await(5, TimeUnit.SECONDS)).isTrue();
+                assertBlocked(noSpendFuture);
+
+                pause.release();
+                deleteFuture.get(5, TimeUnit.SECONDS);
+                noSpendFuture.get(5, TimeUnit.SECONDS);
+
+                assertThat(expenseRepository.findById(seeded.latest().getId()).orElseThrow().getStatus())
+                        .isEqualTo(ExpenseStatus.DELETED);
+                assertThat(noSpendDayRepository.existsByUser_IdAndRecordDate(user.getId(), MIDDLE_DATE)).isTrue();
+                assertThat(userRepository.findById(user.getId()).orElseThrow().getLastUpdated())
+                        .isEqualTo(MIDDLE_DATE);
+            } finally {
+                pause.release();
+                executor.shutdownNow();
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("중간 날짜 무지출 기록이 먼저 사용자 행을 잠그면, 최신 지출 삭제는 그 커밋을 보고 lastUpdated를 중간 날짜로 재계산한다")
+    void deleteWaitsForNoSpendAndRecomputesLastUpdatedIncludingNewRecord() throws Exception {
+        User user = saveUser("no-spend-then-delete", "무지출후삭제");
+        SeededExpenses seeded = seedOldestAndLatestExpenses(user);
+        LockPause pause = pauseFirstLock(user.getId());
+
+        try (ExecutorService executor = Executors.newFixedThreadPool(2)) {
+            try {
+                Future<?> noSpendFuture = executor.submit(() ->
+                        expenseService.recordNoSpend(user.getId(), new NoSpendRecordRequest(MIDDLE_DATE)));
+                assertThat(pause.firstLocked().await(5, TimeUnit.SECONDS)).isTrue();
+
+                Future<?> deleteFuture = executor.submit(() -> expenseService.delete(user.getId(), seeded.latest().getId()));
+                assertThat(pause.twoAttempts().await(5, TimeUnit.SECONDS)).isTrue();
+                assertBlocked(deleteFuture);
+
+                pause.release();
+                noSpendFuture.get(5, TimeUnit.SECONDS);
+                deleteFuture.get(5, TimeUnit.SECONDS);
+
+                assertThat(expenseRepository.findById(seeded.latest().getId()).orElseThrow().getStatus())
+                        .isEqualTo(ExpenseStatus.DELETED);
+                assertThat(noSpendDayRepository.existsByUser_IdAndRecordDate(user.getId(), MIDDLE_DATE)).isTrue();
+                assertThat(userRepository.findById(user.getId()).orElseThrow().getLastUpdated())
+                        .isEqualTo(MIDDLE_DATE);
+            } finally {
+                pause.release();
+                executor.shutdownNow();
+            }
+        }
+    }
+
     private User saveUser(String emailPrefix, String nickname) {
         return userRepository.saveAndFlush(User.createLocalUser(
                 emailPrefix + "@hampouch.test", "encoded", nickname));
     }
 
     private ExpenseCreateRequest request(String name) {
+        return request(name, RECORD_DATE);
+    }
+
+    private ExpenseCreateRequest request(String name, LocalDate date) {
         return new ExpenseCreateRequest(
                 name,
                 8000,
@@ -193,7 +333,7 @@ class ExpenseNoSpendConsistencyMySqlTest {
                 null,
                 ExpenseEmotion.STRESS,
                 null,
-                RECORD_DATE,
+                date,
                 null,
                 null);
     }
@@ -220,6 +360,20 @@ class ExpenseNoSpendConsistencyMySqlTest {
                 ExpenseEmotion.STRESS,
                 RECORD_DATE,
                 persistedUser));
+    }
+
+    /** OLDEST_DATE·RECORD_DATE(최신) 지출을 미리 남겨 lastUpdated=RECORD_DATE로 세팅한 픽스처. RECORD_DATE 지출을 지우면 재계산 폴백이 OLDEST_DATE로 떨어진다. */
+    private SeededExpenses seedOldestAndLatestExpenses(User persistedUser) {
+        Expense oldest = expenseRepository.saveAndFlush(Expense.of(
+                "오래된 지출", 5000, ExpenseCategory.CAFE, ExpenseEmotion.STRESS, OLDEST_DATE, persistedUser));
+        Expense latest = expenseRepository.saveAndFlush(Expense.of(
+                "최신 지출", 8000, ExpenseCategory.CAFE, ExpenseEmotion.STRESS, RECORD_DATE, persistedUser));
+        persistedUser.updateLastUpdated(RECORD_DATE);
+        userRepository.saveAndFlush(persistedUser);
+        return new SeededExpenses(oldest, latest);
+    }
+
+    private record SeededExpenses(Expense oldest, Expense latest) {
     }
 
     private LockPause pauseFirstLock(Long userId) {

--- a/src/test/java/Hampouch/server/domain/expense/service/ExpenseImageServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/expense/service/ExpenseImageServiceTest.java
@@ -61,6 +61,8 @@ class ExpenseImageServiceTest {
         ExpenseImageService service = new ExpenseImageService(s3Presigner, s3Client, expenseRepository, expenseDetailRepository, expenseDetailAccess);
         ReflectionTestUtils.setField(service, "bucket", "hampouch-bucket");
         ReflectionTestUtils.setField(service, "region", "ap-northeast-2");
+        // attach()가 self(프록시 자기참조)를 통해 attachLocked()를 호출하므로 단위 테스트에서도 자기 자신을 채워준다.
+        ReflectionTestUtils.setField(service, "self", service);
         return service;
     }
 
@@ -262,13 +264,10 @@ class ExpenseImageServiceTest {
     @Test
     @DisplayName("다른 유저 접두어의 imageKey를 붙이려 하면 403(EXPENSE_IMAGE_KEY_FORBIDDEN)을 던진다(#4)")
     void attach_forbiddenWhenImageKeyOwnedByAnotherUser() {
-        Expense expense = expenseOf(OWNER);
-        when(expenseRepository.findByIdAndStatus(1L, ExpenseStatus.ACTIVE)).thenReturn(Optional.of(expense));
-
         assertThatThrownBy(() -> service().attach(OWNER, 1L, "expenses/" + OTHER + "/abc.jpg"))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ExpenseErrorCode.EXPENSE_IMAGE_KEY_FORBIDDEN);
-        verifyNoInteractions(expenseDetailAccess);
+        verifyNoInteractions(expenseRepository, expenseDetailAccess);
     }
 
     // ---------- remove ----------

--- a/src/test/java/Hampouch/server/domain/expense/service/ExpenseServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/expense/service/ExpenseServiceTest.java
@@ -66,8 +66,11 @@ class ExpenseServiceTest {
     /** 오늘을 직접 고정해야 하는 케이스(주간/월간 요약의 dailyAverage 계산)용 */
     private ExpenseService serviceAt(LocalDate today) {
         Clock clock = Clock.fixed(today.atTime(12, 0).atZone(SEOUL).toInstant(), SEOUL);
-        return new ExpenseService(expenseRepository, expenseDetailRepository, noSpendDayRepository,
+        ExpenseService service = new ExpenseService(expenseRepository, expenseDetailRepository, noSpendDayRepository,
                 expenseDateLockQuery, userOperationLock, userRepository, expenseImageService, expenseDetailAccess, clock);
+        // create()가 self(프록시 자기참조)를 통해 createLocked()를 호출하므로(#149), 단위 테스트에서도 자기 자신을 채워준다.
+        ReflectionTestUtils.setField(service, "self", service);
+        return service;
     }
 
     // ---------- create ----------
@@ -346,10 +349,8 @@ class ExpenseServiceTest {
     }
 
     @Test
-    @DisplayName("imageKey 검증에 실패하면(HeadObject 미확인) create() 전체가 실패하며 예외가 그대로 전파된다")
+    @DisplayName("imageKey 검증에 실패하면(HeadObject 미확인) 사용자 락·DB 쓰기 전에 끝나며 예외가 그대로 전파된다")
     void create_propagatesExceptionWhenImageKeyNotUploaded() {
-        when(userRepository.getReferenceById(OWNER)).thenReturn(user(OWNER));
-        when(expenseRepository.save(any(Expense.class))).thenAnswer(inv -> inv.getArgument(0));
         doThrow(new CustomException(ExpenseErrorCode.EXPENSE_IMAGE_NOT_UPLOADED))
                 .when(expenseImageService).validateOwnedAndUploaded(OWNER, "expenses/missing.jpg");
 
@@ -359,6 +360,8 @@ class ExpenseServiceTest {
         assertThatThrownBy(() -> service().create(OWNER, req))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ExpenseErrorCode.EXPENSE_IMAGE_NOT_UPLOADED);
+        verifyNoInteractions(userOperationLock);
+        verify(expenseRepository, never()).save(any());
         verify(expenseDetailRepository, never()).save(any());
     }
 


### PR DESCRIPTION
## 📎연관된 이슈

- closes: #149

## 📄 작업 내용 요약

- 실제 MySQL에서 미입력 자동 취소 판정(`getCurrent()`)과 지출 기록(`recordNoSpend()`)이 같은 사용자 락을 놓고 경쟁할 때, 어느 쪽이 먼저 잠그든 최종 챌린지 상태·`no_spend_day`·`User.lastUpdated`가 일관되게 수렴함을 검증하는 테스트 2건을 추가했습니다.
- 최신 지출 삭제와 더 최근 날짜의 생성·무지출 기록이 경쟁할 때, `User.lastUpdated`가 락 순서와 무관하게 항상 올바른 날짜로 수렴함을 검증하는 MySQL 테스트 4건(create↔delete, no-spend↔delete 양방향)을 추가했습니다.
- `ExpenseService.create()`의 S3 HeadObject 확인(`ExpenseImageService.validateOwnedAndUploaded`)을 사용자 락·DB 트랜잭션 밖으로 분리했습니다 — S3 지연이 사용자 행 잠금과 DB 커넥션을 붙잡지 않도록 `create()`를 트랜잭션 없는 진입점으로 두고, 실제 락·저장은 `createLocked()`로 나눴습니다.
- `ExpenseImageService.validateOwnedAndUploaded()`에 `NOT_SUPPORTED`를 붙여 `attach()` 쪽 트랜잭션도 S3 호출 동안 일시 중단되게 했습니다.
- (부가) 분석 도메인을 제외한 지출 도메인 전반의 장황한 주석을 핵심만 남기도록 정리했습니다 — 로직 변경 없음.

## 👀 중요 변경 사항

> API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요

- API 요청·응답 계약은 변경되지 않습니다.
- `ExpenseService.create()`는 더 이상 그 자체로 트랜잭션을 열지 않습니다 — 실제 DB 쓰기·사용자 락은 새로 노출된 `createLocked()`가 담당하며, `create()`는 self 프록시로 그 메서드를 호출합니다(컨트롤러는 여전히 `create()`만 호출).
- `ExpenseService`에 자기 자신을 주입하는 필드(`self`, `@Lazy @Autowired`)가 추가됐습니다 — Lombok `@RequiredArgsConstructor` 생성자 주입으로는 `@Lazy`가 복사되지 않아 순환 참조로 실패해서 필드 주입으로 처리했습니다.

## 🔖 Uncompleted Tasks

> 후속 작업 예정인 사항이 있다면 작성해주세요.

## 📢 To Reviewers

> Reviewer가 주로 확인해주었으면 하는 부분을 적어주세요.

- `ExpenseService.create()`/`createLocked()` 분리와 self-injection 패턴이 이 코드베이스에 처음 들어가는 방식이라, 트랜잭션 경계가 의도대로 걸리는지(특히 `createLocked()`가 실제로 새 트랜잭션에서 실행되는지) 확인해주시면 좋겠습니다.
- 마지막 주석 정리 커밋은 로직 변경이 없어 확인하지 않으셔도 됩니다.