### PR TITLE
fix: ExpenseDetail 정합성 보장을 위해 pessimistic lock 도입 및 검증 test 추가

### DIFF
--- a/src/main/java/Hampouch/server/domain/expense/repository/ExpenseDetailRepository.java
+++ b/src/main/java/Hampouch/server/domain/expense/repository/ExpenseDetailRepository.java
@@ -1,7 +1,11 @@
 package Hampouch.server.domain.expense.repository;
 
 import Hampouch.server.domain.expense.entity.ExpenseDetail;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -9,4 +13,15 @@ import java.util.Optional;
 public interface ExpenseDetailRepository extends JpaRepository<ExpenseDetail, Long> {
 
     Optional<ExpenseDetail> findByExpenseId(Long expenseId);
+
+    /**
+     * ExpenseDetailAccess의 insert-후-재조회 전용 — 잠금 없는 SELECT는 호출 트랜잭션의 REPEATABLE READ 스냅샷이
+     * insert보다 먼저 고정돼 있으면(예: loadOwned()가 먼저 읽은 뒤) 방금 커밋된(자신의 REQUIRES_NEW insert 포함) 행을
+     * 못 볼 수 있다. FOR UPDATE는 스냅샷과 무관하게 최신 커밋 데이터를 읽어 이 문제를 피한다.
+     * PESSIMISTIC_READ(공유 락)는 이후 같은 트랜잭션의 UPDATE(memo/imageKey)와 맞물려 락 승격 데드락이 나서
+     * UserRepository.findByIdForUpdate와 동일하게 처음부터 배타 락(PESSIMISTIC_WRITE)을 잡는다.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT d FROM ExpenseDetail d WHERE d.expenseId = :expenseId")
+    Optional<ExpenseDetail> findByExpenseIdForUpdate(@Param("expenseId") Long expenseId);
 }

--- a/src/main/java/Hampouch/server/domain/expense/service/ExpenseDetailAccess.java
+++ b/src/main/java/Hampouch/server/domain/expense/service/ExpenseDetailAccess.java
@@ -30,7 +30,9 @@ public class ExpenseDetailAccess {
         } catch (DataIntegrityViolationException ignored) {
             // 다른 트랜잭션이 먼저 만든 경우 — 아래 재조회에서 그 행을 가져온다.
         }
-        return expenseDetailRepository.findByExpenseId(expense.getId())
+        // findByExpenseId(잠금 없는 SELECT)는 이 트랜잭션의 REPEATABLE READ 스냅샷이 insert보다 먼저
+        // 고정돼 있으면 방금 커밋된 행(자신의 insert 포함)을 못 볼 수 있어 findByExpenseIdForUpdate로 재조회한다.
+        return expenseDetailRepository.findByExpenseIdForUpdate(expense.getId())
                 .orElseThrow(() -> new IllegalStateException(
                         "ExpenseDetail insert 직후 재조회 실패: expenseId=" + expense.getId()));
     }

--- a/src/test/java/Hampouch/server/domain/expense/ExpenseDetailConcurrentCreationMySqlTest.java
+++ b/src/test/java/Hampouch/server/domain/expense/ExpenseDetailConcurrentCreationMySqlTest.java
@@ -1,0 +1,273 @@
+package Hampouch.server.domain.expense;
+
+import Hampouch.server.domain.expense.dto.ExpenseUpdateRequest;
+import Hampouch.server.domain.expense.entity.Expense;
+import Hampouch.server.domain.expense.entity.ExpenseCategory;
+import Hampouch.server.domain.expense.entity.ExpenseDetail;
+import Hampouch.server.domain.expense.entity.ExpenseEmotion;
+import Hampouch.server.domain.expense.repository.ExpenseDetailRepository;
+import Hampouch.server.domain.expense.repository.ExpenseRepository;
+import Hampouch.server.domain.expense.service.ExpenseDetailInserter;
+import Hampouch.server.domain.expense.service.ExpenseImageService;
+import Hampouch.server.domain.expense.service.ExpenseService;
+import Hampouch.server.domain.user.entity.User;
+import Hampouch.server.domain.user.repository.UserRepository;
+import Hampouch.server.global.mysql.MySqlContainerTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+
+import java.time.LocalDate;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * ExpenseDetail이 없는 지출에 메모 수정과 이미지 첨부가 동시에 최초 생성을 시도할 때,
+ * ExpenseDetailAccess의 REQUIRES_NEW insert 경쟁 복구가 실 MySQL 위에서도 두 순서 모두 정상 동작하는지 고정한다.
+ */
+@MySqlContainerTest
+@Import(ExpenseDetailConcurrentCreationMySqlTest.PausingInserterConfig.class)
+class ExpenseDetailConcurrentCreationMySqlTest {
+
+    private static final LocalDate EXPENSE_DATE = LocalDate.of(2026, 8, 12);
+    private static final String MEMO = "동시성 테스트 메모";
+
+    @Autowired
+    ExpenseService expenseService;
+    @Autowired
+    ExpenseImageService expenseImageService;
+    @Autowired
+    ExpenseRepository expenseRepository;
+    @Autowired
+    ExpenseDetailRepository expenseDetailRepository;
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    PausingExpenseDetailInserter pausingExpenseDetailInserter;
+
+    @MockitoBean
+    S3Client s3Client;
+
+    @BeforeEach
+    void stubImageUploadCheck() {
+        when(s3Client.headObject(any(HeadObjectRequest.class))).thenReturn(HeadObjectResponse.builder().build());
+    }
+
+    @Test
+    @DisplayName("메모 insert가 먼저 커밋되면 이미지 첨부는 PK 충돌 후 재조회로 복구되고 두 필드가 모두 남는다")
+    void memoInsertWinsThenImageAttachRecovers() throws Exception {
+        User user = saveUser();
+        Expense expense = saveExpense(user);
+        String imageKey = imageKey(user);
+        pausingExpenseDetailInserter.pin(PausingExpenseDetailInserter.Role.MEMO, PausingExpenseDetailInserter.Role.IMAGE);
+
+        RaceResult result = race(
+                () -> {
+                    pausingExpenseDetailInserter.actAs(PausingExpenseDetailInserter.Role.MEMO);
+                    expenseService.update(user.getId(), expense.getId(), updateRequestWithMemo(expense));
+                    return null;
+                },
+                () -> {
+                    pausingExpenseDetailInserter.actAs(PausingExpenseDetailInserter.Role.IMAGE);
+                    expenseImageService.attach(user.getId(), expense.getId(), imageKey);
+                    return null;
+                });
+
+        assertSucceeded(result);
+        assertFinalDetail(expense.getId(), imageKey);
+    }
+
+    @Test
+    @DisplayName("이미지 첨부 insert가 먼저 커밋되면 메모 수정은 PK 충돌 후 재조회로 복구되고 두 필드가 모두 남는다")
+    void imageAttachWinsThenMemoUpdateRecovers() throws Exception {
+        User user = saveUser();
+        Expense expense = saveExpense(user);
+        String imageKey = imageKey(user);
+        pausingExpenseDetailInserter.pin(PausingExpenseDetailInserter.Role.IMAGE, PausingExpenseDetailInserter.Role.MEMO);
+
+        RaceResult result = race(
+                () -> {
+                    pausingExpenseDetailInserter.actAs(PausingExpenseDetailInserter.Role.MEMO);
+                    expenseService.update(user.getId(), expense.getId(), updateRequestWithMemo(expense));
+                    return null;
+                },
+                () -> {
+                    pausingExpenseDetailInserter.actAs(PausingExpenseDetailInserter.Role.IMAGE);
+                    expenseImageService.attach(user.getId(), expense.getId(), imageKey);
+                    return null;
+                });
+
+        assertSucceeded(result);
+        assertFinalDetail(expense.getId(), imageKey);
+    }
+
+    private void assertSucceeded(RaceResult result) {
+        assertThat(result.memo().error()).as("메모 수정 결과").isNull();
+        assertThat(result.image().error()).as("이미지 첨부 결과").isNull();
+    }
+
+    private void assertFinalDetail(Long expenseId, String imageKey) {
+        ExpenseDetail detail = expenseDetailRepository.findByExpenseId(expenseId).orElseThrow();
+        assertThat(detail.getMemo()).isEqualTo(MEMO);
+        assertThat(detail.getImageKey()).isEqualTo(imageKey);
+    }
+
+    private User saveUser() {
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        return userRepository.saveAndFlush(User.createLocalUser(
+                "detail-race-" + suffix + "@hampouch.test", "encoded", "동시성" + suffix));
+    }
+
+    private Expense saveExpense(User user) {
+        return expenseRepository.saveAndFlush(Expense.of(
+                "점심", 8000, ExpenseCategory.CAFE, ExpenseEmotion.STRESS, EXPENSE_DATE, user));
+    }
+
+    private String imageKey(User user) {
+        return "expenses/" + user.getId() + "/" + UUID.randomUUID() + ".jpg";
+    }
+
+    private ExpenseUpdateRequest updateRequestWithMemo(Expense expense) {
+        return new ExpenseUpdateRequest(
+                expense.getName(),
+                expense.getPrice(),
+                expense.getCategory(),
+                null,
+                expense.getEmotion(),
+                null,
+                expense.getExpenseDate(),
+                MEMO);
+    }
+
+    private RaceResult race(Callable<Void> memoTask, Callable<Void> imageTask) throws Exception {
+        CyclicBarrier startBarrier = new CyclicBarrier(2);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<Outcome> memoFuture = executor.submit(() -> runAfterBarrier(startBarrier, memoTask));
+            Future<Outcome> imageFuture = executor.submit(() -> runAfterBarrier(startBarrier, imageTask));
+            return new RaceResult(memoFuture.get(15, TimeUnit.SECONDS), imageFuture.get(15, TimeUnit.SECONDS));
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private Outcome runAfterBarrier(CyclicBarrier barrier, Callable<Void> task) {
+        try {
+            barrier.await(5, TimeUnit.SECONDS);
+            task.call();
+            return new Outcome(null);
+        } catch (Throwable error) {
+            return new Outcome(error);
+        }
+    }
+
+    private record Outcome(Throwable error) {
+    }
+
+    private record RaceResult(Outcome memo, Outcome image) {
+    }
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class PausingInserterConfig {
+
+        @Bean
+        @Primary
+        PausingExpenseDetailInserter pausingExpenseDetailInserter(ExpenseDetailRepository expenseDetailRepository) {
+            return new PausingExpenseDetailInserter(expenseDetailRepository);
+        }
+    }
+
+    /**
+     * insert 순서를 결정적으로 고정하는 테스트 더블.
+     * 두 스레드는 먼저 CyclicBarrier에서 만나 "각자 자기 스냅샷 기준으로는 행이 없다"고 이미 판단한 뒤임을 보장하고,
+     * 그 다음 패자만 승자의 실제 insert(flush)가 끝날 때까지 대기해 PK 충돌을 결정적으로 재현한다.
+     */
+    static class PausingExpenseDetailInserter extends ExpenseDetailInserter {
+
+        enum Role { MEMO, IMAGE }
+
+        private final ThreadLocal<Role> currentRole = new ThreadLocal<>();
+        private volatile CyclicBarrier bothArrived;
+        private volatile CountDownLatch winnerDone;
+        private volatile Role winnerRole;
+        private volatile Role loserRole;
+
+        PausingExpenseDetailInserter(ExpenseDetailRepository expenseDetailRepository) {
+            super(expenseDetailRepository);
+        }
+
+        void pin(Role winner, Role loser) {
+            this.winnerRole = winner;
+            this.loserRole = loser;
+            this.bothArrived = new CyclicBarrier(2);
+            this.winnerDone = new CountDownLatch(1);
+        }
+
+        void actAs(Role role) {
+            currentRole.set(role);
+        }
+
+        @Override
+        @Transactional(propagation = Propagation.REQUIRES_NEW)
+        public void insert(Expense expense) {
+            CyclicBarrier barrier = this.bothArrived;
+            if (barrier == null) {
+                super.insert(expense);
+                return;
+            }
+
+            awaitBarrier(barrier);
+            Role role = currentRole.get();
+            if (role == loserRole) {
+                awaitLatch(winnerDone);
+            }
+            try {
+                super.insert(expense);
+            } finally {
+                if (role == winnerRole) {
+                    winnerDone.countDown();
+                }
+            }
+        }
+
+        private void awaitBarrier(CyclicBarrier barrier) {
+            try {
+                barrier.await(5, TimeUnit.SECONDS);
+            } catch (Exception e) {
+                throw new IllegalStateException("insert 동시 도착 대기 실패", e);
+            }
+        }
+
+        private void awaitLatch(CountDownLatch latch) {
+            try {
+                if (!latch.await(5, TimeUnit.SECONDS)) {
+                    throw new IllegalStateException("승자 insert 완료 대기 시간 초과");
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("승자 insert 완료 대기 중 인터럽트", e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 📎연관된 이슈

- close: #179

## 📄 작업 내용 요약

- `ExpenseDetailConcurrentCreationMySqlTest`(`@MySqlContainerTest`) 추가 — 메모 선행/이미지 선행 두 순서를 각각 결정적으로 고정해 검증. S3 HeadObject는 `@MockitoBean`으로 격리하고 DB 트랜잭션 경쟁만 실 MySQL로 태움.
- 테스트를 처음 돌렸을 때 두 케이스 모두 `IllegalStateException: ExpenseDetail insert 직후 재조회 실패`로 실패. 동시성을 제거한 단독 호출로도 동일하게 재현돼, 레이스가 아니라 **`ExpenseDetail`을 처음 만드는 모든 시도가 실 MySQL(REPEATABLE READ)에서 깨지는 구조적 버그**임을 확인.
- 원인: `ExpenseDetailInserter.insert()`는 `REQUIRES_NEW`로 별도 트랜잭션에서 커밋되는데, `ExpenseDetailAccess.createThenReload()`의 insert-후-재조회(`findByExpenseId`, plain SELECT)는 바깥 트랜잭션에서 실행됩니다. 바깥 트랜잭션은 이미 `loadOwned()`의 plain SELECT로 REPEATABLE READ 스냅샷이 고정된 뒤라, 방금 커밋된 행(승자 자신의 insert 포함)을 재조회가 못 보는 경우가 있었습니다.
- 수정: `ExpenseDetailRepository.findByExpenseIdForUpdate`(`@Lock(PESSIMISTIC_WRITE)`, `UserRepository.findByIdForUpdate`와 동일 패턴)를 추가하고 `createThenReload()`의 재조회를 여기로 교체 — `SELECT ... FOR UPDATE`는 스냅샷과 무관하게 최신 커밋 데이터를 읽습니다.
- 검증: 새 회귀 테스트 2건 반복 실행으로 재현성 확인, 전체 `test`(유닛) 및 전체 `mysqlTest`(`ChallengeConcurrencyMySqlTest`/`ExpenseNoSpendConsistencyMySqlTest` 포함) — 기존 동시성 테스트에 회귀 없음.

## 👀 중요 변경 사항

- `ExpenseDetail` 생성 시 모든 `insert` 작업이 `IllegalStateException`을 도출하던 오류 수정
- `findByExpenseIdForUpdate`은 `PESSIMISTIC_WRITE`(배타 락) 도입 ㅡ 재조회 시점에 곧바로 배타 락을 잡아, 한쪽이 정상적으로 대기하게 만들어 데드락 방지.
- **`ExpenseDetail`을 최초 생성하는 두 경로(메모 수정, 이미지 첨부)가 동시에 겹치면 그중 하나는 재조회 시점에 짧게 블로킹.** 두 요청이 완전히 병렬로 끝나진 않는다는 점은 참고해주세요.
- expense·battle 도메인 전반에 같은 클래스의 버그(REQUIRES_NEW로 커밋 분리 + 바깥 트랜잭션 재조회)가 더 있는지 점검 — `REQUIRES_NEW`는 도메인 전체에서 `ExpenseDetailInserter`가 유일한 사용처였고, `PESSIMISTIC_READ`도 이번 시행착오 전까지 사용처가 없어 다른 곳에 재발 소지는 없습니다. `BattleService.join()`이 비슷한 `catch (DataIntegrityViolationException)` 패턴을 쓰지만 같은 트랜잭션에서 insert하고 충돌 시 재조회 없이 바로 에러 응답만 해 구조적으로 안전함을 확인했습니다.

## 🔖 Uncompleted Tasks

- 없음

## 📢 To Reviewers

- `PESSIMISTIC_WRITE` 채택 근거(공유 락 승격 데드락 재현)와, 그로 인해 메모/이미지 동시 최초 생성이 완전 병렬이 아니라 짧게 직렬화된다는 트레이드오프가 괜찮은지 봐주세요.
- `ExpenseDetailConcurrentCreationMySqlTest`의 `PausingExpenseDetailInserter`(insert 순서를 결정적으로 고정하는 테스트 더블) 구조가 기존 `PausingUserOperationLock`(`ExpenseNoSpendConsistencyMySqlTest`) 패턴과 일관되는지 확인 부탁드립니다.