### PR TITLE
test(concurrency): 사용자별 조정 락의 비차단 계약 검증 (#210) [base: develop]

### DIFF
--- a/src/test/java/Hampouch/server/domain/challenge/ChallengeConcurrencyMySqlTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/ChallengeConcurrencyMySqlTest.java
@@ -140,6 +140,41 @@ class ChallengeConcurrencyMySqlTest {
     }
 
     @Test
+    @DisplayName("서로 다른 사용자의 챌린지 생성은 한쪽 사용자 락을 해제하기 전에 독립적으로 완료된다")
+    void doesNotBlockChallengeCreationForDifferentUsers() throws Exception {
+        User firstUser = newUser("different-user-first");
+        User secondUser = newUser("different-user-second");
+        LocalDate today = today();
+
+        pausingUserOperationLock.pauseNextLock();
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<Outcome<CreateChallengeResponse>> firstFuture = executor.submit(() -> capture(
+                    () -> challengeService.create(firstUser.getId(), createRequest(today, 70000))));
+            assertThat(pausingUserOperationLock.awaitLock()).isTrue();
+
+            Future<Outcome<CreateChallengeResponse>> secondFuture = executor.submit(() -> capture(
+                    () -> challengeService.create(secondUser.getId(), createRequest(today, 84000))));
+
+            assertThat(pausingUserOperationLock.awaitAdditionalLock()).isTrue();
+            Outcome<CreateChallengeResponse> secondOutcome = secondFuture.get(15, TimeUnit.SECONDS);
+            assertThat(secondOutcome.succeeded()).isTrue();
+            assertThat(firstFuture.isDone()).isFalse();
+
+            pausingUserOperationLock.release();
+            assertThat(firstFuture.get(15, TimeUnit.SECONDS).succeeded()).isTrue();
+        } finally {
+            pausingUserOperationLock.release();
+            executor.shutdownNow();
+        }
+
+        assertThat(challengeRepository.findInProgress(firstUser.getId()))
+                .get().extracting(Challenge::getBudgetTotal).isEqualTo(70000);
+        assertThat(challengeRepository.findInProgress(secondUser.getId()))
+                .get().extracting(Challenge::getBudgetTotal).isEqualTo(84000);
+    }
+
+    @Test
     @DisplayName("같은 유저의 휴식 시작 두 건은 하나만 성공하고 다른 한 건은 409이며 활성 휴식은 하나다")
     void serializesConcurrentRestStart() throws Exception {
         User user = newUser("rest");
@@ -498,6 +533,7 @@ class ChallengeConcurrencyMySqlTest {
 
         private final AtomicBoolean pauseNext = new AtomicBoolean();
         private volatile CountDownLatch locked = new CountDownLatch(0);
+        private volatile CountDownLatch additionalLock = new CountDownLatch(0);
         private volatile CountDownLatch release = new CountDownLatch(0);
 
         PausingUserOperationLock(UserRepository userRepository) {
@@ -506,12 +542,17 @@ class ChallengeConcurrencyMySqlTest {
 
         public synchronized void pauseNextLock() {
             locked = new CountDownLatch(1);
+            additionalLock = new CountDownLatch(1);
             release = new CountDownLatch(1);
             pauseNext.set(true);
         }
 
         public boolean awaitLock() throws InterruptedException {
             return locked.await(10, TimeUnit.SECONDS);
+        }
+
+        public boolean awaitAdditionalLock() throws InterruptedException {
+            return additionalLock.await(10, TimeUnit.SECONDS);
         }
 
         public void release() {
@@ -523,6 +564,7 @@ class ChallengeConcurrencyMySqlTest {
         public void lock(Long userId) {
             super.lock(userId);
             if (!pauseNext.compareAndSet(true, false)) {
+                additionalLock.countDown();
                 return;
             }
             locked.countDown();


### PR DESCRIPTION
## 📎연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) closes #[issue number]

- Closes #210

## 📄 작업 내용 요약
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.

- 실제 MySQL에서 사용자 A의 행 잠금을 유지한 채 사용자 B의 챌린지 생성이 독립적으로 완료되는지 검증합니다.
- 두 요청이 모두 성공하고 사용자별 진행 중 챌린지와 예산이 정확히 저장되는지 단언합니다.
- 기존 동시성 테스트용 일시정지 락에 두 번째 사용자 락 획득 신호를 추가했습니다.

## 👀 중요 변경 사항
> API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요

- 운영 코드, API, DB 스키마 변경은 없습니다.
- 새 테스트는 `@MySqlContainerTest`이므로 `mysql-test` CI job에서 실제 MySQL로 실행됩니다.

## 🔖 Uncompleted Tasks
> 후속 작업 예정인 사항이 있다면 작성해주세요.

- PR의 정확한 HEAD에서 전체 CI와 새 MySQL 테스트 통과 확인
- 머지 후 갱신된 `develop`으로 운영 릴리스 PR 생성

## 📢 To Reviewers
> Reviewer가 주로 확인해주었으면 하는 부분을 적어주세요.

- 첫 번째 사용자 락이 유지된 동안 두 번째 사용자의 전체 챌린지 생성이 완료돼 사용자별 비차단 계약을 결정론적으로 검증하는지 확인 부탁드립니다.