### PR TITLE
fix(infra): Datadog Agent 운영 다운그레이드 방지 (#206) [base: develop]

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -118,7 +118,7 @@ services:
       AWS_SECRET_KEY: ${AWS_SECRET_KEY:?필수값 누락}
 
   datadog:
-    image: registry.datadoghq.com/agent:7.81.2
+    image: registry.datadoghq.com/agent:7.82.1
     container_name: hampouch-datadog
     restart: always
     mem_limit: 384m

--- a/scripts/deployment/test_datadog_monitoring_contract.py
+++ b/scripts/deployment/test_datadog_monitoring_contract.py
@@ -50,9 +50,9 @@ class DatadogMonitoringContractTest(unittest.TestCase):
             ROOT / "scripts/observability/verify-datadog.sh"
         ).read_text(encoding="utf-8")
 
-        self.assertIn("registry.datadoghq.com/agent:7.81.2", compose)
+        self.assertIn("registry.datadoghq.com/agent:7.82.1", compose)
         self.assertIn('"${compose[@]}" pull datadog', deployment)
-        self.assertIn("MIN_DATADOG_AGENT_VERSION:-7.61.0", verification)
+        self.assertIn("MIN_DATADOG_AGENT_VERSION:-7.82.1", verification)
 
 
 if __name__ == "__main__":

--- a/scripts/observability/README.md
+++ b/scripts/observability/README.md
@@ -30,7 +30,7 @@ Compose의 `mysql-monitoring-init` 서비스가 기존 데이터 볼륨에서도
 
 ## 배포와 검증
 
-운영 Compose는 Datadog Agent 7.81.2를 고정하고 Dependabot으로 후속 패치를 받는다. 운영 배포는 이 이미지를 먼저 갱신하고 `container.restarts`를 제공하는 7.61.0 이상인지 확인한다. 이번 배포 뒤 재시작 지표가 실제 Datadog에 도착하지 않으면 배포 검증이 실패한다.
+운영 Compose는 Datadog Agent 7.82.1을 고정하고 Dependabot으로 후속 패치를 받는다. 운영 배포는 이 이미지를 먼저 갱신하고 운영 승인 하한인 7.82.1 이상인지 확인한다. 이번 배포 뒤 재시작 지표가 실제 Datadog에 도착하지 않으면 배포 검증이 실패한다.
 
 ```bash
 docker compose -f docker-compose.prod.yml up -d

--- a/scripts/observability/verify-datadog.sh
+++ b/scripts/observability/verify-datadog.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 attempts="${VERIFY_ATTEMPTS:-36}"
 interval_seconds="${VERIFY_INTERVAL_SECONDS:-5}"
-minimum_agent_version="${MIN_DATADOG_AGENT_VERSION:-7.61.0}"
+minimum_agent_version="${MIN_DATADOG_AGENT_VERSION:-7.82.1}"
 
 wait_for() {
     local description="$1"
@@ -60,7 +60,7 @@ verify_agent_version() {
 
     oldest="$(printf '%s\n%s\n' "$minimum_agent_version" "$version" | sort -V | head -n 1)"
     if [ "$oldest" != "$minimum_agent_version" ]; then
-        echo "Datadog Agent $version은 container.restarts를 보장하는 $minimum_agent_version보다 낮습니다." >&2
+        echo "Datadog Agent $version은 운영 승인 하한 $minimum_agent_version보다 낮습니다." >&2
         return 1
     fi
     echo "Datadog Agent version=$version"


### PR DESCRIPTION
## 📎연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) closes #[issue number]

- Closes #206

## 📄 작업 내용 요약
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.

- 운영 Compose의 Datadog Agent 고정 버전을 현재 운영 버전 `7.82.1`로 올렸습니다.
- 배포 런타임의 최소 허용 Agent 버전도 `7.82.1`로 맞춰 캐시·드리프트에 따른 다운그레이드를 차단합니다.
- 계약 테스트와 운영 문서를 같은 버전으로 갱신했습니다.

## 👀 중요 변경 사항
> API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요

- 애플리케이션 API와 DB 스키마 변경은 없습니다.
- 배포 시 Agent가 `7.82.1`보다 낮으면 검증이 실패하고 기존 운영 버전으로 롤백됩니다.

## 🔖 Uncompleted Tasks
> 후속 작업 예정인 사항이 있다면 작성해주세요.

- `develop` 최신 HEAD CI 통과 확인
- 전체 `develop`을 `main`에 반영한 뒤 운영 CD와 Datadog 재시작 지표 검증

## 📢 To Reviewers
> Reviewer가 주로 확인해주었으면 하는 부분을 적어주세요.

- Compose 고정 버전과 런타임 최소 버전 검증이 모두 `7.82.1`로 일치하는지 확인 부탁드립니다.