### PR TITLE
Feat: 마이페이지 기본 정보 조회 · 닉네임 변경 API 구현

### DIFF
--- a/src/main/java/Hampouch/server/domain/user/controller/UserController.java
+++ b/src/main/java/Hampouch/server/domain/user/controller/UserController.java
@@ -1,10 +1,14 @@
 package Hampouch.server.domain.user.controller;
 
+import Hampouch.server.domain.user.dto.request.NicknameUpdateRequest;
+import Hampouch.server.domain.user.dto.response.NicknameUpdateResponse;
+import Hampouch.server.domain.user.dto.response.UserMeResponse;
 import Hampouch.server.domain.user.service.UserService;
 import Hampouch.server.global.common.response.ApiResponse;
+import Hampouch.server.global.security.LoginUserId;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -14,4 +18,20 @@ public class UserController {
 
     private final UserService userService;
 
+    //마이페이지 기본 정보 조회
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<UserMeResponse>> getMyInfo(@LoginUserId Long userId) {
+        UserMeResponse response = userService.getMyInfo(userId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    //닉네임 변경
+    @PatchMapping("/me/nickname")
+    public ResponseEntity<ApiResponse<NicknameUpdateResponse>> updateNickname(
+            @LoginUserId Long userId,
+            @RequestBody @Valid NicknameUpdateRequest request
+    ) {
+        NicknameUpdateResponse response = userService.updateNickname(userId, request);
+        return ResponseEntity.ok(ApiResponse.success("닉네임이 변경되었습니다.", response));
+    }
 }

--- a/src/main/java/Hampouch/server/domain/user/dto/request/NicknameUpdateRequest.java
+++ b/src/main/java/Hampouch/server/domain/user/dto/request/NicknameUpdateRequest.java
@@ -1,0 +1,12 @@
+package Hampouch.server.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record NicknameUpdateRequest(
+
+        @NotBlank(message = "닉네임을 입력해주세요.")
+        @Size(min = 2, max = 10, message = "닉네임은 2자 이상 10자 이하로 입력해주세요.")
+        String nickname
+) {
+}

--- a/src/main/java/Hampouch/server/domain/user/dto/response/NicknameUpdateResponse.java
+++ b/src/main/java/Hampouch/server/domain/user/dto/response/NicknameUpdateResponse.java
@@ -1,0 +1,9 @@
+package Hampouch.server.domain.user.dto.response;
+
+public record NicknameUpdateResponse(
+        String nickname
+) {
+    public static NicknameUpdateResponse of(String nickname) {
+        return new NicknameUpdateResponse(nickname);
+    }
+}

--- a/src/main/java/Hampouch/server/domain/user/dto/response/UserMeResponse.java
+++ b/src/main/java/Hampouch/server/domain/user/dto/response/UserMeResponse.java
@@ -1,0 +1,15 @@
+package Hampouch.server.domain.user.dto.response;
+
+public record UserMeResponse(
+        String nickname,
+        String profileImageUrl,
+        String handle
+) {
+    public static UserMeResponse of(String nickname, String profileImageUrl, String email) {
+        return new UserMeResponse(nickname, profileImageUrl, extractHandle(email));
+    }
+
+    private static String extractHandle(String email) {
+        return email.substring(0, email.indexOf('@'));
+    }
+}

--- a/src/main/java/Hampouch/server/domain/user/entity/User.java
+++ b/src/main/java/Hampouch/server/domain/user/entity/User.java
@@ -104,6 +104,10 @@ public class User {
         this.nickname = nickname;
     }
 
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
     public boolean isDeleted() {
         return this.status == UserStatus.DELETED;
     }

--- a/src/main/java/Hampouch/server/domain/user/service/UserService.java
+++ b/src/main/java/Hampouch/server/domain/user/service/UserService.java
@@ -18,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final UserOperationLock userOperationLock;
 
     public User getUser(Long userId) {
         User user = userRepository.findById(userId)
@@ -37,6 +38,10 @@ public class UserService {
 
     @Transactional
     public NicknameUpdateResponse updateNickname(Long userId, NicknameUpdateRequest request) {
+        // 같은 유저 row를 건드리는 다른 쓰기(예: ExpenseService.create()의 lastUpdated 갱신)와
+        // 직렬화하기 위해 getUser()보다 먼저 잠근다 - 순서가 바뀌면 락 없는 getUser()가 먼저 올린
+        // 1차 캐시 엔티티를 이 락이 갱신해주지 못해 무의미해진다.
+        userOperationLock.lock(userId);
         User user = getUser(userId);
 
         String nickname = request.nickname();

--- a/src/main/java/Hampouch/server/domain/user/service/UserService.java
+++ b/src/main/java/Hampouch/server/domain/user/service/UserService.java
@@ -45,7 +45,9 @@ public class UserService {
         User user = getUser(userId);
 
         String nickname = request.nickname();
-        if (!nickname.equals(user.getNickname()) && userRepository.existsByNickname(nickname)) {
+        // users.nickname은 대소문자 구분 없는 collation이라 DB의 uk_user_nickname도 "ab"="Ab"로 본다.
+        // equals로 비교하면 케이스만 바꾸는 변경(ab->Ab)이 자기 자신과 충돌한다고 오판해 409가 난다.
+        if (!nickname.equalsIgnoreCase(user.getNickname()) && userRepository.existsByNickname(nickname)) {
             throw new CustomException(UserErrorCode.USER_NICKNAME_ALREADY_EXISTS);
         }
 

--- a/src/main/java/Hampouch/server/domain/user/service/UserService.java
+++ b/src/main/java/Hampouch/server/domain/user/service/UserService.java
@@ -1,5 +1,8 @@
 package Hampouch.server.domain.user.service;
 
+import Hampouch.server.domain.user.dto.request.NicknameUpdateRequest;
+import Hampouch.server.domain.user.dto.response.NicknameUpdateResponse;
+import Hampouch.server.domain.user.dto.response.UserMeResponse;
 import Hampouch.server.domain.user.entity.User;
 import Hampouch.server.domain.user.repository.UserRepository;
 import Hampouch.server.global.common.exception.CustomException;
@@ -24,5 +27,23 @@ public class UserService {
         }
 
         return user;
+    }
+
+    public UserMeResponse getMyInfo(Long userId) {
+        User user = getUser(userId);
+        return UserMeResponse.of(user.getNickname(), user.getProfileImageUrl(), user.getEmail());
+    }
+
+    @Transactional
+    public NicknameUpdateResponse updateNickname(Long userId, NicknameUpdateRequest request) {
+        User user = getUser(userId);
+
+        String nickname = request.nickname();
+        if (!nickname.equals(user.getNickname()) && userRepository.existsByNickname(nickname)) {
+            throw new CustomException(UserErrorCode.USER_NICKNAME_ALREADY_EXISTS);
+        }
+
+        user.updateNickname(nickname);
+        return NicknameUpdateResponse.of(nickname);
     }
 }

--- a/src/main/java/Hampouch/server/domain/user/service/UserService.java
+++ b/src/main/java/Hampouch/server/domain/user/service/UserService.java
@@ -8,6 +8,7 @@ import Hampouch.server.domain.user.repository.UserRepository;
 import Hampouch.server.global.common.exception.CustomException;
 import Hampouch.server.global.common.exception.domain.UserErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -44,6 +45,14 @@ public class UserService {
         }
 
         user.updateNickname(nickname);
-        return NicknameUpdateResponse.of(nickname);
+
+        // 동시에 같은 닉네임으로 변경 요청이 들어오면 saveAndFlush로 여기서 즉시 UPDATE를 실행해 그 자리에서 잡고 409로 변환
+        try {
+            userRepository.saveAndFlush(user);
+        } catch (DataIntegrityViolationException e) {
+            throw new CustomException(UserErrorCode.USER_NICKNAME_ALREADY_EXISTS);
+        }
+
+        return NicknameUpdateResponse.of(user.getNickname());
     }
 }

--- a/src/test/java/Hampouch/server/domain/user/UserConcurrencyTest.java
+++ b/src/test/java/Hampouch/server/domain/user/UserConcurrencyTest.java
@@ -1,0 +1,154 @@
+package Hampouch.server.domain.user;
+
+import Hampouch.server.domain.auth.entity.EmailVerification;
+import Hampouch.server.domain.auth.entity.VerificationPurpose;
+import Hampouch.server.domain.auth.repository.EmailVerificationRepository;
+import Hampouch.server.domain.auth.util.EmailSender;
+import Hampouch.server.global.mysql.MySqlContainerTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import tools.jackson.databind.ObjectMapper;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.time.LocalDateTime;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * PATCH /api/users/me/nickname의 동시성 경쟁 상태를 검증한다.
+ *
+ * AuthConcurrencyTest(회원가입 닉네임 중복)와 동일한 기법을 쓴다: raw JDBC로 별도 커넥션을 열어
+ * 목표 닉네임을 가진 행을 커밋하지 않은 채로 붙잡아두고, 그 사이 실제 PATCH 요청이 사전 검사
+ * (existsByNickname)는 통과하되 실제 UPDATE 시점에 MySQL 유니크 인덱스 잠금에 걸려 블로킹되는지,
+ * holder가 커밋된 뒤 UserService.updateNickname의 saveAndFlush + DataIntegrityViolationException
+ * 처리가 이를 409로 정확히 변환하는지 검증한다.
+ */
+@MySqlContainerTest
+@AutoConfigureMockMvc
+class UserConcurrencyTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    EmailVerificationRepository emailVerificationRepository;
+
+    @Autowired
+    JdbcTemplate jdbc;
+
+    @MockitoBean
+    EmailSender emailSender;
+
+    private record HttpResult(int status, String body) {
+    }
+
+    @Test
+    @DisplayName("동시에 다른 회원이 먼저 같은 닉네임을 선점하면 변경이 거부되고 기존 닉네임이 유지된다")
+    void updateNickname_rejectsWhenAnotherUserConcurrentlyClaimsSameNickname() throws Exception {
+        String email = "concurrent-nickname-update-" + System.currentTimeMillis() + "@example.com";
+        String holderEmail = "concurrent-nickname-holder-" + System.currentTimeMillis() + "@example.com";
+        String originalNickname = "원래닉" + (System.currentTimeMillis() % 100000);
+        String targetNickname = "탐나는닉" + (System.currentTimeMillis() % 100000);
+
+        prepareVerifiedEmail(email);
+        signup(email, originalNickname);
+        String accessToken = login(email);
+
+        try (Connection holderConn = jdbc.getDataSource().getConnection()) {
+            holderConn.setAutoCommit(false);
+
+            // raw JDBC로 목표 닉네임을 가진 유저를 커밋하지 않은 채로 직접 삽입해서 붙잡아둔다.
+            // 이 상태에서는 existsByNickname(스냅샷 격리상 안 보임)은 통과하고, 실제 UPDATE 실행 시점에
+            // MySQL의 유니크 인덱스 잠금에 걸려야 한다 - AuthConcurrencyTest의 회원가입 INSERT 경쟁과 동일한 원리.
+            try (PreparedStatement ps = holderConn.prepareStatement(
+                    "INSERT INTO users (email, nickname, provider, role, status, created_at, updated_at) " +
+                            "VALUES (?, ?, 'LOCAL', 'USER', 'ACTIVE', NOW(), NOW())")) {
+                ps.setString(1, holderEmail);
+                ps.setString(2, targetNickname);
+                ps.executeUpdate();
+            }
+
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+            try {
+                Future<HttpResult> call = executor.submit(() -> callUpdateNickname(accessToken, targetNickname));
+
+                Thread.sleep(500);
+                assertThat(call.isDone())
+                        .as("실제 요청은 우리가 커밋하지 않은 동일 닉네임 INSERT와 충돌해 막혀 있어야 한다")
+                        .isFalse();
+
+                holderConn.commit();
+
+                HttpResult result = call.get(10, TimeUnit.SECONDS);
+                assertThat(result.status()).isEqualTo(409);
+                assertThat(result.body()).contains("USER_NICKNAME_ALREADY_EXISTS");
+            } finally {
+                executor.shutdownNow();
+            }
+        }
+
+        Integer targetNicknameCount = jdbc.queryForObject(
+                "SELECT COUNT(*) FROM users WHERE nickname = ?", Integer.class, targetNickname);
+        assertThat(targetNicknameCount).as("목표 닉네임은 먼저 선점한 holder 한 명만 가지고 있어야 한다").isEqualTo(1);
+
+        Integer originalNicknameCount = jdbc.queryForObject(
+                "SELECT COUNT(*) FROM users WHERE email = ? AND nickname = ?", Integer.class, email, originalNickname);
+        assertThat(originalNicknameCount).as("변경이 거부됐으므로 원래 유저의 닉네임은 그대로여야 한다").isEqualTo(1);
+    }
+
+    private HttpResult callUpdateNickname(String accessToken, String nickname) {
+        try {
+            MvcResult result = mvc.perform(patch("/api/users/me/nickname")
+                            .header("Authorization", "Bearer " + accessToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"nickname\":\"" + nickname + "\"}"))
+                    .andReturn();
+            return new HttpResult(result.getResponse().getStatus(), result.getResponse().getContentAsString());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void signup(String email, String nickname) throws Exception {
+        mvc.perform(post("/api/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"" + email + "\",\"password\":\"password1\",\"nickname\":\"" + nickname + "\"}"))
+                .andExpect(status().isOk());
+    }
+
+    private String login(String email) throws Exception {
+        MvcResult loginResult = mvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"" + email + "\",\"password\":\"password1\"}"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        return objectMapper.readTree(loginResult.getResponse().getContentAsString())
+                .path("data").path("accessToken").asText();
+    }
+
+    private void prepareVerifiedEmail(String email) {
+        LocalDateTime now = LocalDateTime.now();
+        EmailVerification verification = EmailVerification.create(email, "123456", VerificationPurpose.SIGNUP, now.plusMinutes(10));
+        verification.verify(now);
+        emailVerificationRepository.save(verification);
+    }
+}

--- a/src/test/java/Hampouch/server/domain/user/UserConcurrencyTest.java
+++ b/src/test/java/Hampouch/server/domain/user/UserConcurrencyTest.java
@@ -4,6 +4,14 @@ import Hampouch.server.domain.auth.entity.EmailVerification;
 import Hampouch.server.domain.auth.entity.VerificationPurpose;
 import Hampouch.server.domain.auth.repository.EmailVerificationRepository;
 import Hampouch.server.domain.auth.util.EmailSender;
+import Hampouch.server.domain.expense.dto.ExpenseCreateRequest;
+import Hampouch.server.domain.expense.entity.ExpenseCategory;
+import Hampouch.server.domain.expense.entity.ExpenseEmotion;
+import Hampouch.server.domain.expense.service.ExpenseService;
+import Hampouch.server.domain.user.dto.request.NicknameUpdateRequest;
+import Hampouch.server.domain.user.entity.User;
+import Hampouch.server.domain.user.repository.UserRepository;
+import Hampouch.server.domain.user.service.UserService;
 import Hampouch.server.global.mysql.MySqlContainerTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,7 +26,9 @@ import tools.jackson.databind.ObjectMapper;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -53,6 +63,15 @@ class UserConcurrencyTest {
 
     @Autowired
     JdbcTemplate jdbc;
+
+    @Autowired
+    UserService userService;
+
+    @Autowired
+    ExpenseService expenseService;
+
+    @Autowired
+    UserRepository userRepository;
 
     @MockitoBean
     EmailSender emailSender;
@@ -112,6 +131,38 @@ class UserConcurrencyTest {
         Integer originalNicknameCount = jdbc.queryForObject(
                 "SELECT COUNT(*) FROM users WHERE email = ? AND nickname = ?", Integer.class, email, originalNickname);
         assertThat(originalNicknameCount).as("변경이 거부됐으므로 원래 유저의 닉네임은 그대로여야 한다").isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("닉네임 변경과 지출 생성이 동시에 들어와도 UserOperationLock으로 직렬화되어 닉네임과 lastUpdated가 모두 보존된다")
+    void updateNicknameAndCreateExpense_bothSurviveWhenRunConcurrently() throws Exception {
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        User user = userRepository.save(User.createLocalUser(
+                "user-lock-race-" + System.currentTimeMillis() + "@hampouch.test", "encoded", "락경쟁전"));
+        Long userId = user.getId();
+
+        // 두 서비스 모두 UserOperationLock으로 같은 유저 row에 SELECT ... FOR UPDATE를 걸므로,
+        // 실제 동시 실행이어도 MySQL 행 락으로 직렬화된다 - 나중에 락을 얻는 쪽은 먼저 커밋된
+        // 최신 상태를 다시 읽으므로, 어느 쪽이 먼저 끝나든 두 변경 모두 유실 없이 남아야 한다.
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<?> nicknameFuture = executor.submit(() ->
+                    userService.updateNickname(userId, new NicknameUpdateRequest("락경쟁후")));
+            Future<?> expenseFuture = executor.submit(() ->
+                    expenseService.create(userId, new ExpenseCreateRequest(
+                            "점심", 8000, ExpenseCategory.CAFE, null, ExpenseEmotion.STRESS, null, today, null, null)));
+
+            nicknameFuture.get(10, TimeUnit.SECONDS);
+            expenseFuture.get(10, TimeUnit.SECONDS);
+        } finally {
+            executor.shutdownNow();
+        }
+
+        User reloaded = userRepository.findById(userId).orElseThrow();
+        assertThat(reloaded.getNickname())
+                .as("동시에 지출이 생성돼도 닉네임 변경 결과가 사라지면 안 된다").isEqualTo("락경쟁후");
+        assertThat(reloaded.getLastUpdated())
+                .as("동시에 닉네임이 바뀌어도 지출 생성으로 갱신된 lastUpdated가 사라지면 안 된다").isEqualTo(today);
     }
 
     private HttpResult callUpdateNickname(String accessToken, String nickname) {

--- a/src/test/java/Hampouch/server/domain/user/UserConcurrencyTest.java
+++ b/src/test/java/Hampouch/server/domain/user/UserConcurrencyTest.java
@@ -26,6 +26,8 @@ import tools.jackson.databind.ObjectMapper;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -35,6 +37,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -47,6 +50,20 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * (existsByNickname)는 통과하되 실제 UPDATE 시점에 MySQL 유니크 인덱스 잠금에 걸려 블로킹되는지,
  * holder가 커밋된 뒤 UserService.updateNickname의 saveAndFlush + DataIntegrityViolationException
  * 처리가 이를 409로 정확히 변환하는지 검증한다.
+ *
+ * Thread.sleep과 Future.isDone()만으로는 "정확히 saveAndFlush의 UPDATE가 락 대기 중"이라는 걸 보장하지
+ * 못한다 - existsByNickname 사전 검사가 holder 커밋 이후에야 실행되면(스케줄링이 느린 환경 등) 우리가
+ * 검증하려는 saveAndFlush+catch 경로를 전혀 안 타고도 똑같은 409/USER_NICKNAME_ALREADY_EXISTS로 헛통과할
+ * 수 있다.
+ *
+ * information_schema.INNODB_TRX / performance_schema.data_lock_waits로 직접 확인하는 게 가장 정확하지만
+ * Testcontainers가 만드는 애플리케이션 계정엔 PROCESS 권한이 없어 조회가 막힌다(공유 컨테이너 설정에
+ * 권한을 추가하는 대신 이미 있는 권한만으로 검증한다). 대신 UserOperationLock.lock(userId)이 트랜잭션
+ * 시작부터 끝(커밋/롤백)까지 요청자 본인 row를 계속 잠그고 있다는 점을 이용한다: 사전 검사에서 바로
+ * 409를 던지는 경로는 in-memory 연산 몇 번뿐이라 row 락이 사실상 즉시 풀리지만, saveAndFlush의 UPDATE가
+ * holder의 유니크 인덱스에 막힌 경로는 holder가 커밋할 때까지 row 락이 계속 유지된다. 별도의 저권한
+ * 프로브 커넥션으로 "SELECT ... FOR UPDATE NOWAIT"를 그 row에 반복 시도해, 연속으로 여러 번 즉시 실패하는
+ * 것("한동안 계속 잠겨 있다")을 확인해야만 다음 단계로 진행하고, 그 안에 도달 못 하면 테스트를 실패시킨다.
  */
 @MySqlContainerTest
 @AutoConfigureMockMvc
@@ -90,6 +107,7 @@ class UserConcurrencyTest {
         prepareVerifiedEmail(email);
         signup(email, originalNickname);
         String accessToken = login(email);
+        Long userAId = userRepository.findByEmail(email).orElseThrow().getId();
 
         try (Connection holderConn = jdbc.getDataSource().getConnection()) {
             holderConn.setAutoCommit(false);
@@ -109,7 +127,7 @@ class UserConcurrencyTest {
             try {
                 Future<HttpResult> call = executor.submit(() -> callUpdateNickname(accessToken, targetNickname));
 
-                Thread.sleep(500);
+                awaitSustainedRowLock(userAId);
                 assertThat(call.isDone())
                         .as("실제 요청은 우리가 커밋하지 않은 동일 닉네임 INSERT와 충돌해 막혀 있어야 한다")
                         .isFalse();
@@ -163,6 +181,42 @@ class UserConcurrencyTest {
                 .as("동시에 지출이 생성돼도 닉네임 변경 결과가 사라지면 안 된다").isEqualTo("락경쟁후");
         assertThat(reloaded.getLastUpdated())
                 .as("동시에 닉네임이 바뀌어도 지출 생성으로 갱신된 lastUpdated가 사라지면 안 된다").isEqualTo(today);
+    }
+
+    /**
+     * PATCH 요청의 트랜잭션이 userAId row를 "한동안 계속" 잠그고 있는지 확인할 때까지 폴링한다.
+     * UserOperationLock.lock()이 트랜잭션 시작부터 끝까지 이 row를 쥐고 있으므로, 사전 검사에서
+     * 바로 끝나는 빠른 경로라면 이 정도로 오래 잠긴 채 관측되지 않는다 - 연속 LOCK_STREAK회
+     * 즉시 실패(NOWAIT)를 관측해야만 saveAndFlush에서 실제로 막혀 있다고 보고 다음 단계로 진행한다.
+     * 제한 시간 안에 도달 못 하면 검증하려는 saveAndFlush+catch 경로 자체를 안 탄 것이므로 실패시킨다.
+     */
+    private void awaitSustainedRowLock(Long userId) throws Exception {
+        int LOCK_STREAK = 5;
+        int consecutiveLocked = 0;
+        long deadline = System.currentTimeMillis() + 5000;
+        while (System.currentTimeMillis() < deadline) {
+            consecutiveLocked = isRowLockedByOthers(userId) ? consecutiveLocked + 1 : 0;
+            if (consecutiveLocked >= LOCK_STREAK) {
+                return;
+            }
+            Thread.sleep(30);
+        }
+        fail("PATCH 요청이 5초 안에 user row를 지속적으로 잠근 상태에 도달하지 못했다 - "
+                + "existsByNickname 사전 검사에서 이미 처리됐거나 saveAndFlush에 도달하지 못했을 수 있다");
+    }
+
+    /** 별도의 저권한 프로브 커넥션으로 SELECT ... FOR UPDATE NOWAIT를 시도해, 다른 트랜잭션이 이미 이 row를 잠그고 있는지 즉시 확인한다. */
+    private boolean isRowLockedByOthers(Long userId) throws SQLException {
+        try (Connection probe = jdbc.getDataSource().getConnection();
+             PreparedStatement ps = probe.prepareStatement(
+                     "SELECT user_id FROM users WHERE user_id = ? FOR UPDATE NOWAIT")) {
+            ps.setLong(1, userId);
+            try (ResultSet rs = ps.executeQuery()) {
+                return !rs.next(); // 결과가 없으면 안전장치일 뿐, 정상 락 실패는 SQLException으로 옴
+            }
+        } catch (SQLException e) {
+            return true; // NOWAIT 실패 = 다른 트랜잭션이 이미 이 row를 잠그고 있다
+        }
     }
 
     private HttpResult callUpdateNickname(String accessToken, String nickname) {

--- a/src/test/java/Hampouch/server/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/Hampouch/server/domain/user/controller/UserControllerTest.java
@@ -1,0 +1,145 @@
+package Hampouch.server.domain.user.controller;
+
+import Hampouch.server.domain.user.dto.response.NicknameUpdateResponse;
+import Hampouch.server.domain.user.dto.response.UserMeResponse;
+import Hampouch.server.domain.user.service.UserService;
+import Hampouch.server.global.common.exception.CustomException;
+import Hampouch.server.global.common.exception.domain.UserErrorCode;
+import Hampouch.server.global.jwt.JwtProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class UserControllerTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    @MockitoBean
+    UserService userService;
+
+    @MockitoBean
+    JwtProvider jwtProvider; // JwtFilter가 Filter 타입이라 슬라이스에 자동 포함되며 요구하는 의존성
+
+    /**
+     * addFilters=false라 JwtFilter가 동작하지 않아 SecurityContext가 비어있다.
+     * 실제 필터가 채워주는 것과 동일한 형태로 매 테스트 전에 인증된 사용자(userId=1L)를 직접 세팅해준다.
+     */
+    @BeforeEach
+    void setUpAuthentication() {
+        var authentication = new UsernamePasswordAuthenticationToken(1L, null, List.of());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    @AfterEach
+    void clearAuthentication() {
+        SecurityContextHolder.clearContext();
+    }
+
+    // ---------- 마이페이지 기본 정보 조회 ----------
+
+    @Test
+    @DisplayName("정상 조회면 200과 닉네임·프로필이미지·handle을 반환한다")
+    void getMyInfo_returns200WithNicknameProfileImageAndHandle() throws Exception {
+        when(userService.getMyInfo(1L))
+                .thenReturn(UserMeResponse.of("절약왕 민준", null, "hampochi_minjun@hampouch.com"));
+
+        mvc.perform(get("/api/users/me"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.nickname").value("절약왕 민준"))
+                .andExpect(jsonPath("$.data.handle").value("hampochi_minjun"));
+    }
+
+    @Test
+    @DisplayName("탈퇴한 회원이면 403을 반환한다")
+    void getMyInfo_returns403WhenUserDeleted() throws Exception {
+        when(userService.getMyInfo(1L)).thenThrow(new CustomException(UserErrorCode.USER_DELETED));
+
+        mvc.perform(get("/api/users/me"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("USER_DELETED"));
+    }
+
+    // ---------- 닉네임 변경 ----------
+
+    @Test
+    @DisplayName("닉네임이 2자 미만이면 400을 반환한다")
+    void updateNickname_returns400WhenShorterThanTwoChars() throws Exception {
+        mvc.perform(patch("/api/users/me/nickname")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"nickname\":\"아\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+                .andExpect(jsonPath("$.fieldErrors.nickname").exists());
+    }
+
+    @Test
+    @DisplayName("닉네임이 10자를 초과하면 400을 반환한다")
+    void updateNickname_returns400WhenLongerThanTenChars() throws Exception {
+        mvc.perform(patch("/api/users/me/nickname")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"nickname\":\"가나다라마바사아자차카\"}")) // 11자
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.fieldErrors.nickname").exists());
+    }
+
+    @Test
+    @DisplayName("정상 변경이면 200과 바뀐 닉네임을 반환한다")
+    void updateNickname_returns200WithChangedNickname() throws Exception {
+        when(userService.updateNickname(eq(1L), any())).thenReturn(NicknameUpdateResponse.of("새닉네임"));
+
+        mvc.perform(patch("/api/users/me/nickname")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"nickname\":\"새닉네임\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.nickname").value("새닉네임"));
+    }
+
+    @Test
+    @DisplayName("이미 존재하는 닉네임이면 409를 반환한다")
+    void updateNickname_returns409WhenNicknameAlreadyExists() throws Exception {
+        when(userService.updateNickname(eq(1L), any()))
+                .thenThrow(new CustomException(UserErrorCode.USER_NICKNAME_ALREADY_EXISTS));
+
+        mvc.perform(patch("/api/users/me/nickname")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"nickname\":\"중복닉네임\"}"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("USER_NICKNAME_ALREADY_EXISTS"));
+    }
+
+    @Test
+    @DisplayName("탈퇴한 회원이면 403을 반환한다")
+    void updateNickname_returns403WhenUserDeleted() throws Exception {
+        when(userService.updateNickname(eq(1L), any())).thenThrow(new CustomException(UserErrorCode.USER_DELETED));
+
+        mvc.perform(patch("/api/users/me/nickname")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"nickname\":\"새닉네임\"}"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("USER_DELETED"));
+    }
+}

--- a/src/test/java/Hampouch/server/domain/user/service/UserServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/user/service/UserServiceTest.java
@@ -1,0 +1,157 @@
+package Hampouch.server.domain.user.service;
+
+import Hampouch.server.domain.user.dto.request.NicknameUpdateRequest;
+import Hampouch.server.domain.user.dto.response.NicknameUpdateResponse;
+import Hampouch.server.domain.user.dto.response.UserMeResponse;
+import Hampouch.server.domain.user.entity.User;
+import Hampouch.server.domain.user.entity.UserStatus;
+import Hampouch.server.domain.user.repository.UserRepository;
+import Hampouch.server.global.common.exception.CustomException;
+import Hampouch.server.global.common.exception.domain.UserErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 서비스 상태 전이·검증. 리포지토리는 Mockito 목 — DB 불필요
+ */
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    private static final Long USER_ID = 1L;
+
+    @Mock
+    UserRepository userRepository;
+
+    private UserService service() {
+        return new UserService(userRepository);
+    }
+
+    // ---------- getMyInfo ----------
+
+    @Test
+    @DisplayName("정상 조회면 닉네임·프로필이미지·이메일에서 파생한 handle을 반환한다")
+    void getMyInfo_returnsNicknameProfileImageAndDerivedHandle() {
+        User user = user(USER_ID, "hampochi_minjun@hampouch.com", "절약왕 민준");
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+
+        UserMeResponse response = service().getMyInfo(USER_ID);
+
+        assertThat(response.nickname()).isEqualTo("절약왕 민준");
+        assertThat(response.profileImageUrl()).isNull();
+        assertThat(response.handle()).isEqualTo("hampochi_minjun");
+    }
+
+    @Test
+    @DisplayName("탈퇴한 회원이면 403(USER_DELETED)을 던진다")
+    void getMyInfo_throws403WhenUserDeleted() {
+        User user = deletedUser(USER_ID);
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+
+        assertThatThrownBy(() -> service().getMyInfo(USER_ID))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.USER_DELETED);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원이면 404(USER_NOT_FOUND)를 던진다")
+    void getMyInfo_throws404WhenUserNotFound() {
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service().getMyInfo(USER_ID))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.USER_NOT_FOUND);
+    }
+
+    // ---------- updateNickname ----------
+
+    @Test
+    @DisplayName("정상 변경이면 바뀐 닉네임을 반환한다")
+    void updateNickname_returnsChangedNickname() {
+        User user = user(USER_ID, "user1@hampouch.com", "기존닉네임");
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+        when(userRepository.existsByNickname("새닉네임")).thenReturn(false);
+        when(userRepository.saveAndFlush(user)).thenReturn(user);
+
+        NicknameUpdateResponse response = service().updateNickname(USER_ID, new NicknameUpdateRequest("새닉네임"));
+
+        assertThat(response.nickname()).isEqualTo("새닉네임");
+        assertThat(user.getNickname()).isEqualTo("새닉네임");
+    }
+
+    @Test
+    @DisplayName("기존 닉네임과 같은 값이면 중복검사를 건너뛴다")
+    void updateNickname_skipsDuplicateCheckWhenNicknameUnchanged() {
+        User user = user(USER_ID, "user1@hampouch.com", "동일닉네임");
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+        when(userRepository.saveAndFlush(user)).thenReturn(user);
+
+        NicknameUpdateResponse response = service().updateNickname(USER_ID, new NicknameUpdateRequest("동일닉네임"));
+
+        assertThat(response.nickname()).isEqualTo("동일닉네임");
+        verify(userRepository, never()).existsByNickname(any());
+    }
+
+    @Test
+    @DisplayName("다른 회원이 이미 쓰는 닉네임이면 409(USER_NICKNAME_ALREADY_EXISTS)를 던진다")
+    void updateNickname_throws409WhenNicknameAlreadyExists() {
+        User user = user(USER_ID, "user1@hampouch.com", "기존닉네임");
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+        when(userRepository.existsByNickname("중복닉네임")).thenReturn(true);
+
+        assertThatThrownBy(() -> service().updateNickname(USER_ID, new NicknameUpdateRequest("중복닉네임")))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.USER_NICKNAME_ALREADY_EXISTS);
+    }
+
+    @Test
+    @DisplayName("탈퇴한 회원이면 403(USER_DELETED)을 던진다")
+    void updateNickname_throws403WhenUserDeleted() {
+        User user = deletedUser(USER_ID);
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+
+        assertThatThrownBy(() -> service().updateNickname(USER_ID, new NicknameUpdateRequest("새닉네임")))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.USER_DELETED);
+    }
+
+    @Test
+    @DisplayName("사전검사를 통과한 직후 동시에 다른 회원이 선점하면(saveAndFlush의 DataIntegrityViolationException) 409로 변환한다")
+    void updateNickname_throws409WhenConcurrentSaveHitsUniqueConstraint() {
+        // existsByNickname 사전 검사는 통과했지만, saveAndFlush 시점에 다른 트랜잭션이 먼저 커밋되어
+        // uk_user_nickname 제약을 위반하는 경쟁 상태를 재현한다.
+        User user = user(USER_ID, "user1@hampouch.com", "기존닉네임");
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+        when(userRepository.existsByNickname("경합닉네임")).thenReturn(false);
+        when(userRepository.saveAndFlush(user)).thenThrow(new DataIntegrityViolationException("uk_user_nickname"));
+
+        assertThatThrownBy(() -> service().updateNickname(USER_ID, new NicknameUpdateRequest("경합닉네임")))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.USER_NICKNAME_ALREADY_EXISTS);
+    }
+
+    private static User user(Long id, String email, String nickname) {
+        User user = User.createLocalUser(email, "encoded", nickname);
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    private static User deletedUser(Long id) {
+        User user = user(id, "deleted@hampouch.com", "탈퇴예정");
+        ReflectionTestUtils.setField(user, "status", UserStatus.DELETED);
+        return user;
+    }
+}

--- a/src/test/java/Hampouch/server/domain/user/service/UserServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/user/service/UserServiceTest.java
@@ -110,6 +110,19 @@ class UserServiceTest {
     }
 
     @Test
+    @DisplayName("기존 닉네임과 대소문자만 다르면(예: ab->Ab) 중복검사를 건너뛰고 새 표기로 반영된다 - uk_user_nickname은 대소문자를 구분하지 않는다")
+    void updateNickname_skipsDuplicateCheckWhenOnlyCaseDiffers() {
+        User user = user(USER_ID, "user1@hampouch.com", "ab");
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+        when(userRepository.saveAndFlush(user)).thenReturn(user);
+
+        NicknameUpdateResponse response = service().updateNickname(USER_ID, new NicknameUpdateRequest("Ab"));
+
+        assertThat(response.nickname()).isEqualTo("Ab");
+        verify(userRepository, never()).existsByNickname(any());
+    }
+
+    @Test
     @DisplayName("다른 회원이 이미 쓰는 닉네임이면 409(USER_NICKNAME_ALREADY_EXISTS)를 던진다")
     void updateNickname_throws409WhenNicknameAlreadyExists() {
         User user = user(USER_ID, "user1@hampouch.com", "기존닉네임");

--- a/src/test/java/Hampouch/server/domain/user/service/UserServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/user/service/UserServiceTest.java
@@ -11,6 +11,7 @@ import Hampouch.server.global.common.exception.domain.UserErrorCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -21,6 +22,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -35,9 +37,11 @@ class UserServiceTest {
 
     @Mock
     UserRepository userRepository;
+    @Mock
+    UserOperationLock userOperationLock;
 
     private UserService service() {
-        return new UserService(userRepository);
+        return new UserService(userRepository, userOperationLock);
     }
 
     // ---------- getMyInfo ----------
@@ -126,6 +130,21 @@ class UserServiceTest {
         assertThatThrownBy(() -> service().updateNickname(USER_ID, new NicknameUpdateRequest("새닉네임")))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.USER_DELETED);
+    }
+
+    @Test
+    @DisplayName("getUser()로 조회하기 전에 UserOperationLock으로 사용자 행을 먼저 잠근다")
+    void updateNickname_locksUserBeforeReadingIt() {
+        User user = user(USER_ID, "user1@hampouch.com", "기존닉네임");
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+        when(userRepository.existsByNickname("새닉네임")).thenReturn(false);
+        when(userRepository.saveAndFlush(user)).thenReturn(user);
+
+        service().updateNickname(USER_ID, new NicknameUpdateRequest("새닉네임"));
+
+        InOrder order = inOrder(userOperationLock, userRepository);
+        order.verify(userOperationLock).lock(USER_ID);
+        order.verify(userRepository).findById(USER_ID);
     }
 
     @Test


### PR DESCRIPTION
## 📎연관된 이슈

- close: #189

## 📄 작업 내용 요약

`UserController`/`UserService`에 처음 붙는 엔드포인트라, 이후 PR(프로필 사진, 비밀번호 변경)이 참고할 기본 골격으로 계층별로 나눠 커밋했습니다.

- `User.updateNickname()` 추가 — 기존 `setInitialNickname`(최초 설정)과 분리된 변경 전용 메서드
- `UserMeResponse`/`NicknameUpdateRequest`/`NicknameUpdateResponse` DTO 신설
- `UserService.getMyInfo()` — 탈퇴 회원 403은 기존 `getUser()`를 그대로 재사용
- `UserService.updateNickname()` — 2~10자 검증(400, Bean Validation), 중복 닉네임 검사(409, 현재 값과 같으면 스킵)
- `GET /api/users/me`, `PATCH /api/users/me/nickname` — `UserController`에 추가
- 단위 테스트: `UserServiceTest`(8), `UserControllerTest`(7)
- 동시성 통합 테스트: `UserConcurrencyTest`(1, `@MySqlContainerTest`) — `AuthConcurrencyTest`와 동일 기법(raw JDBC로 목표 닉네임 행을 커밋 전 상태로 붙잡아두기)으로 실제 MySQL 유니크 제약 경쟁을 재현

## 👀 중요 변경 사항

- **`GET /api/users/me` 응답에서 `userId` 제외**: 이슈 원문 스펙엔 `userId`·`nickname`·`profileImageUrl`·`handle` 4개 필드가 명시돼 있었지만, 이 API는 로그인 직후 홈→마이페이지 전환 시에만 호출되어 프론트가 이미 `userId`를 보유한 상태라 응답에서 뺐습니다. 
- **`handle`은 DB에 저장하지 않음**: 매 요청마다 가입 이메일 로컬파트(`@` 앞부분)에서 `UserMeResponse.of()` 팩토리 내부에서 파생시킵니다. 이메일이 바뀌면 handle도 함께 바뀝니다.
- **닉네임 변경 동시성 가드 추가**: `existsByNickname` 사전 검사만으로는 두 요청이 동시에 같은 닉네임을 통과할 수 있어(TOCTOU), `saveAndFlush` + `DataIntegrityViolationException` catch로 즉시 409로 변환하도록 했습니다(`AuthService.signup()`과 동일 패턴). 

## 🔖 Uncompleted Tasks

- 프로필 사진 업로드/반영/초기화, 비밀번호 변경 및 #108 은 후속 PR — 이번 PR의 `UserController`/`UserService` 구조를 그대로 이어붙일 예정입니다.

## 📢 To Reviewers

- `GET /api/users/me`/`PATCH .../nickname` 응답에서 `userId`를 뺀 판단에 동의하시는지 확인 부탁드립니다 — 프론트가 로그인 시점부터 `userId`를 들고 있다는 전제가 맞는지 한 번 더 봐주세요.
- 닉네임 변경 동시성 가드를 `UserOperationLock` 대신 `saveAndFlush` + 예외 변환으로 처리한 판단이 적절한지 봐주세요.
- `handle` 파생 로직을 Service가 아니라 `UserMeResponse.of()` DTO 팩토리에 둔 위치가 이 코드베이스 컨벤션과 맞는지 확인 부탁드립니다.