### PR TITLE
Fix: todaySpent를 ChallengeDay 스냅샷이 아닌 실제 지출 합계로 계산 (#101)

### DIFF
--- a/src/main/java/Hampouch/server/domain/challenge/dto/DayUpsertRequest.java
+++ b/src/main/java/Hampouch/server/domain/challenge/dto/DayUpsertRequest.java
@@ -6,8 +6,7 @@ import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 
 /**
- * POST /api/challenges/{id}/days 요청 — 일별 지출 수신.
- *
+ * POST /api/challenges/{id}/days 요청 — 테스트/시드 전용 엔드포인트.
  * category/emotion은 령준 지출(EXPENSE) 연동 형태 확정 후 사용 — 현재 미저장.
  */
 public record DayUpsertRequest(

--- a/src/main/java/Hampouch/server/domain/challenge/entity/ChallengeDay.java
+++ b/src/main/java/Hampouch/server/domain/challenge/entity/ChallengeDay.java
@@ -10,8 +10,9 @@ import java.time.LocalDate;
 /**
  * 일별 판정 1행 (캘린더·결과 집계용). 하루 1행: unique(challenge_id, day_date).
  *
- * spentAmount는 그날 EXPENSE(외부) 합계지만, Phase 1에서는 POST /days로 직접 받는다.
- * TODO(령준 지출 연동): spentAmount 출처를 EXPENSE 합계 조회로 교체.
+ * spentAmount는 그날 EXPENSE의 합계. upsertDay()/getCurrent()는 ExpenseService.getDaySpending()으로
+ * 계산해 저장·조회).
+ * TODO: getCalendar()/ChallengeCalculator.summarizeForResult()는 아직 이 스냅샷을 그대로 쓴다 — DailyLimitTimeline류 폴백 설계가 필요해 별도 이슈로 분리.
  */
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA 필수 빈 생성자(Hibernate가 행→객체 복원·프록시 생성에 사용). protected = 우리 코드의 new 차단, 정식 생성은 of()

--- a/src/main/java/Hampouch/server/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/Hampouch/server/domain/challenge/service/ChallengeService.java
@@ -91,10 +91,9 @@ public class ChallengeService {
         LocalDate today = LocalDate.now(clock);
         ExpenseInputState expenseInputState = evaluateExpenseInputState(userId, c, today);
 
-        // TODO: todaySpent를 ChallengeDay가 아닌 지출 원본에서 계산한다.
         int dailyLimit = c.getDailyLimit();
         Optional<ChallengeDay> todayRow = challengeDayRepository.findByChallenge_IdAndDayDate(c.getId(), today);
-        int todaySpent = todayRow.map(ChallengeDay::getSpentAmount).orElse(0);
+        int todaySpent = expenseService.getDaySpending(userId, today).totalAmount();
         double usageRate = ChallengeCalculator.usageRate(todaySpent, dailyLimit);
         AlertLevel alertLevel = AlertLevel.of(usageRate);
 
@@ -263,15 +262,17 @@ public class ChallengeService {
         }
         // 과거 기록은 조정 후 현재 한도가 아니라 해당 날짜의 한도로 판정한다.
         int dailyLimit = timelineOf(c).on(req.date());
-        DayStatus status = ChallengeCalculator.judge(req.spentAmount(), dailyLimit);
+        // 테스트/시드 전용 엔드포인트 — req.spentAmount()는 더 이상 판정에 쓰지 않고 지출 원본에서 계산한다.
+        int spentAmount = expenseService.getDaySpending(userId, req.date()).totalAmount();
+        DayStatus status = ChallengeCalculator.judge(spentAmount, dailyLimit);
 
         ChallengeDay day = challengeDayRepository.findByChallenge_IdAndDayDate(challengeId, req.date())
                 .map(existing -> {
-                    existing.update(req.spentAmount(), status);
+                    existing.update(spentAmount, status);
                     return existing;
                 })
                 .orElseGet(() -> challengeDayRepository.save(
-                        ChallengeDay.of(c, req.date(), req.spentAmount(), status, dailyLimit)));
+                        ChallengeDay.of(c, req.date(), spentAmount, status, dailyLimit)));
 
         // 기록 기반 결과만 수정된 지출로 재계산한다.
         if (!c.isInProgress() && c.isResultFromRecords()) {

--- a/src/main/java/Hampouch/server/domain/expense/service/ExpenseService.java
+++ b/src/main/java/Hampouch/server/domain/expense/service/ExpenseService.java
@@ -262,7 +262,7 @@ public class ExpenseService {
 
     /**
      * category/emotion이 ETC일 때만 커스텀 태그 문자열을 기록하고, 그 외엔 명시적으로 null 해제
-     * EXPENSE_CUSTOM_*_NAME_DUPLICATED는 내장 enum 라벨(예약어)과의 충돌 전용 에러코드
+     * EXPENSE_CUSTOM_*_NAME_DUPLICATED는 내장 enum 라벨과의 충돌 전용 에러코드
      */
     private void attachCustomTags(Expense expense, ExpenseCategory category, String customCategoryName,
                                   ExpenseEmotion emotion, String customEmotionName) {

--- a/src/test/java/Hampouch/server/domain/challenge/ChallengeFlowIntegrationTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/ChallengeFlowIntegrationTest.java
@@ -3,6 +3,10 @@ package Hampouch.server.domain.challenge;
 import Hampouch.server.domain.challenge.entity.*;
 import Hampouch.server.domain.challenge.repository.ChallengeDayRepository;
 import Hampouch.server.domain.challenge.repository.ChallengeRepository;
+import Hampouch.server.domain.expense.entity.Expense;
+import Hampouch.server.domain.expense.entity.ExpenseCategory;
+import Hampouch.server.domain.expense.entity.ExpenseEmotion;
+import Hampouch.server.domain.expense.repository.ExpenseRepository;
 import Hampouch.server.domain.user.entity.User;
 import Hampouch.server.domain.user.entity.UserRole;
 import Hampouch.server.domain.user.repository.UserRepository;
@@ -51,6 +55,8 @@ class ChallengeFlowIntegrationTest {
     JdbcTemplate jdbc;
     @Autowired
     JwtProvider jwtProvider;
+    @Autowired
+    ExpenseRepository expenseRepository;
 
     /** 실제 서명이 붙은 액세스 토큰의 Authorization 헤더 값 — 로그인 API를 거치지 않고 발급만 빌려 쓴다. */
     private String bearer(Long userId) {
@@ -62,6 +68,15 @@ class ChallengeFlowIntegrationTest {
         User user = User.createLocalUser(
                 "challenge-flow-" + suffix + "@hampouch.test", "encoded", "챌린지" + suffix);
         return userRepository.save(user).getId();
+    }
+
+    /**
+     * POST /days가 이제 지출 원본에서 재계산하므로(#101), 그날의 판정을 특정 금액으로 맞추려면
+     * 실제 ACTIVE Expense를 심어야 한다 — 요청 JSON의 spentAmount는 더 이상 판정에 쓰이지 않는다.
+     */
+    private Expense seedExpense(Long userId, LocalDate date, int price) {
+        User user = userRepository.getReferenceById(userId);
+        return expenseRepository.save(Expense.of(null, price, ExpenseCategory.ETC, ExpenseEmotion.ETC, date, user));
     }
 
     @Test
@@ -147,7 +162,8 @@ class ChallengeFlowIntegrationTest {
                 .andReturn().getResponse().getContentAsString();
         long id = om.readTree(created).path("data").path("challengeId").asLong();
 
-        // 2) 일별 입력: 성공 1일(8,000) + 초과 1일(15,000)
+        // 2) 일별 입력: 성공 1일(8,000) + 초과 1일(15,000) — 판정은 이제 실제 지출 합계 기준이라 먼저 심는다(#101)
+        seedExpense(user, start, 8000);
         mvc.perform(post("/api/challenges/" + id + "/days")
                         .header("Authorization", bearer(user))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -155,6 +171,7 @@ class ChallengeFlowIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.status").value("SUCCESS"))
                 .andExpect(jsonPath("$.data.dailyLimit").value(10000));
+        seedExpense(user, day2, 15000);
         mvc.perform(post("/api/challenges/" + id + "/days")
                         .header("Authorization", bearer(user))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -193,6 +210,7 @@ class ChallengeFlowIntegrationTest {
         LocalDate lastDay = today.minusDays(1);
 
         // 결과 팝업의 [지출 수정하기] 구간 — 기간은 끝났지만 아직 안 잠겨 기록 수정이 통한다
+        seedExpense(user, lastDay, 9000);
         mvc.perform(post("/api/challenges/" + ch.getId() + "/days")
                         .header("Authorization", bearer(user))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -387,6 +405,7 @@ class ChallengeFlowIntegrationTest {
                 .andExpect(status().isCreated())
                 .andReturn().getResponse().getContentAsString();
         long id = om.readTree(created).path("data").path("challengeId").asLong();
+        Expense firstExpense = seedExpense(user, start, 15000);
         mvc.perform(post("/api/challenges/" + id + "/days")
                         .header("Authorization", bearer(user))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -415,6 +434,10 @@ class ChallengeFlowIntegrationTest {
 
         // 5) 기간 내 지출 수정은 여전히 허용(0711 "종료 후 자유 수정")되고 그날 판정도 새 금액 기준으로 바뀌지만,
         //    기록상 전원 성공이 돼도 포기 FAIL은 유저 선언이라 재계산으로 부활하지 않는다 — 히스토리에도 FAIL로 남는다
+        // 판정이 그날 ACTIVE 지출 합계 기준이라(#101), 1단계에서 심은 15,000원은 지우고 1,000원만 남긴다
+        firstExpense.delete();
+        expenseRepository.save(firstExpense);
+        seedExpense(user, start, 1000);
         mvc.perform(post("/api/challenges/" + id + "/days")
                         .header("Authorization", bearer(user))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -471,6 +494,7 @@ class ChallengeFlowIntegrationTest {
                 .andReturn().getResponse().getContentAsString();
         long id = om.readTree(created).path("data").path("challengeId").asLong();
 
+        // 지출을 하나도 안 심었으니(#101) 요청의 spentAmount(8000)는 무시되고 실제 합계 0원 = SUCCESS로 판정된다
         mvc.perform(post("/api/challenges/" + id + "/days")
                         .header("Authorization", bearer(user))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -479,6 +503,8 @@ class ChallengeFlowIntegrationTest {
                 .andExpect(jsonPath("$.data.status").value("SUCCESS"));
         Long rowId = challengeDayRepository.findByChallenge_IdAndDayDate(id, start).orElseThrow().getId();
 
+        // 두 번째 판정은 그날 ACTIVE 지출 합계 기준이라(#101) 15,000원 지출을 실제로 심는다
+        seedExpense(user, start, 15000);
         mvc.perform(post("/api/challenges/" + id + "/days")
                         .header("Authorization", bearer(user))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -509,6 +535,8 @@ class ChallengeFlowIntegrationTest {
         challengeRepository.save(ch);
 
         // 종료 후 지출 수정(0711 확정 경로) — 80,000을 5,000으로 고치면 총지출이 목표 아래로 내려간다
+        // 판정이 그날 ACTIVE 지출 합계 기준이라(#101) 실제 5,000원 지출을 심는다
+        seedExpense(user, overDay, 5000);
         mvc.perform(post("/api/challenges/" + ch.getId() + "/days")
                         .header("Authorization", bearer(user))
                         .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/Hampouch/server/domain/challenge/service/ChallengeServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/service/ChallengeServiceTest.java
@@ -6,6 +6,7 @@ import Hampouch.server.domain.challenge.repository.ChallengeAdjustmentRepository
 import Hampouch.server.domain.challenge.repository.ChallengeDayRepository;
 import Hampouch.server.domain.challenge.repository.ChallengeRepository;
 import Hampouch.server.domain.expense.entity.ExpenseEmotion;
+import Hampouch.server.domain.expense.service.DaySpending;
 import Hampouch.server.domain.expense.service.EmotionSpending;
 import Hampouch.server.domain.expense.service.ExpenseService;
 import Hampouch.server.domain.expense.service.ExpenseSpendingQuery;
@@ -65,6 +66,9 @@ class ChallengeServiceTest {
     void defaultExpenseInput() {
         lenient().when(expenseService.hasDayRecord(anyLong(), any(LocalDate.class)))
                 .thenReturn(true);
+        // getCurrent()/upsertDay()가 항상 호출하므로 기본값을 0원으로 깔아 둔다(#101) — 금액을 보는 테스트만 스텁을 따로 덮어쓴다.
+        lenient().when(expenseService.getDaySpending(anyLong(), any(LocalDate.class)))
+                .thenReturn(new DaySpending(0, true));
         // getResult()가 항상 호출하므로 기본값을 빈 집계로 깔아 둔다(#64) — 실제 배선을 보는 테스트만 스텁을 따로 덮어쓴다.
         lenient().when(expenseSpendingQuery.periodSpending(anyLong(), any(LocalDate.class), any(LocalDate.class)))
                 .thenReturn(new PeriodSpending(0, List.of()));
@@ -154,15 +158,16 @@ class ChallengeServiceTest {
     }
 
     @Test
-    @DisplayName("같은 날짜로 다시 입력하면 기존 행을 덮어쓰고 판정도 새 금액 기준으로 바뀐다 (S7 upsert)")
+    @DisplayName("같은 날짜로 다시 입력하면 기존 행을 덮어쓰고 판정도 지출 원본 합계 기준으로 바뀐다 (S7 upsert) — 요청의 spentAmount는 무시된다(#101)")
     void upsertDay_overwritesExisting() {
         Challenge ch = inProgress(LocalDate.of(2026, 6, 1));
         LocalDate date = LocalDate.of(2026, 6, 3);
         ChallengeDay existing = ChallengeDay.of(ch, date, 1000, DayStatus.SUCCESS, ch.getDailyLimit());
         when(challengeRepository.findByIdForUpdate(10L)).thenReturn(Optional.of(ch));
         when(challengeDayRepository.findByChallenge_IdAndDayDate(10L, date)).thenReturn(Optional.of(existing));
+        when(expenseService.getDaySpending(USER, date)).thenReturn(new DaySpending(99999, true));
 
-        var req = new DayUpsertRequest(date, 99999, null, null);
+        var req = new DayUpsertRequest(date, 5, null, null); // req의 spentAmount는 이제 무시되므로 임의값
         DayUpsertResponse res = serviceAt(LocalDate.of(2026, 6, 5)).upsertDay(USER, 10L, req);
 
         assertThat(res.spentAmount()).isEqualTo(99999);
@@ -209,8 +214,9 @@ class ChallengeServiceTest {
         when(challengeRepository.findByIdForUpdate(10L)).thenReturn(Optional.of(ch));
         when(challengeDayRepository.findByChallenge_IdAndDayDate(10L, date)).thenReturn(Optional.of(existing));
         when(challengeDayRepository.findByChallenge_Id(10L)).thenReturn(List.of(existing));
+        when(expenseService.getDaySpending(USER, date)).thenReturn(new DaySpending(300000, true));
 
-        serviceAt(LocalDate.of(2026, 6, 20)).upsertDay(USER, 10L, new DayUpsertRequest(date, 300000, null, null));
+        serviceAt(LocalDate.of(2026, 6, 20)).upsertDay(USER, 10L, new DayUpsertRequest(date, 1, null, null));
 
         assertThat(ch.getStatus()).isEqualTo(ChallengeStatus.FAIL);
     }
@@ -225,8 +231,9 @@ class ChallengeServiceTest {
         when(challengeRepository.findByIdForUpdate(10L)).thenReturn(Optional.of(ch));
         when(challengeDayRepository.findByChallenge_IdAndDayDate(10L, date)).thenReturn(Optional.of(existing));
         when(challengeDayRepository.findByChallenge_Id(10L)).thenReturn(List.of(existing));
+        when(expenseService.getDaySpending(USER, date)).thenReturn(new DaySpending(1000, true));
 
-        serviceAt(LocalDate.of(2026, 6, 20)).upsertDay(USER, 10L, new DayUpsertRequest(date, 1000, null, null));
+        serviceAt(LocalDate.of(2026, 6, 20)).upsertDay(USER, 10L, new DayUpsertRequest(date, 1, null, null));
 
         assertThat(ch.getStatus()).isEqualTo(ChallengeStatus.SUCCESS);
     }
@@ -263,12 +270,15 @@ class ChallengeServiceTest {
     void current_consumptionState() {
         Challenge ch = inProgress(LocalDate.of(2026, 6, 1));
         LocalDate today = LocalDate.of(2026, 6, 5);
-        ChallengeDay todayRow = ChallengeDay.of(ch, today, 15000, DayStatus.OVER, ch.getDailyLimit());
+        // ChallengeDay의 저장값(999)과 getDaySpending의 값(15000)을 일부러 다르게 둬서, todaySpent가
+        // ChallengeDay를 다시 읽는 회귀가 생기면 이 테스트가 확실히 깨지게 한다(#101).
+        ChallengeDay todayRow = ChallengeDay.of(ch, today, 999, DayStatus.SUCCESS, ch.getDailyLimit());
         when(challengeRepository.findInProgress(USER))
                 .thenReturn(Optional.of(ch));
         when(challengeDayRepository.findByChallenge_Id(any())).thenReturn(List.of(todayRow));
         when(challengeDayRepository.findByChallenge_IdAndDayDate(any(), any()))
                 .thenReturn(Optional.of(todayRow));
+        when(expenseService.getDaySpending(USER, today)).thenReturn(new DaySpending(15000, true));
 
         CurrentChallengeResponse res = serviceAt(today).getCurrent(USER);
 
@@ -486,9 +496,10 @@ class ChallengeServiceTest {
                         .previousBudgetTotal(280000).newBudgetTotal(308000)
                         .previousDailyLimit(20000).newDailyLimit(22000).build()));
         when(challengeDayRepository.save(any(ChallengeDay.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(expenseService.getDaySpending(USER, pastDay)).thenReturn(new DaySpending(21000, true));
 
         DayUpsertResponse res = serviceAt(LocalDate.of(2026, 6, 6))
-                .upsertDay(USER, 10L, new DayUpsertRequest(pastDay, 21000, null, null));
+                .upsertDay(USER, 10L, new DayUpsertRequest(pastDay, 1, null, null));
 
         assertThat(res.dailyLimit()).isEqualTo(20000);
         assertThat(res.status()).isEqualTo(DayStatus.OVER);
@@ -688,7 +699,8 @@ class ChallengeServiceTest {
 
         assertThat(res.expenseInputState()).isEqualTo(ExpenseInputState.NORMAL);
         assertThat(ch.getStatus()).isEqualTo(ChallengeStatus.IN_PROGRESS);
-        verifyNoInteractions(expenseService);
+        // todaySpent 계산(#101)은 항상 getDaySpending을 호출하므로, 미입력일 판정(hasDayRecord)만 안 탔는지로 좁혀서 검증한다.
+        verify(expenseService, never()).hasDayRecord(any(), any());
     }
 
     @Test
@@ -1032,8 +1044,9 @@ class ChallengeServiceTest {
         ChallengeDay existing = ChallengeDay.of(ch, date, 99999, DayStatus.OVER, ch.getDailyLimit());
         when(challengeRepository.findByIdForUpdate(10L)).thenReturn(Optional.of(ch));
         when(challengeDayRepository.findByChallenge_IdAndDayDate(10L, date)).thenReturn(Optional.of(existing));
+        when(expenseService.getDaySpending(USER, date)).thenReturn(new DaySpending(1000, true));
 
-        serviceAt(LocalDate.of(2026, 6, 10)).upsertDay(USER, 10L, new DayUpsertRequest(date, 1000, null, null));
+        serviceAt(LocalDate.of(2026, 6, 10)).upsertDay(USER, 10L, new DayUpsertRequest(date, 1, null, null));
 
         assertThat(existing.getSpentAmount()).isEqualTo(1000);
         assertThat(ch.getStatus()).isEqualTo(ChallengeStatus.FAIL);
@@ -1049,9 +1062,10 @@ class ChallengeServiceTest {
         ChallengeDay existing = ChallengeDay.of(ch, date, 0, DayStatus.SUCCESS, ch.getDailyLimit());
         when(challengeRepository.findByIdForUpdate(10L)).thenReturn(Optional.of(ch));
         when(challengeDayRepository.findByChallenge_IdAndDayDate(10L, date)).thenReturn(Optional.of(existing));
+        when(expenseService.getDaySpending(USER, date)).thenReturn(new DaySpending(1000, true));
 
         serviceAt(LocalDate.of(2026, 6, 10))
-                .upsertDay(USER, 10L, new DayUpsertRequest(date, 1000, null, null));
+                .upsertDay(USER, 10L, new DayUpsertRequest(date, 1, null, null));
 
         assertThat(existing.getSpentAmount()).isEqualTo(1000);
         assertThat(ch.getStatus()).isEqualTo(ChallengeStatus.VOID);


### PR DESCRIPTION
## 📎연관된 이슈

- #101 

⚠️ #101 체크리스트 중 todaySpent(getCurrent)·upsertDay만 처리했고, 캘린더(getCalendar)와 결과/히스토리 집계(ChallengeCalculator.summarizeForResult)는 DailyLimitTimeline 폴백 설계가
더 필요해 이번 PR 범위에서 뺐습니다. merge해도 #101이 자동으로 닫히지 않습니다. 남은 범위는 별도 이슈로 분리할지 issue를 계속 열어둘지 정해주세요.

## 📄 작업 내용 요약

- `ChallengeService.getCurrent()`의 `todaySpent`를 `ChallengeDay.spentAmount`(클라이언트가 보낸 값)
  대신 `ExpenseService.getDaySpending()`의 실제 ACTIVE 지출 합계로 계산하도록 변경
- `ChallengeService.upsertDay()`도 `req.spentAmount()`를 무시하고 같은 방식으로 재계산하도록 변경
  — 내부 API 스펙상 `POST /api/challenges/{id}/days`는 테스트/시드 전용 엔드포인트이고 운영 판정은
  지출 조회 메서드로 대체될 예정이라 요청 계약(`DayUpsertRequest`)은 그대로 두고 서버 판정만 바꿨습니다
- `ChallengeDay`/`DayUpsertRequest`의 Javadoc을 새 소스에 맞게 갱신
- `ChallengeServiceTest`/`ChallengeFlowIntegrationTest`를 실제 지출 합계 기준으로 재작성
  (통합 테스트는 `ExpenseRepository`로 실제 `Expense` 행을 심는 방식으로 변경)

## 👀 중요 변경 사항

- `POST /days`의 요청 바디 `spentAmount` 필드는 이제 서버에서 무시됩니다. 판정은 그 날짜의 실제
  ACTIVE 지출 합계로만 결정됩니다 — 프론트/QA가 이 엔드포인트로 시드할 때 실제 지출 데이터 없이는
  원하는 금액으로 판정이 안 나옵니다.
- `getCalendar()`와 결과/히스토리 화면은 아직 `ChallengeDay` 스냅샷을 그대로 씁니다 — 오늘 지출과
  캘린더/결과 화면의 금액 소스가 당분간 다를 수 있습니다.

## 🔖 Uncompleted Tasks

- `CalendarResponse.DayView.spentAmount`, `ChallengeCalculator.summarizeForResult`(결과/히스토리/추천)의
  지출 출처 교체 — `ChallengeDay` 행이 없는 날의 `DailyLimitTimeline` 폴백 설계가 필요해 별도 논의 후 진행

## 📢 To Reviewers

- `upsertDay`가 요청의 `spentAmount`를 완전히 무시하는 게 맞는 방향인지, 아니면 `DayUpsertRequest`
  자체에서 필드를 없애는 게 나을지 의견 부탁드립니다 (이번엔 계약 변경 없이 서버 로직만 바꾸는 쪽을 택했습니다).