### PR TITLE
fix(deploy): Datadog 배포 검증 대기시간과 취소 정리 제한 (#214) [base: develop]

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,7 @@ jobs:
   build-and-deploy:
     #Github가 제공하는 임시 가상머신에서 빌드하기 때문에 EC2는 컴파일 부담 x
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       #1. 저장소 코드를 러너로 가져옴

--- a/scripts/deployment/README.md
+++ b/scripts/deployment/README.md
@@ -30,7 +30,7 @@ Datadog 서비스가 있는 배포에서는 `datadog_verification.py deployment`
 4. `datadog-verification.json`에 기록된 여섯 모니터의 이름, 종류, 쿼리, 임계치, 필수 옵션과 태그가 실제 설정과 같은지 확인한다.
 5. 각 모니터가 `published` 상태이고 활성 downtime이 없으며, 승인된 알림 수신처가 메시지에 포함됐는지 확인한다.
 
-수집 지연은 기본 4분까지 기다린다. `DD_DATA_VERIFY_ATTEMPTS`와 `DD_DATA_VERIFY_INTERVAL_SECONDS`로 제한 시간을 바꿀 수 있다. 하나라도 확인되지 않으면 배포는 실패하고 앱 롤백을 실행한다.
+수집 지연 검증은 API 응답시간과 polling 간격을 모두 포함해 최대 5분만 기다린다. 이미 도착한 항목은 다음 polling에서 제외하고 미도착 항목을 즉시 로그에 남긴다. `DD_DATA_VERIFY_ATTEMPTS`와 `DD_DATA_VERIFY_INTERVAL_SECONDS`로 polling을 조정할 수 있고, `DD_DATA_VERIFY_TIMEOUT_SECONDS`는 1~300초 안에서만 줄일 수 있다. 검증 프로세스는 310초에 강제 종료되며 timeout이나 취소 신호에서도 로그 프로브를 정리하고 앱 롤백을 실행한다. CD job 전체 상한은 빌드와 전송을 포함해 20분이다. 하나라도 확인되지 않으면 배포는 실패하고 앱 롤백을 실행한다.
 
 운영 EC2의 `.env`에 다음 값을 설정한다. 값은 저장소, PR, GitHub Actions 로그에 넣지 않는다.
 

--- a/scripts/deployment/datadog_verification.py
+++ b/scripts/deployment/datadog_verification.py
@@ -30,6 +30,8 @@ DATADOG_API_BASES = {
     "us2.ddog-gov.com": "https://api.us2.ddog-gov.com",
 }
 DISCORD_API_BASE = "https://discord.com/api/v10"
+MAX_DEPLOYMENT_TIMEOUT_SECONDS = 300
+DEPLOYMENT_TIMEOUT_MESSAGE = "Datadog 배포 데이터 검증의 전체 제한시간을 초과했습니다."
 
 
 def load_env_file(path):
@@ -64,6 +66,18 @@ class DatadogClient:
         self.app_key = app_key
         self.api_base = DATADOG_API_BASES[site]
         self.timeout_seconds = timeout_seconds
+        self.deadline = None
+
+    def set_deadline(self, deadline):
+        self.deadline = deadline
+
+    def request_timeout_seconds(self):
+        if self.deadline is None:
+            return self.timeout_seconds
+        remaining_seconds = self.deadline - time.monotonic()
+        if remaining_seconds <= 0:
+            raise VerificationError(DEPLOYMENT_TIMEOUT_MESSAGE)
+        return max(0.001, min(self.timeout_seconds, remaining_seconds))
 
     def request(self, method, path, params=None, body=None, require_app_key=True):
         query = urllib.parse.urlencode(params or {}, doseq=True)
@@ -84,13 +98,18 @@ class DatadogClient:
 
         request = urllib.request.Request(url, data=data, headers=headers, method=method)
         try:
-            with urllib.request.urlopen(request, timeout=self.timeout_seconds) as response:
+            with urllib.request.urlopen(
+                request,
+                timeout=self.request_timeout_seconds(),
+            ) as response:
                 payload = response.read()
         except urllib.error.HTTPError as error:
             raise VerificationError(
                 f"Datadog API 요청이 실패했습니다: {method} {path}, HTTP {error.code}"
             ) from error
-        except urllib.error.URLError as error:
+        except (urllib.error.URLError, TimeoutError) as error:
+            if self.deadline is not None and time.monotonic() >= self.deadline:
+                raise VerificationError(DEPLOYMENT_TIMEOUT_MESSAGE) from error
             raise VerificationError(f"Datadog API에 연결할 수 없습니다: {method} {path}") from error
 
         if not payload:
@@ -273,19 +292,26 @@ def iso_timestamp(epoch_seconds):
     return datetime.fromtimestamp(epoch_seconds, timezone.utc).isoformat().replace("+00:00", "Z")
 
 
-def pending_deployment_data(client, config, from_epoch, sha):
+def pending_deployment_data(client, config, from_epoch, sha, previous_pending=None):
     pending = []
+    selected = None if previous_pending is None else set(previous_pending)
     now_epoch = int(time.time())
     for metric in config["metrics"]:
+        key = f"metric:{metric['name']}"
+        if selected is not None and key not in selected:
+            continue
         response = client.get(
             "/api/v1/query",
             params={"from": from_epoch, "to": now_epoch, "query": metric["query"]},
         )
         if not metric_has_fresh_point(response, from_epoch):
-            pending.append(f"metric:{metric['name']}")
+            pending.append(key)
 
     marker_query = f'"hampouch_deploy_verification" "sha:{sha}"'
     for log in config["logs"]:
+        key = f"log:{log['name']}"
+        if selected is not None and key not in selected:
+            continue
         response = client.post(
             "/api/v2/logs/events/search",
             {
@@ -299,19 +325,45 @@ def pending_deployment_data(client, config, from_epoch, sha):
             },
         )
         if not response.get("data"):
-            pending.append(f"log:{log['name']}")
+            pending.append(key)
     return pending
 
 
-def wait_for_deployment_data(client, config, from_epoch, sha, attempts, interval_seconds):
+def wait_for_deployment_data(
+    client,
+    config,
+    from_epoch,
+    sha,
+    attempts,
+    interval_seconds,
+    deadline,
+    clock=None,
+    sleeper=None,
+):
+    clock = clock or time.monotonic
+    sleeper = sleeper or time.sleep
+    pending = None
     for attempt in range(1, attempts + 1):
-        pending = pending_deployment_data(client, config, from_epoch, sha)
+        if clock() >= deadline:
+            raise VerificationError(DEPLOYMENT_TIMEOUT_MESSAGE)
+        pending = pending_deployment_data(client, config, from_epoch, sha, pending)
+        if clock() >= deadline:
+            raise VerificationError(DEPLOYMENT_TIMEOUT_MESSAGE)
         if not pending:
-            print("이번 배포 뒤의 Datadog 호스트·컨테이너·JVM·MySQL 지표와 앱·MySQL 로그를 확인했습니다.")
+            print(
+                "이번 배포 뒤의 Datadog 호스트·컨테이너·JVM·MySQL 지표와 앱·MySQL 로그를 확인했습니다.",
+                flush=True,
+            )
             return
-        print(f"Datadog 데이터 도착 대기 {attempt}/{attempts}: {', '.join(pending)}")
+        print(
+            f"Datadog 데이터 도착 대기 {attempt}/{attempts}: {', '.join(pending)}",
+            flush=True,
+        )
         if attempt < attempts:
-            time.sleep(interval_seconds)
+            remaining_seconds = deadline - clock()
+            if remaining_seconds <= 0:
+                raise VerificationError(DEPLOYMENT_TIMEOUT_MESSAGE)
+            sleeper(min(interval_seconds, remaining_seconds))
     raise VerificationError("이번 배포에서 생성된 필수 Datadog 지표 또는 로그가 제한 시간 안에 도착하지 않았습니다.")
 
 
@@ -451,6 +503,7 @@ def build_parser():
     deployment.add_argument("--sha", required=True)
     deployment.add_argument("--attempts", type=int)
     deployment.add_argument("--interval-seconds", type=int)
+    deployment.add_argument("--timeout-seconds", type=int)
 
     alert_path = subparsers.add_parser("alert-path")
     alert_path.add_argument("--attempts", type=int)
@@ -466,12 +519,39 @@ def main():
         config = load_config(args.config)
         client = create_client()
         if args.command == "deployment":
-            args.attempts = args.attempts or int(os.environ.get("DD_DATA_VERIFY_ATTEMPTS", "24"))
-            args.interval_seconds = args.interval_seconds or int(
-                os.environ.get("DD_DATA_VERIFY_INTERVAL_SECONDS", "10")
+            args.attempts = (
+                args.attempts
+                if args.attempts is not None
+                else int(os.environ.get("DD_DATA_VERIFY_ATTEMPTS", "24"))
             )
+            args.interval_seconds = (
+                args.interval_seconds
+                if args.interval_seconds is not None
+                else int(os.environ.get("DD_DATA_VERIFY_INTERVAL_SECONDS", "10"))
+            )
+            args.timeout_seconds = (
+                args.timeout_seconds
+                if args.timeout_seconds is not None
+                else int(
+                    os.environ.get(
+                        "DD_DATA_VERIFY_TIMEOUT_SECONDS",
+                        str(MAX_DEPLOYMENT_TIMEOUT_SECONDS),
+                    )
+                )
+            )
+            if args.attempts <= 0:
+                raise VerificationError("Datadog 배포 데이터 검증 시도 횟수는 1 이상이어야 합니다.")
+            if args.interval_seconds < 0:
+                raise VerificationError("Datadog 배포 데이터 검증 간격은 0초 이상이어야 합니다.")
+            if not 1 <= args.timeout_seconds <= MAX_DEPLOYMENT_TIMEOUT_SECONDS:
+                raise VerificationError(
+                    f"Datadog 배포 데이터 검증 제한시간은 1~{MAX_DEPLOYMENT_TIMEOUT_SECONDS}초여야 합니다."
+                )
             if not re.fullmatch(r"[0-9a-fA-F]{7,40}", args.sha):
                 raise VerificationError("배포 SHA 형식이 올바르지 않습니다.")
+            deadline = time.monotonic() + args.timeout_seconds
+            client.set_deadline(deadline)
+            print(f"Datadog 배포 데이터 검증 제한시간={args.timeout_seconds}초", flush=True)
             validate_api_key(client)
             verify_all_monitors(client, config)
             wait_for_deployment_data(
@@ -481,6 +561,7 @@ def main():
                 args.sha.lower(),
                 args.attempts,
                 args.interval_seconds,
+                deadline,
             )
         else:
             args.attempts = args.attempts or int(os.environ.get("DD_ALERT_VERIFY_ATTEMPTS", "30"))

--- a/scripts/deployment/deploy-and-verify.sh
+++ b/scripts/deployment/deploy-and-verify.sh
@@ -11,6 +11,7 @@ minimum_available_memory_mb="${MIN_AVAILABLE_MEMORY_MB:-256}"
 maximum_container_memory_percent="${MAX_CONTAINER_MEMORY_PERCENT:-90}"
 health_attempts="${HEALTH_ATTEMPTS:-24}"
 health_interval_seconds="${HEALTH_INTERVAL_SECONDS:-5}"
+datadog_process_timeout_seconds=310
 os_release_file="${OS_RELEASE_FILE:-/etc/os-release}"
 meminfo_file="${MEMINFO_FILE:-/proc/meminfo}"
 
@@ -144,11 +145,12 @@ verify_datadog_delivery() {
         'while :; do printf "%s\n" "$HAMPOUCH_DEPLOY_MARKER"; sleep 5; done' >/dev/null
     echo "Datadog 로그 도착 검증용 임시 앱·MySQL 로그 표식을 기록했습니다."
 
-    python3 scripts/deployment/datadog_verification.py \
-        --env-file .env \
-        deployment \
-        --from-epoch "$deployment_started_epoch" \
-        --sha "$sha_tag" || verification_exit_code="$?"
+    timeout --signal=TERM --kill-after=5s "${datadog_process_timeout_seconds}s" \
+        python3 -u scripts/deployment/datadog_verification.py \
+            --env-file .env \
+            deployment \
+            --from-epoch "$deployment_started_epoch" \
+            --sha "$sha_tag" || verification_exit_code="$?"
     cleanup_log_probes
     return "$verification_exit_code"
 }
@@ -230,14 +232,18 @@ promote_staged_compose() {
     fi
 }
 
-on_error() {
-    local exit_code="$?"
+disable_failure_traps() {
+    trap - ERR INT TERM HUP
+}
+
+handle_failure() {
+    local exit_code="$1"
+    local message="$2"
     local rollback_exit_code=0
 
-    trap - ERR
     set +e
     cleanup_log_probes
-    echo "배포 검증이 실패했습니다." >&2
+    echo "$message" >&2
     print_diagnostics
     if [ "$deployment_started" = true ]; then
         rollback
@@ -247,8 +253,25 @@ on_error() {
         else
             discard_staged_compose
         fi
+    else
+        discard_staged_compose
     fi
     exit "$exit_code"
+}
+
+on_error() {
+    local exit_code="$?"
+
+    disable_failure_traps
+    handle_failure "$exit_code" "배포 검증이 실패했습니다."
+}
+
+on_signal() {
+    local signal_name="$1"
+    local exit_code="$2"
+
+    disable_failure_traps
+    handle_failure "$exit_code" "배포 검증이 ${signal_name} 신호로 중단됐습니다."
 }
 
 cleanup_old_images() {
@@ -271,8 +294,11 @@ cleanup_old_images() {
 }
 
 trap on_error ERR
+trap 'on_signal INT 130' INT
+trap 'on_signal TERM 143' TERM
+trap 'on_signal HUP 129' HUP
 
-for command_name in curl docker free sha256sum; do
+for command_name in curl docker free sha256sum timeout; do
     command -v "$command_name" >/dev/null
 done
 
@@ -321,6 +347,6 @@ verify_resources
 
 promote_staged_compose
 deployment_started=false
-trap - ERR
+trap - ERR INT TERM HUP
 cleanup_old_images
 echo "배포 SHA ${sha_tag}의 운영 환경 검증을 통과했습니다."

--- a/scripts/deployment/test-deploy-and-verify.sh
+++ b/scripts/deployment/test-deploy-and-verify.sh
@@ -173,6 +173,7 @@ docker() {
                 >>"$FAKE_STATE_DIR/events"
             ;;
         rm)
+            printf 'probe-cleanup:%s\n' "$*" >>"$FAKE_STATE_DIR/events"
             return 0
             ;;
         stats)
@@ -214,26 +215,63 @@ sleep() {
     return 0
 }
 
+timeout() {
+    printf 'datadog-process-timeout:%s\n' "$*" >>"$FAKE_STATE_DIR/events"
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --signal=* | --kill-after=*)
+                shift
+                ;;
+            *s)
+                shift
+                break
+                ;;
+            *)
+                break
+                ;;
+        esac
+    done
+    if [ "${FAKE_DATADOG_SIGNAL:-0}" = "1" ]; then
+        while :; do
+            :
+        done
+    fi
+    if [ "${FAKE_DATADOG_TIMEOUT:-0}" = "1" ]; then
+        return 124
+    fi
+    "$@"
+}
+
 python3() {
+    [ "${1:-}" = "-u" ] || fail "Datadog 검증 Python이 unbuffered 모드가 아닙니다: $*"
+    shift
     [ "${1:-}" = "scripts/deployment/datadog_verification.py" ] \
         || fail "지원하지 않는 Python 실행: $*"
     printf 'datadog-verification\n' >>"$FAKE_STATE_DIR/events"
     [ "${FAKE_DATADOG_DELIVERY_FAIL:-0}" != "1" ]
 }
 
-export -f curl docker fail free python3 read_state sha256sum sleep write_state
+export -f curl docker fail free python3 read_state sha256sum sleep timeout write_state
 trap cleanup EXIT
 
 run_case() {
     local case_name="$1"
     local app_check_fail="$2"
     local datadog_delivery_fail="$3"
+    local datadog_timeout="$4"
+    local datadog_signal="$5"
     local case_dir="$test_root/$case_name"
     local state_dir="$case_dir/state"
     local log_file="$case_dir/run.log"
     local expected_failure=0
+    local deployment_status=0
+    local deployment_pid=""
+    local attempt
 
-    if [ "$app_check_fail" = "1" ] || [ "$datadog_delivery_fail" = "1" ]; then
+    if [ "$app_check_fail" = "1" ] \
+        || [ "$datadog_delivery_fail" = "1" ] \
+        || [ "$datadog_timeout" = "1" ] \
+        || [ "$datadog_signal" = "1" ]; then
         expected_failure=1
     fi
 
@@ -257,8 +295,39 @@ run_case() {
     export FAKE_STATE_DIR="$state_dir"
     export FAKE_APP_CHECK_FAIL="$app_check_fail"
     export FAKE_DATADOG_DELIVERY_FAIL="$datadog_delivery_fail"
+    export FAKE_DATADOG_TIMEOUT="$datadog_timeout"
+    export FAKE_DATADOG_SIGNAL="$datadog_signal"
 
-    if (
+    if [ "$datadog_signal" = "1" ]; then
+        (
+            cd "$case_dir"
+            exec env \
+                DEPLOY_SHA_TAG=abcdef12 \
+                EXPECTED_COMPOSE_SHA256=compose-hash \
+                COMPOSE_FILE=docker-compose.prod.next.yml \
+                ACTIVE_COMPOSE_FILE=docker-compose.prod.yml \
+                HEALTH_ATTEMPTS=1 \
+                HEALTH_INTERVAL_SECONDS=0 \
+                OS_RELEASE_FILE="$case_dir/os-release" \
+                MEMINFO_FILE="$case_dir/meminfo" \
+                bash "$deployment_script"
+        ) >"$log_file" 2>&1 &
+        deployment_pid="$!"
+        for ((attempt = 1; attempt <= 100; attempt++)); do
+            if grep -q '^datadog-process-timeout:' "$state_dir/events"; then
+                break
+            fi
+            /bin/sleep 0.01
+        done
+        grep -q '^datadog-process-timeout:' "$state_dir/events" \
+            || fail "취소 신호를 보낼 Datadog 검증 프로세스가 시작되지 않았습니다"
+        kill -TERM "$deployment_pid"
+        if wait "$deployment_pid"; then
+            deployment_status=0
+        else
+            deployment_status="$?"
+        fi
+    elif (
         cd "$case_dir"
         DEPLOY_SHA_TAG=abcdef12 \
             EXPECTED_COMPOSE_SHA256=compose-hash \
@@ -270,12 +339,24 @@ run_case() {
             MEMINFO_FILE="$case_dir/meminfo" \
             bash "$deployment_script"
     ) >"$log_file" 2>&1; then
+        deployment_status=0
+    else
+        deployment_status="$?"
+    fi
+
+    if [ "$deployment_status" = "0" ]; then
         [ "$expected_failure" = "0" ] || fail "실패 시나리오가 성공했습니다"
     else
         [ "$expected_failure" = "1" ] || {
             sed -n '1,240p' "$log_file" >&2
             fail "성공 시나리오가 실패했습니다"
         }
+    fi
+    if [ "$datadog_timeout" = "1" ]; then
+        [ "$deployment_status" = "124" ] || fail "timeout 종료 코드가 124가 아닙니다: $deployment_status"
+    fi
+    if [ "$datadog_signal" = "1" ]; then
+        [ "$deployment_status" = "143" ] || fail "TERM 종료 코드가 143이 아닙니다: $deployment_status"
     fi
 
     grep -qx 'health:hampouch-datadog' "$state_dir/events" \
@@ -290,8 +371,16 @@ run_case() {
             || fail "앱 로그 배포 표식이 기록되지 않았습니다"
         grep -qx 'probe:hampouch-mysql-log-probe:hampouch-mysql:hampouch_deploy_verification sha:abcdef12' "$state_dir/events" \
             || fail "MySQL 로그 배포 표식이 기록되지 않았습니다"
-        grep -qx 'datadog-verification' "$state_dir/events" \
-            || fail "Datadog 데이터 도착 검증이 실행되지 않았습니다"
+        grep -q '^datadog-process-timeout:--signal=TERM --kill-after=5s 310s python3 -u scripts/deployment/datadog_verification.py ' "$state_dir/events" \
+            || fail "Datadog 검증 프로세스의 절대 제한이 적용되지 않았습니다"
+        [ "$(grep -c '^probe-cleanup:' "$state_dir/events")" -ge 2 ] \
+            || fail "Datadog 로그 프로브가 검증 종료 뒤 정리되지 않았습니다"
+        if [ "$datadog_timeout" = "0" ] && [ "$datadog_signal" = "0" ]; then
+            grep -qx 'datadog-verification' "$state_dir/events" \
+                || fail "Datadog 데이터 도착 검증이 실행되지 않았습니다"
+        elif grep -qx 'datadog-verification' "$state_dir/events"; then
+            fail "timeout 또는 취소 신호 뒤 Datadog 검증기가 실행됐습니다"
+        fi
     fi
 
     if [ "$expected_failure" = "0" ]; then
@@ -314,10 +403,16 @@ run_case() {
             || fail "롤백 뒤 활성 Compose가 바뀌었습니다"
         grep -q '이전 이미지로 앱 컨테이너를 복구하고 health를 확인했습니다' "$log_file" \
             || fail "롤백 성공 로그가 없습니다"
+        if [ "$datadog_signal" = "1" ]; then
+            grep -q 'TERM 신호로 중단됐습니다' "$log_file" \
+                || fail "취소 신호 원인이 배포 로그에 남지 않았습니다"
+        fi
     fi
 }
 
-run_case success 0 0
-run_case app-check-rollback 1 0
-run_case datadog-delivery-rollback 0 1
+run_case success 0 0 0 0
+run_case app-check-rollback 1 0 0 0
+run_case datadog-delivery-rollback 0 1 0 0
+run_case datadog-timeout-rollback 0 0 1 0
+run_case datadog-signal-rollback 0 0 0 1
 echo "deployment verification script tests passed"

--- a/scripts/deployment/test_datadog_verification.py
+++ b/scripts/deployment/test_datadog_verification.py
@@ -22,6 +22,8 @@ class FakeClient:
         self.metric_response = {"series": []}
         self.log_response = {"data": []}
         self.downtime_response = {"data": []}
+        self.metric_calls = 0
+        self.log_calls = 0
 
     def request(self, method, path, params=None, body=None, require_app_key=True):
         if path == "/api/v1/validate":
@@ -30,6 +32,7 @@ class FakeClient:
 
     def get(self, path, params=None):
         if path == "/api/v1/query":
+            self.metric_calls += 1
             return self.metric_response
         if path.startswith("/api/v2/monitor/"):
             return self.downtime_response
@@ -49,6 +52,7 @@ class FakeClient:
 
     def post(self, path, body, require_app_key=True):
         if path == "/api/v2/logs/events/search":
+            self.log_calls += 1
             return self.log_response
         if path == "/api/v1/check_run":
             check = body[0]
@@ -66,6 +70,17 @@ class FakeDiscordClient:
     def received(self, signal_id, phase):
         self.queries.append((signal_id, phase))
         return self.received_result
+
+
+class FakeClock:
+    def __init__(self):
+        self.now = 0
+
+    def __call__(self):
+        return self.now
+
+    def sleep(self, seconds):
+        self.now += seconds
 
 
 def alert_monitor():
@@ -171,6 +186,113 @@ class DatadogVerificationTest(unittest.TestCase):
         pending = verification.pending_deployment_data(client, config, from_epoch, "abcdef12")
 
         self.assertEqual([], pending)
+
+    def test_deployment_client_caps_each_request_at_the_absolute_deadline(self):
+        class Response:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def read(self):
+                return b"{}"
+
+        client = verification.DatadogClient(
+            "api-key",
+            "app-key",
+            "us5.datadoghq.com",
+            timeout_seconds=15,
+        )
+        client.set_deadline(105)
+
+        with patch.object(verification.time, "monotonic", return_value=100), patch.object(
+            verification.urllib.request,
+            "urlopen",
+            return_value=Response(),
+        ) as urlopen:
+            client.get("/api/v1/query")
+
+        self.assertEqual(5, urlopen.call_args.kwargs["timeout"])
+
+    def test_deployment_client_rejects_a_request_after_the_deadline(self):
+        client = verification.DatadogClient(
+            "api-key",
+            "app-key",
+            "us5.datadoghq.com",
+        )
+        client.set_deadline(100)
+
+        with patch.object(verification.time, "monotonic", return_value=100), patch.object(
+            verification.urllib.request,
+            "urlopen",
+        ) as urlopen, self.assertRaisesRegex(
+            verification.VerificationError,
+            "전체 제한시간",
+        ):
+            client.get("/api/v1/query")
+
+        urlopen.assert_not_called()
+
+    def test_deployment_wait_stops_at_the_absolute_deadline(self):
+        client = FakeClient(actual_monitor())
+        config = {
+            "metrics": [{"name": "host", "query": "system.mem.pct_usable"}],
+            "logs": [{"name": "app", "query": "service:hampouch-server"}],
+        }
+        clock = FakeClock()
+
+        with self.assertRaisesRegex(verification.VerificationError, "전체 제한시간"):
+            verification.wait_for_deployment_data(
+                client,
+                config,
+                1_700_000_000,
+                "abcdef12",
+                attempts=24,
+                interval_seconds=10,
+                deadline=25,
+                clock=clock,
+                sleeper=clock.sleep,
+            )
+
+        self.assertEqual(25, clock.now)
+        self.assertEqual(3, client.metric_calls)
+        self.assertEqual(3, client.log_calls)
+
+    def test_deployment_wait_rechecks_only_pending_data(self):
+        class SequencedClient(FakeClient):
+            def post(self, path, body, require_app_key=True):
+                if path == "/api/v2/logs/events/search":
+                    self.log_calls += 1
+                    if self.log_calls == 1:
+                        return {"data": []}
+                    return {"data": [{"id": "log"}]}
+                return super().post(path, body, require_app_key)
+
+        from_epoch = 1_700_000_000
+        client = SequencedClient(actual_monitor())
+        client.metric_response = {
+            "series": [{"pointlist": [[from_epoch * 1000, 1.0]]}]
+        }
+        config = {
+            "metrics": [{"name": "host", "query": "system.mem.pct_usable"}],
+            "logs": [{"name": "app", "query": "service:hampouch-server"}],
+        }
+
+        verification.wait_for_deployment_data(
+            client,
+            config,
+            from_epoch,
+            "abcdef12",
+            attempts=2,
+            interval_seconds=0,
+            deadline=300,
+            clock=lambda: 0,
+            sleeper=lambda _seconds: None,
+        )
+
+        self.assertEqual(1, client.metric_calls)
+        self.assertEqual(2, client.log_calls)
 
     def test_alert_path_confirms_alert_and_recovery(self):
         client = FakeClient(actual_monitor())


### PR DESCRIPTION
## 📎연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) closes #[issue number]

- Closes #214

## 📄 작업 내용 요약
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.

- Datadog 배포 데이터 검증에 300초 절대 deadline을 적용하고, 개별 API 요청 timeout도 남은 시간 안으로 제한했습니다.
- 이미 확인된 지표와 로그는 다시 조회하지 않고 미도착 항목만 polling하며, 진행 로그를 즉시 출력하도록 변경했습니다.
- 배포 셸에 310초 프로세스 timeout과 INT·TERM·HUP 처리 경로를 추가해 probe 정리와 이전 배포 롤백을 보장했습니다.
- 전체 CD job에 20분 timeout을 설정하고 deadline·재조회·취소·롤백 회귀 테스트를 추가했습니다.

## 👀 중요 변경 사항
> API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요

- Datadog 검증 timeout 설정값은 1초 이상 300초 이하만 허용합니다.
- 검증 프로세스가 310초를 넘기거나 작업 취소 신호를 받으면 실패로 처리하며, 임시 로그 probe 제거 후 이전 이미지와 활성 Compose 상태로 복구합니다.
- 애플리케이션 API·DB·Java 소스에는 변경이 없습니다.

## 🔖 Uncompleted Tasks
> 후속 작업 예정인 사항이 있다면 작성해주세요.

- 없음

## 📢 To Reviewers
> Reviewer가 주로 확인해주었으면 하는 부분을 적어주세요.

- 300초 검증 deadline, 310초 프로세스 backstop, 20분 CD job timeout의 계층과 취소 신호 시 cleanup·rollback 순서를 확인해주세요.