### PR TITLE
fix: auth 도메인 정합성 보장

### DIFF
--- a/src/main/java/Hampouch/server/domain/auth/entity/EmailVerification.java
+++ b/src/main/java/Hampouch/server/domain/auth/entity/EmailVerification.java
@@ -12,7 +12,13 @@ import java.time.LocalDateTime;
 
 @Getter
 @Entity
-@Table(name = "email_verifications")
+@Table(
+        name = "email_verifications",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_email_verification_email_purpose",
+                columnNames = {"email", "purpose"}
+        )
+)
 @EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class EmailVerification {
@@ -96,5 +102,17 @@ public class EmailVerification {
 
     public boolean isAttemptExceeded() {
         return attemptCount >= 5;
+    }
+
+    //재발송 메서드
+    public void reissue(
+            String verificationCode,
+            LocalDateTime expiredAt
+    ) {
+        this.verificationCode = verificationCode;
+        this.expiredAt = expiredAt;
+        this.verified = false;
+        this.verifiedAt = null;
+        this.attemptCount = 0;
     }
 }

--- a/src/main/java/Hampouch/server/domain/auth/repository/EmailVerificationRepository.java
+++ b/src/main/java/Hampouch/server/domain/auth/repository/EmailVerificationRepository.java
@@ -2,14 +2,30 @@ package Hampouch.server.domain.auth.repository;
 
 import Hampouch.server.domain.auth.entity.EmailVerification;
 import Hampouch.server.domain.auth.entity.VerificationPurpose;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface EmailVerificationRepository extends JpaRepository<EmailVerification, Long> {
 
-    Optional<EmailVerification> findTopByEmailAndPurposeOrderByCreatedAtDesc(
+    Optional<EmailVerification> findByEmailAndPurpose(
             String email,
             VerificationPurpose purpose
+    );
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+        select e
+        from EmailVerification e
+        where e.email = :email
+          and e.purpose = :purpose
+        """)
+    Optional<EmailVerification> findByEmailAndPurposeForUpdate(
+            @Param("email") String email,
+            @Param("purpose") VerificationPurpose purpose
     );
 }

--- a/src/main/java/Hampouch/server/domain/auth/service/AuthService.java
+++ b/src/main/java/Hampouch/server/domain/auth/service/AuthService.java
@@ -18,6 +18,7 @@ import Hampouch.server.global.common.exception.domain.AuthErrorCode;
 import Hampouch.server.global.common.exception.domain.UserErrorCode;
 import Hampouch.server.global.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.CannotAcquireLockException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -59,30 +60,71 @@ public class AuthService {
         String email = request.email();
 
         validateEmailForPurpose(email, purpose);
-        validateResendCooldown(email, purpose);
 
         String code = generateCode();
-        LocalDateTime expiredAt = LocalDateTime.now(clock).plusSeconds(EMAIL_CODE_EXPIRES_IN_SECONDS);
+        LocalDateTime now = LocalDateTime.now(clock);
+        LocalDateTime expiredAt = now.plusSeconds(
+                EMAIL_CODE_EXPIRES_IN_SECONDS
+        );
 
-        emailVerificationRepository.save(EmailVerification.create(email, code, purpose, expiredAt));
+        EmailVerification verification =
+                emailVerificationRepository
+                        .findByEmailAndPurposeForUpdate(email, purpose)
+                        .orElse(null);
+
+        if (verification == null) {
+            try {
+                emailVerificationRepository.saveAndFlush(
+                        EmailVerification.create(
+                                email,
+                                code,
+                                purpose,
+                                expiredAt
+                        )
+                );
+            } catch (DataIntegrityViolationException e) {
+                if (hasConstraint(
+                        e,
+                        "uk_email_verification_email_purpose"
+                )) {
+                    throw new CustomException(
+                            AuthErrorCode.AUTH_EMAIL_SEND_TOO_FREQUENT
+                    );
+                }
+
+                throw e;
+            } catch (CannotAcquireLockException e) {
+                //동일 이메일·목적의 최초 행을 동시에 생성하면서MySQL gap/insert lock 경쟁이 발생한 경우
+                throw new CustomException(
+                        AuthErrorCode.AUTH_EMAIL_SEND_TOO_FREQUENT
+                );
+            }
+        } else {
+            validateResendCooldown(verification, now);
+            verification.reissue(code, expiredAt);
+        }
 
         try {
             emailSender.send(email, code, purpose);
         } catch (Exception e) {
-            throw new CustomException(AuthErrorCode.AUTH_EMAIL_SEND_FAILED);
+            throw new CustomException(
+                    AuthErrorCode.AUTH_EMAIL_SEND_FAILED
+            );
         }
 
         return EmailSendResponse.of(EMAIL_CODE_EXPIRES_IN_SECONDS);
     }
 
-    private void validateResendCooldown(String email, VerificationPurpose purpose) {
-        emailVerificationRepository.findTopByEmailAndPurposeOrderByCreatedAtDesc(email, purpose)
-                .ifPresent(lastVerification -> {
-                    LocalDateTime cooldownEnd = lastVerification.getCreatedAt().plusSeconds(EMAIL_RESEND_COOLDOWN_SECONDS);
-                    if (LocalDateTime.now(clock).isBefore(cooldownEnd)) {
-                        throw new CustomException(AuthErrorCode.AUTH_EMAIL_SEND_TOO_FREQUENT);
-                    }
-                });
+    private void validateResendCooldown(EmailVerification verification, LocalDateTime now
+    ) {
+        LocalDateTime lastSentAt = verification.getExpiredAt().minusSeconds(EMAIL_CODE_EXPIRES_IN_SECONDS);
+
+        LocalDateTime cooldownEnd = lastSentAt.plusSeconds(EMAIL_RESEND_COOLDOWN_SECONDS);
+
+        if (now.isBefore(cooldownEnd)) {
+            throw new CustomException(AuthErrorCode.AUTH_EMAIL_SEND_TOO_FREQUENT);
+        }
+
     }
 
     private void validateEmailForPurpose(String email, VerificationPurpose purpose) {
@@ -112,12 +154,12 @@ public class AuthService {
     }
 
     //이메일 인증번호 확인
-    @Transactional
+    @Transactional(noRollbackFor = CustomException.class)
     public EmailVerifyResponse verifyEmail(EmailVerifyRequest request) {
         VerificationPurpose purpose = VerificationPurpose.valueOf(request.purpose());
 
         EmailVerification verification = emailVerificationRepository
-                .findTopByEmailAndPurposeOrderByCreatedAtDesc(request.email(), purpose)
+                .findByEmailAndPurposeForUpdate(request.email(), purpose)
                 .orElseThrow(() -> new CustomException(AuthErrorCode.AUTH_EMAIL_VERIFICATION_NOT_FOUND));
 
         LocalDateTime now = LocalDateTime.now(clock);
@@ -168,7 +210,7 @@ public class AuthService {
         }
 
         EmailVerification verification = emailVerificationRepository
-                .findTopByEmailAndPurposeOrderByCreatedAtDesc(email, VerificationPurpose.SIGNUP)
+                .findByEmailAndPurpose(email, VerificationPurpose.SIGNUP)
                 .orElseThrow(() -> new CustomException(AuthErrorCode.AUTH_EMAIL_NOT_VERIFIED));
 
         if (!verification.isVerified()) {
@@ -235,28 +277,38 @@ public class AuthService {
         AuthProvider provider = AuthProvider.valueOf(request.provider());
 
         SocialTokenVerifier verifier = socialTokenVerifiers.stream()
-                .filter(v -> v.supports(provider.name()))
-                .findFirst()
-                .orElseThrow(() -> new CustomException(AuthErrorCode.AUTH_UNSUPPORTED_PROVIDER));
+                        .filter(v -> v.supports(provider.name()))
+                        .findFirst()
+                        .orElseThrow(() -> new CustomException(AuthErrorCode.AUTH_UNSUPPORTED_PROVIDER));
 
-        // 외부 소셜 토큰 검증(네트워크 I/O)은 사용자 조회보다 먼저, 잠금과 무관하게 끝낸다.
+        //외부 소셜 토큰 검증은 DB 락 전에 수행
         SocialTokenVerifier.SocialUserInfo socialInfo = verifier.verify(request.providerToken());
 
         if (socialInfo.email() == null || socialInfo.email().isBlank()) {
             throw new CustomException(AuthErrorCode.AUTH_SOCIAL_EMAIL_NOT_PROVIDED);
         }
 
+        String email = socialInfo.email();
+
+        User user = userRepository.findByEmailForUpdate(email).orElse(null);
+
         boolean isNewUser;
-        User user = userRepository.findByEmailForUpdate(socialInfo.email()).orElse(null);
 
         if (user == null) {
-            user = User.createSocialUser(
-                    socialInfo.email(),
-                    provider,
-                    socialInfo.providerId()
-            );
-            userRepository.save(user);
+            user = User.createSocialUser(email, provider, socialInfo.providerId());
+
+            try {
+                userRepository.saveAndFlush(user);
+            } catch (DataIntegrityViolationException | CannotAcquireLockException e) {
+                //동일 소셜 계정의 최초 로그인 요청이 겹쳐 다른 트랜잭션이 같은 email 또는 provider/providerId 사용자를 먼저 생성한 경우
+                if (e instanceof CannotAcquireLockException || hasConstraint(e, "uk_user_email")
+                        || hasConstraint(e, "uk_users_provider_provider_id")) {
+                    throw new CustomException(AuthErrorCode.AUTH_EMAIL_ALREADY_EXISTS);
+                }
+                throw e;
+            }
             isNewUser = true;
+
         } else {
             if (user.getProvider() != provider) {
                 throw new CustomException(AuthErrorCode.AUTH_LOGIN_TYPE_MISMATCH);
@@ -300,6 +352,15 @@ public class AuthService {
         }
 
         user.setInitialNickname(request.nickname());
+
+        try {
+            userRepository.saveAndFlush(user);
+        } catch (DataIntegrityViolationException e) {
+            if (hasConstraint(e, "uk_user_nickname")) {
+                throw new CustomException(UserErrorCode.USER_NICKNAME_ALREADY_EXISTS);
+            }
+            throw e;
+        }
 
         return NicknameSetResponse.of(user.getId(), user.getNickname());
     }
@@ -356,7 +417,7 @@ public class AuthService {
         String email = request.email();
 
         EmailVerification verification = emailVerificationRepository
-                .findTopByEmailAndPurposeOrderByCreatedAtDesc(email, VerificationPurpose.PASSWORD_RESET)
+                .findByEmailAndPurpose(email, VerificationPurpose.PASSWORD_RESET)
                 .orElseThrow(() -> new CustomException(AuthErrorCode.AUTH_EMAIL_NOT_VERIFIED));
 
         if (!verification.isVerified()) {
@@ -445,5 +506,19 @@ public class AuthService {
                 jwtProvider.getAccessTokenExpiresInMs(),
                 jwtProvider.getRefreshTokenExpiresInMs()
         );
+    }
+
+    private boolean hasConstraint(Throwable throwable, String constraintName) {
+        Throwable current = throwable;
+
+        while (current != null) {
+            String message = current.getMessage();
+
+            if (message != null && message.contains(constraintName)) {return true;}
+
+            current = current.getCause();
+        }
+
+        return false;
     }
 }

--- a/src/main/java/Hampouch/server/domain/auth/service/AuthService.java
+++ b/src/main/java/Hampouch/server/domain/auth/service/AuthService.java
@@ -200,14 +200,9 @@ public class AuthService {
     //일반 로그인
     @Transactional
     public LoginResponse login(LoginRequest request) {
-        // #182: 조회 자체를 잠금 조회로 만든다. 트랜잭션의 첫 조회가 일반(non-locking) SELECT면
-        // 그 시점에 MySQL REPEATABLE READ 스냅샷이 고정되어, 그 뒤 아무리 다시 읽어도
-        // (findById 재조회든 entityManager.refresh든, 락 모드를 줘도) 여전히 그 옛 스냅샷을
-        // 보게 되는 문제가 있었다 - 그 사이 deleteMe가 커밋한 상태 변화가 반영되지 않아
-        // 탈퇴한 유저의 로그인이 통과해버렸다. 조회 자체를 처음부터 FOR UPDATE로 만들면
-        // 이 문제가 원천적으로 발생하지 않는다.
-        // 트레이드오프: 비밀번호 검증(bcrypt)이 락을 잡은 채로 일어난다 - 걸리는 시간이
-        // 수십 밀리초 수준이라 이 정합성 문제를 감수하는 것보다 낫다고 판단했다.
+        // 조회 자체를 잠금 조회로 만듬.
+        // --> 트랜잭션의 첫 조회가 일반(non-locking) SELECT면 그 시점에 MySQL REPEATABLE READ 스냅샷이 고정되어, 그 뒤 아무리 다시 읽어도
+        // 여전히 그 옛 스냅샷을 보게 되는 문제 - 그 사이 deleteMe가 커밋한 상태 변화가 반영되지 않아 탈퇴한 유저의 로그인이 통과해버렸었음.
         User user = userRepository.findByEmailForUpdate(request.email())
                 .orElseThrow(() -> new CustomException(AuthErrorCode.AUTH_LOGIN_FAILED));
 
@@ -252,8 +247,6 @@ public class AuthService {
         }
 
         boolean isNewUser;
-        // login()과 같은 이유로 조회 자체를 잠금 조회로 만든다. 신규 유저 분기(행이 아예 없음)에서는
-        // 이 잠금이 실질적으로 아무 것도 잠그지 않으므로(대상 행이 없음) 비용이 크지 않다.
         User user = userRepository.findByEmailForUpdate(socialInfo.email()).orElse(null);
 
         if (user == null) {
@@ -290,8 +283,6 @@ public class AuthService {
     //닉네임 최초 설정(소셜 로그인)
     @Transactional
     public NicknameSetResponse setInitialNickname(Long userId, NicknameSetRequest request) {
-        // 이 메서드는 userId로 곧바로 락을 잡으므로(이메일 경유 사전 조회가 없음) 위 login()/
-        // resetPassword()가 겪은 스냅샷 고정 문제가 없다.
         userOperationLock.lock(userId);
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
@@ -319,9 +310,7 @@ public class AuthService {
         Long userId = jwtProvider.getUserIdFromRefreshToken(request.refreshToken());
         String tokenHash = hashToken(request.refreshToken());
 
-        // 사용자 행을 먼저 잠근 뒤 refresh token 행을 잠근다 (deleteMe도 사용자 행만 잠그므로
-        // 순서가 항상 user → token으로 일관되어 교착이 생기지 않는다).
-        // 이 메서드는 userId로 곧바로 락을 잡으므로 스냅샷 고정 문제가 없다.
+        // 사용자 행을 먼저 잠근 뒤 refresh token 행을 잠근다 (deleteMe도 사용자 행만 잠그므로 순서가 항상 user → token으로 일관되어 교착이 생기지 않는다)
         userOperationLock.lock(userId);
 
         RefreshToken savedToken = refreshTokenRepository.findByTokenHashForUpdate(tokenHash)

--- a/src/main/java/Hampouch/server/domain/auth/service/AuthService.java
+++ b/src/main/java/Hampouch/server/domain/auth/service/AuthService.java
@@ -327,12 +327,7 @@ public class AuthService {
                 }
                 throw e;
             }
-            user = User.createSocialUser(
-                    socialInfo.email(),
-                    provider,
-                    socialInfo.providerId()
-            );
-            userRepository.save(user);
+
             notificationScheduleRepository.save(NotificationSchedule.createDefault(user));
 
             isNewUser = true;

--- a/src/main/java/Hampouch/server/domain/auth/service/AuthService.java
+++ b/src/main/java/Hampouch/server/domain/auth/service/AuthService.java
@@ -12,6 +12,7 @@ import Hampouch.server.domain.auth.util.SocialTokenVerifier;
 import Hampouch.server.domain.user.entity.AuthProvider;
 import Hampouch.server.domain.user.entity.User;
 import Hampouch.server.domain.user.repository.UserRepository;
+import Hampouch.server.domain.user.service.UserOperationLock;
 import Hampouch.server.global.common.exception.CustomException;
 import Hampouch.server.global.common.exception.domain.AuthErrorCode;
 import Hampouch.server.global.common.exception.domain.UserErrorCode;
@@ -46,6 +47,7 @@ public class AuthService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
+    private final UserOperationLock userOperationLock;
     private final Clock clock;
     private final EmailSender emailSender;
     private final List<SocialTokenVerifier> socialTokenVerifiers;
@@ -179,13 +181,9 @@ public class AuthService {
         String encodedPassword = passwordEncoder.encode(request.password());
         User user = User.createLocalUser(email, encodedPassword, request.nickname());
 
-        // 동시에 같은 이메일/닉네임으로 회원가입 요청이 들어오면, 두 트랜잭션 모두 위 findByEmail / existsByNickname 사전 검사를 통과한 뒤 나중에 저장을 시도하는 쪽이 users.uk_user_email 또는 uk_user_nickname 제약에 막힐 수 있음
-        // 사전 검사는 일반적인 경우의 빠른 실패 + 명확한 에러 메시지용이고, 실제 동시성 방어는 여기 saveAndFlush + 아래 예외 처리가 담당
-        // saveAndFlush로 그 자리에서 즉시 INSERT를 실행해 DataIntegrityViolationException을 이 메서드 안에서 잡고, 예상된 409로 변환한다.
         try {
             userRepository.saveAndFlush(user);
         } catch (DataIntegrityViolationException e) {
-            // 제약조건 이름(uk_user_email / uk_user_nickname, V2 마이그레이션에서 명시적으로 부여)으로 원인을 구분
             String rootCauseMessage = e.getMostSpecificCause().getMessage();
             if (rootCauseMessage != null && rootCauseMessage.contains("uk_user_nickname")) {
                 throw new CustomException(UserErrorCode.USER_NICKNAME_ALREADY_EXISTS);
@@ -202,7 +200,15 @@ public class AuthService {
     //일반 로그인
     @Transactional
     public LoginResponse login(LoginRequest request) {
-        User user = userRepository.findByEmail(request.email())
+        // #182: 조회 자체를 잠금 조회로 만든다. 트랜잭션의 첫 조회가 일반(non-locking) SELECT면
+        // 그 시점에 MySQL REPEATABLE READ 스냅샷이 고정되어, 그 뒤 아무리 다시 읽어도
+        // (findById 재조회든 entityManager.refresh든, 락 모드를 줘도) 여전히 그 옛 스냅샷을
+        // 보게 되는 문제가 있었다 - 그 사이 deleteMe가 커밋한 상태 변화가 반영되지 않아
+        // 탈퇴한 유저의 로그인이 통과해버렸다. 조회 자체를 처음부터 FOR UPDATE로 만들면
+        // 이 문제가 원천적으로 발생하지 않는다.
+        // 트레이드오프: 비밀번호 검증(bcrypt)이 락을 잡은 채로 일어난다 - 걸리는 시간이
+        // 수십 밀리초 수준이라 이 정합성 문제를 감수하는 것보다 낫다고 판단했다.
+        User user = userRepository.findByEmailForUpdate(request.email())
                 .orElseThrow(() -> new CustomException(AuthErrorCode.AUTH_LOGIN_FAILED));
 
         if (!user.isLocalUser()) {
@@ -238,6 +244,7 @@ public class AuthService {
                 .findFirst()
                 .orElseThrow(() -> new CustomException(AuthErrorCode.AUTH_UNSUPPORTED_PROVIDER));
 
+        // 외부 소셜 토큰 검증(네트워크 I/O)은 사용자 조회보다 먼저, 잠금과 무관하게 끝낸다.
         SocialTokenVerifier.SocialUserInfo socialInfo = verifier.verify(request.providerToken());
 
         if (socialInfo.email() == null || socialInfo.email().isBlank()) {
@@ -245,7 +252,9 @@ public class AuthService {
         }
 
         boolean isNewUser;
-        User user = userRepository.findByEmail(socialInfo.email()).orElse(null);
+        // login()과 같은 이유로 조회 자체를 잠금 조회로 만든다. 신규 유저 분기(행이 아예 없음)에서는
+        // 이 잠금이 실질적으로 아무 것도 잠그지 않으므로(대상 행이 없음) 비용이 크지 않다.
+        User user = userRepository.findByEmailForUpdate(socialInfo.email()).orElse(null);
 
         if (user == null) {
             user = User.createSocialUser(
@@ -281,6 +290,9 @@ public class AuthService {
     //닉네임 최초 설정(소셜 로그인)
     @Transactional
     public NicknameSetResponse setInitialNickname(Long userId, NicknameSetRequest request) {
+        // 이 메서드는 userId로 곧바로 락을 잡으므로(이메일 경유 사전 조회가 없음) 위 login()/
+        // resetPassword()가 겪은 스냅샷 고정 문제가 없다.
+        userOperationLock.lock(userId);
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
 
@@ -305,9 +317,14 @@ public class AuthService {
     @Transactional
     public TokenReissueResponse reissueToken(RefreshRequest request) {
         Long userId = jwtProvider.getUserIdFromRefreshToken(request.refreshToken());
+        String tokenHash = hashToken(request.refreshToken());
 
-        // 같은 refresh token으로 동시에 재발급 요청이 들어오는 경쟁 상태를 막기 위해 비관적 락으로 조회
-        RefreshToken savedToken = refreshTokenRepository.findByTokenHashForUpdate(hashToken(request.refreshToken()))
+        // 사용자 행을 먼저 잠근 뒤 refresh token 행을 잠근다 (deleteMe도 사용자 행만 잠그므로
+        // 순서가 항상 user → token으로 일관되어 교착이 생기지 않는다).
+        // 이 메서드는 userId로 곧바로 락을 잡으므로 스냅샷 고정 문제가 없다.
+        userOperationLock.lock(userId);
+
+        RefreshToken savedToken = refreshTokenRepository.findByTokenHashForUpdate(tokenHash)
                 .orElseThrow(() -> new CustomException(AuthErrorCode.AUTH_REFRESH_TOKEN_INVALID));
 
         LocalDateTime now = LocalDateTime.now(clock);
@@ -360,7 +377,11 @@ public class AuthService {
             throw new CustomException(AuthErrorCode.AUTH_EMAIL_NOT_VERIFIED);
         }
 
-        User user = userRepository.findByEmail(email)
+        // 비밀번호 인코딩(bcrypt, 무거운 연산)은 조회와 무관한 순수 계산이라 먼저 계산해둔다.
+        String encodedPassword = passwordEncoder.encode(request.newPassword());
+
+        // login()과 같은 이유로 조회 자체를 잠금 조회로 만든다.
+        User user = userRepository.findByEmailForUpdate(email)
                 .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
 
         if (user.isSocialUser()) {
@@ -371,12 +392,14 @@ public class AuthService {
             throw new CustomException(UserErrorCode.USER_DELETED);
         }
 
-        user.resetPassword(passwordEncoder.encode(request.newPassword()));
+        user.resetPassword(encodedPassword);
     }
 
     // 회원 탈퇴
     @Transactional
     public void deleteMe(Long userId) {
+        // 이 메서드는 userId로 곧바로 락을 잡으므로 스냅샷 고정 문제가 없다.
+        userOperationLock.lock(userId);
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
 
@@ -385,7 +408,7 @@ public class AuthService {
         }
 
         user.delete();
-        userRepository.saveAndFlush(user); //clear 전에 확실히 DB에 반영
+        userRepository.saveAndFlush(user);
 
         refreshTokenRepository.revokeAllByUserId(userId);
     }
@@ -429,7 +452,7 @@ public class AuthService {
 
         return TokenReissueResponse.of(
                 accessToken,
-                refreshToken, //클라이언트에는 원문 그대로 응답-DB에는 해시만 저장
+                refreshToken,
                 jwtProvider.getAccessTokenExpiresInMs(),
                 jwtProvider.getRefreshTokenExpiresInMs()
         );

--- a/src/main/java/Hampouch/server/domain/auth/service/AuthService.java
+++ b/src/main/java/Hampouch/server/domain/auth/service/AuthService.java
@@ -245,6 +245,20 @@ public class AuthService {
         // 조회 자체를 잠금 조회로 만듬.
         // --> 트랜잭션의 첫 조회가 일반(non-locking) SELECT면 그 시점에 MySQL REPEATABLE READ 스냅샷이 고정되어, 그 뒤 아무리 다시 읽어도
         // 여전히 그 옛 스냅샷을 보게 되는 문제 - 그 사이 deleteMe가 커밋한 상태 변화가 반영되지 않아 탈퇴한 유저의 로그인이 통과해버렸었음.
+        UserRepository.LoginCredentialView credential =
+                userRepository.findLoginCredentialByEmail(request.email())
+                        .orElseThrow(() -> new CustomException(AuthErrorCode.AUTH_LOGIN_FAILED));
+
+        if (credential.getProvider() != AuthProvider.LOCAL) {
+            throw new CustomException(AuthErrorCode.AUTH_LOGIN_TYPE_MISMATCH);
+        }
+
+        String passwordBeforeLock = credential.getPassword();
+
+        if (!passwordEncoder.matches(request.password(), passwordBeforeLock)) {
+            throw new CustomException(AuthErrorCode.AUTH_LOGIN_FAILED);
+        }
+
         User user = userRepository.findByEmailForUpdate(request.email())
                 .orElseThrow(() -> new CustomException(AuthErrorCode.AUTH_LOGIN_FAILED));
 
@@ -252,12 +266,13 @@ public class AuthService {
             throw new CustomException(AuthErrorCode.AUTH_LOGIN_TYPE_MISMATCH);
         }
 
-        if (!passwordEncoder.matches(request.password(), user.getPassword())) {
-            throw new CustomException(AuthErrorCode.AUTH_LOGIN_FAILED);
-        }
-
         if (user.isDeleted()) {
             throw new CustomException(UserErrorCode.USER_DELETED);
+        }
+
+        //BCrypt 검증과 락 획득 사이에 비밀번호가 변경됐다면 이전 비밀번호로 토큰을 발급하지 않는다
+        if (!passwordHashEquals(passwordBeforeLock, user.getPassword())) {
+            throw new CustomException(AuthErrorCode.AUTH_LOGIN_FAILED);
         }
 
         TokenReissueResponse tokens = issueTokens(user);
@@ -520,5 +535,16 @@ public class AuthService {
         }
 
         return false;
+    }
+
+    private boolean passwordHashEquals(String expected, String actual) {
+        if (expected == null || actual == null) {
+            return false;
+        }
+
+        return MessageDigest.isEqual(
+                expected.getBytes(StandardCharsets.UTF_8),
+                actual.getBytes(StandardCharsets.UTF_8)
+        );
     }
 }

--- a/src/main/java/Hampouch/server/domain/user/repository/UserRepository.java
+++ b/src/main/java/Hampouch/server/domain/user/repository/UserRepository.java
@@ -16,11 +16,13 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query("SELECT u FROM User u WHERE u.id = :id")
     Optional<User> findByIdForUpdate(@Param("id") Long id);
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT u FROM User u WHERE u.email = :email")
+    Optional<User> findByEmailForUpdate(@Param("email") String email);
+
     Optional<User> findByEmail(String email);
 
     Optional<User> findByProviderAndProviderId(AuthProvider provider, String providerId);
-
-    boolean existsByEmail(String email);
 
     boolean existsByNickname(String nickname);
 }

--- a/src/main/java/Hampouch/server/domain/user/repository/UserRepository.java
+++ b/src/main/java/Hampouch/server/domain/user/repository/UserRepository.java
@@ -25,4 +25,17 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByProviderAndProviderId(AuthProvider provider, String providerId);
 
     boolean existsByNickname(String nickname);
+
+    @Query("""
+        select u.provider as provider,
+               u.password as password
+        from User u
+        where u.email = :email
+        """)
+    Optional<LoginCredentialView> findLoginCredentialByEmail(@Param("email") String email);
+
+    interface LoginCredentialView {
+        AuthProvider getProvider();
+        String getPassword();
+    }
 }

--- a/src/main/java/Hampouch/server/global/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/Hampouch/server/global/common/exception/GlobalExceptionHandler.java
@@ -1,10 +1,12 @@
 package Hampouch.server.global.common.exception;
 
+import Hampouch.server.global.common.exception.domain.AuthErrorCode;
 import Hampouch.server.global.common.exception.domain.CommonErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.CannotAcquireLockException;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -233,6 +235,26 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(CommonErrorCode.NOT_FOUND.getHttpStatus())
                 .body(ErrorResponse.from(CommonErrorCode.NOT_FOUND));
+    }
+
+    @ExceptionHandler(CannotAcquireLockException.class)
+    public ResponseEntity<ErrorResponse> handleCannotAcquireLockException(
+            CannotAcquireLockException e,
+            HttpServletRequest request
+    ) {
+        AuthErrorCode errorCode = AuthErrorCode.AUTH_REQUEST_IN_PROGRESS;
+
+        log.warn(
+                "[CannotAcquireLockException] {} {} | userId={} | message={}",
+                request.getMethod(),
+                request.getRequestURI(),
+                resolveUserId(),
+                e.getMessage()
+        );
+
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ErrorResponse.from(errorCode));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/Hampouch/server/global/common/exception/domain/AuthErrorCode.java
+++ b/src/main/java/Hampouch/server/global/common/exception/domain/AuthErrorCode.java
@@ -25,6 +25,7 @@ public enum AuthErrorCode implements BaseErrorCode {
     AUTH_EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "AUTH_EMAIL_NOT_VERIFIED", "이메일 인증이 완료되지 않았습니다."),
     AUTH_EMAIL_CODE_ATTEMPT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "AUTH_EMAIL_CODE_ATTEMPT_EXCEEDED", "인증번호 확인 횟수를 초과했습니다. 인증번호를 다시 요청해주세요."),
     AUTH_EMAIL_SEND_TOO_FREQUENT(HttpStatus.TOO_MANY_REQUESTS, "AUTH_EMAIL_SEND_TOO_FREQUENT", "잠시 후 다시 요청해주세요."),
+    AUTH_REQUEST_IN_PROGRESS(HttpStatus.TOO_MANY_REQUESTS, "AUTH_REQUEST_IN_PROGRESS", "동일한 인증 요청을 처리하고 있습니다. 잠시 후 다시 시도해주세요."),
 
     // 로그인
     AUTH_LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "AUTH_LOGIN_FAILED", "이메일 또는 비밀번호가 올바르지 않습니다."),

--- a/src/main/resources/db/migration/V10__email_verification_unique.sql
+++ b/src/main/resources/db/migration/V10__email_verification_unique.sql
@@ -1,0 +1,16 @@
+DELETE older
+FROM email_verifications older
+JOIN email_verifications newer
+  ON newer.email = older.email
+ AND newer.purpose = older.purpose
+ AND (
+        newer.created_at > older.created_at
+        OR (
+            newer.created_at = older.created_at
+            AND newer.verification_id > older.verification_id
+        )
+     );
+
+ALTER TABLE email_verifications
+    ADD CONSTRAINT uk_email_verification_email_purpose
+        UNIQUE (email, purpose);

--- a/src/test/java/Hampouch/server/domain/auth/AuthConcurrencyTest.java
+++ b/src/test/java/Hampouch/server/domain/auth/AuthConcurrencyTest.java
@@ -1,10 +1,16 @@
 package Hampouch.server.domain.auth;
 
+import Hampouch.server.domain.auth.dto.request.NicknameSetRequest;
 import Hampouch.server.domain.auth.entity.EmailVerification;
 import Hampouch.server.domain.auth.entity.VerificationPurpose;
 import Hampouch.server.domain.auth.repository.EmailVerificationRepository;
+import Hampouch.server.domain.auth.service.AuthService;
 import Hampouch.server.domain.auth.util.EmailSender;
 import Hampouch.server.domain.auth.util.SocialTokenVerifier;
+import Hampouch.server.domain.user.entity.AuthProvider;
+import Hampouch.server.domain.user.entity.User;
+import Hampouch.server.domain.user.repository.UserRepository;
+import Hampouch.server.global.common.exception.CustomException;
 import Hampouch.server.global.jwt.JwtProvider;
 import Hampouch.server.global.mysql.MySqlContainerTest;
 import org.junit.jupiter.api.Test;
@@ -29,12 +35,13 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.HexFormat;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
@@ -61,6 +68,12 @@ class AuthConcurrencyTest {
 
     @Autowired
     EmailVerificationRepository emailVerificationRepository;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    AuthService authService;
 
     @Autowired
     JdbcTemplate jdbc;
@@ -304,6 +317,124 @@ class AuthConcurrencyTest {
                 .andExpect(jsonPath("$.code").value("USER_NICKNAME_ALREADY_EXISTS"));
     }
 
+    @Test
+    void 동일_소셜계정의_최초로그인이_경쟁해도_사용자는_한명만_저장되고_500은_발생하지_않는다() throws Exception {
+        String email = "social-race-" + System.currentTimeMillis() + "@example.com";
+        String providerId = "google-" + System.currentTimeMillis();
+
+        when(socialTokenVerifier.supports("GOOGLE")).thenReturn(true);
+        when(socialTokenVerifier.verify(any()))
+                .thenReturn(new SocialTokenVerifier.SocialUserInfo(email, providerId));
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<HttpResult> firstCall = executor.submit(this::callSocialLogin);
+            Future<HttpResult> secondCall = executor.submit(this::callSocialLogin);
+
+            HttpResult first = firstCall.get(10, TimeUnit.SECONDS);
+            HttpResult second = secondCall.get(10, TimeUnit.SECONDS);
+
+            long successCount = countStatus(first, second, 200);
+            long conflictCount = countStatus(first, second, 409);
+
+            assertThat(successCount).isEqualTo(1);
+            assertThat(conflictCount).isEqualTo(1);
+            assertThat(first.status()).isNotEqualTo(500);
+            assertThat(second.status()).isNotEqualTo(500);
+
+            Integer userCount = jdbc.queryForObject("""
+                SELECT COUNT(*)
+                FROM users
+                WHERE email = ?
+                """, Integer.class, email);
+
+            assertThat(userCount).isEqualTo(1);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void 같은_사용자의_최초닉네임설정이_경쟁하면_정확히_하나만_성공한다() throws Exception {
+        String email = "nickname-user-race-" + System.currentTimeMillis() + "@example.com";
+        Long userId = createSocialUserWithoutNickname(email);
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<HttpResult> firstCall = executor.submit(
+                    () -> callSetInitialNickname(userId, "첫번째닉네임")
+            );
+            Future<HttpResult> secondCall = executor.submit(
+                    () -> callSetInitialNickname(userId, "두번째닉네임")
+            );
+
+            HttpResult first = firstCall.get(10, TimeUnit.SECONDS);
+            HttpResult second = secondCall.get(10, TimeUnit.SECONDS);
+
+            long successCount = countStatus(first, second, 200);
+            long conflictCount = countStatus(first, second, 409);
+
+            assertThat(successCount).isEqualTo(1);
+            assertThat(conflictCount).isEqualTo(1);
+
+            HttpResult failed = first.status() == 409 ? first : second;
+            assertThat(failed.body()).contains("USER_NICKNAME_ALREADY_SET");
+
+            String nickname = jdbc.queryForObject("""
+                SELECT nickname
+                FROM users
+                WHERE user_id = ?
+                """, String.class, userId);
+
+            assertThat(nickname).isIn("첫번째닉네임", "두번째닉네임");
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void 서로_다른_사용자가_같은_닉네임을_동시에_설정하면_한쪽은_닉네임중복으로_실패한다() throws Exception {
+        Long firstUserId = createSocialUserWithoutNickname(
+                "nickname-owner-a-" + System.currentTimeMillis() + "@example.com"
+        );
+        Long secondUserId = createSocialUserWithoutNickname(
+                "nickname-owner-b-" + System.currentTimeMillis() + "@example.com"
+        );
+        String nickname = "동시닉" + System.currentTimeMillis() % 100000;
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<HttpResult> firstCall = executor.submit(
+                    () -> callSetInitialNickname(firstUserId, nickname)
+            );
+            Future<HttpResult> secondCall = executor.submit(
+                    () -> callSetInitialNickname(secondUserId, nickname)
+            );
+
+            HttpResult first = firstCall.get(10, TimeUnit.SECONDS);
+            HttpResult second = secondCall.get(10, TimeUnit.SECONDS);
+
+            long successCount = countStatus(first, second, 200);
+            long conflictCount = countStatus(first, second, 409);
+
+            assertThat(successCount).isEqualTo(1);
+            assertThat(conflictCount).isEqualTo(1);
+
+            HttpResult failed = first.status() == 409 ? first : second;
+            assertThat(failed.body()).contains("USER_NICKNAME_ALREADY_EXISTS");
+
+            Integer nicknameCount = jdbc.queryForObject("""
+                SELECT COUNT(*)
+                FROM users
+                WHERE nickname = ?
+                """, Integer.class, nickname);
+
+            assertThat(nicknameCount).isEqualTo(1);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
     // ===================== 헬퍼 =====================
 
     private long countStatus(HttpResult a, HttpResult b, int status) {
@@ -368,5 +499,44 @@ class AuthConcurrencyTest {
         MessageDigest digest = MessageDigest.getInstance("SHA-256");
         byte[] hash = digest.digest(token.getBytes(StandardCharsets.UTF_8));
         return HexFormat.of().formatHex(hash);
+    }
+
+    private HttpResult callSocialLogin() {
+        try {
+            MvcResult result = mvc.perform(post("/api/auth/social")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                {
+                                  "provider": "GOOGLE",
+                                  "providerToken": "dummy-token"
+                                }
+                                """))
+                    .andReturn();
+
+            return new HttpResult(
+                    result.getResponse().getStatus(),
+                    result.getResponse().getContentAsString()
+            );
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private HttpResult callSetInitialNickname(Long userId, String nickname) {
+        try {
+            authService.setInitialNickname(userId, new NicknameSetRequest(nickname));
+            return new HttpResult(200, "");
+        } catch (CustomException e) {
+            return new HttpResult(e.getErrorCode().getHttpStatus().value(), e.getErrorCode().getCode());
+        }
+    }
+
+    private Long createSocialUserWithoutNickname(String email) {
+        User user = User.createSocialUser(
+                email,
+                AuthProvider.GOOGLE,
+                "google-" + System.nanoTime()
+        );
+        return userRepository.saveAndFlush(user).getId();
     }
 }

--- a/src/test/java/Hampouch/server/domain/auth/AuthFlowIntegrationTest.java
+++ b/src/test/java/Hampouch/server/domain/auth/AuthFlowIntegrationTest.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -29,6 +30,10 @@ import java.time.LocalDateTime;
 import java.util.HexFormat;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -62,6 +67,9 @@ class AuthFlowIntegrationTest {
     @Autowired
     RefreshTokenRepository refreshTokenRepository;
 
+    @Autowired
+    JdbcTemplate jdbc;
+
     @MockitoBean
     EmailSender emailSender; // 실제 SMTP 발송 대신 mock
 
@@ -80,7 +88,7 @@ class AuthFlowIntegrationTest {
                 .andExpect(jsonPath("$.code").value("SUCCESS"));
 
         EmailVerification verification = emailVerificationRepository
-                .findTopByEmailAndPurposeOrderByCreatedAtDesc(email, VerificationPurpose.SIGNUP)
+                .findByEmailAndPurpose(email, VerificationPurpose.SIGNUP)
                 .orElseThrow();
         String code = verification.getVerificationCode();
 
@@ -284,5 +292,39 @@ class AuthFlowIntegrationTest {
                         .header("Authorization", "Bearer " + refreshToken))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.code").value("AUTH_UNAUTHORIZED"));
+    }
+
+    @Test
+    void 인증번호를_재발급하면_새로운_행을_만들지_않고_기존_행을_갱신한다() throws Exception {
+        String email = "reissue-flow-" + System.currentTimeMillis() + "@example.com";
+
+        mvc.perform(post("/api/auth/email/send")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"" + email + "\",\"purpose\":\"SIGNUP\"}"))
+                .andExpect(status().isOk());
+
+        EmailVerification first = emailVerificationRepository
+                .findByEmailAndPurpose(email, VerificationPurpose.SIGNUP)
+                .orElseThrow();
+        Long verificationId = first.getId();
+
+        jdbc.update(
+                "UPDATE email_verifications SET expired_at = DATE_SUB(expired_at, INTERVAL 31 SECOND) WHERE verification_id = ?",
+                verificationId
+        );
+
+        mvc.perform(post("/api/auth/email/send")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"" + email + "\",\"purpose\":\"SIGNUP\"}"))
+                .andExpect(status().isOk());
+
+        EmailVerification reissued = emailVerificationRepository
+                .findByEmailAndPurpose(email, VerificationPurpose.SIGNUP)
+                .orElseThrow();
+
+        assertThat(reissued.getId()).isEqualTo(verificationId);
+        assertThat(emailVerificationRepository.count()).isEqualTo(1);
+        verify(emailSender, times(2))
+                .send(eq(email), anyString(), eq(VerificationPurpose.SIGNUP));
     }
 }

--- a/src/test/java/Hampouch/server/domain/auth/AuthFlowIntegrationTest.java
+++ b/src/test/java/Hampouch/server/domain/auth/AuthFlowIntegrationTest.java
@@ -10,6 +10,7 @@ import Hampouch.server.domain.auth.util.SocialTokenVerifier;
 import Hampouch.server.domain.user.entity.AuthProvider;
 import Hampouch.server.domain.user.entity.User;
 import Hampouch.server.domain.user.repository.UserRepository;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -69,6 +70,9 @@ class AuthFlowIntegrationTest {
 
     @Autowired
     JdbcTemplate jdbc;
+
+    @Autowired
+    EntityManager entityManager;
 
     @MockitoBean
     EmailSender emailSender; // 실제 SMTP 발송 대신 mock
@@ -308,10 +312,14 @@ class AuthFlowIntegrationTest {
                 .orElseThrow();
         Long verificationId = first.getId();
 
+        LocalDateTime cooldownExpiredAt = first.getExpiredAt().minusSeconds(31);
+
         jdbc.update(
-                "UPDATE email_verifications SET expired_at = DATE_SUB(expired_at, INTERVAL 31 SECOND) WHERE verification_id = ?",
+                "UPDATE email_verifications SET expired_at = ? WHERE verification_id = ?",
+                cooldownExpiredAt,
                 verificationId
         );
+        entityManager.clear();
 
         mvc.perform(post("/api/auth/email/send")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/Hampouch/server/domain/auth/AuthUserLockConcurrencyTest.java
+++ b/src/test/java/Hampouch/server/domain/auth/AuthUserLockConcurrencyTest.java
@@ -1,0 +1,337 @@
+package Hampouch.server.domain.auth;
+
+import Hampouch.server.domain.auth.dto.request.LoginRequest;
+import Hampouch.server.domain.auth.dto.request.NicknameSetRequest;
+import Hampouch.server.domain.auth.dto.request.PasswordResetRequest;
+import Hampouch.server.domain.auth.dto.request.RefreshRequest;
+import Hampouch.server.domain.auth.entity.EmailVerification;
+import Hampouch.server.domain.auth.entity.VerificationPurpose;
+import Hampouch.server.domain.auth.repository.EmailVerificationRepository;
+import Hampouch.server.domain.auth.service.AuthService;
+import Hampouch.server.domain.auth.util.EmailSender;
+import Hampouch.server.domain.auth.util.SocialTokenVerifier;
+import Hampouch.server.domain.user.entity.AuthProvider;
+import Hampouch.server.domain.user.entity.User;
+import Hampouch.server.domain.user.repository.UserRepository;
+import Hampouch.server.global.common.exception.CustomException;
+import Hampouch.server.global.common.exception.domain.AuthErrorCode;
+import Hampouch.server.global.common.exception.domain.UserErrorCode;
+import Hampouch.server.global.mysql.MySqlContainerTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.time.LocalDateTime;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * #182: 회원 탈퇴(deleteMe)를 경계로 기존 사용자 인증·계정 변경 경로 전체가 사용자 행 락
+ * (UserOperationLock, #177)으로 직렬화되는지 검증한다.
+ *
+ * raw JDBC로 users 행에 직접 SELECT ... FOR UPDATE를 걸어 붙잡아둔 채로 실제 서비스
+ * 메서드 두 개를 동시에 호출해, 진짜로 DB 레벨에서 경쟁하는지(둘 다 우리가 풀어줄 때까지
+ * 완료되지 않는지)를 먼저 확인한다. 어느 쪽이 먼저 락을 얻는지는 일부러 강제하지 않는다 —
+ * 강제하면 "락이 실제로 겹친다"는, 이 테스트가 검증하려는 사실 자체를 스스로 무너뜨리게
+ * 된다. 대신 결과가 두 가지 합법적 순서 중 하나와 반드시 일치하는지를 검증한다.
+ *
+ * 컨트롤러 라우팅에 의존하지 않기 위해 MockMvc 대신 AuthService 빈을 직접 호출한다
+ * (deleteMe/setInitialNickname은 이미 userId를 인자로 직접 받는 구조라 더 정확하다).
+ */
+@MySqlContainerTest
+class AuthUserLockConcurrencyTest {
+
+    @Autowired
+    AuthService authService;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    EmailVerificationRepository emailVerificationRepository;
+
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
+    @Autowired
+    JdbcTemplate jdbc;
+
+    @MockitoBean
+    EmailSender emailSender;
+
+    @MockitoBean(name = "googleVerifier")
+    SocialTokenVerifier socialTokenVerifier;
+
+    private record Outcome(boolean success, Exception error) {
+    }
+
+    @Test
+    void 탈퇴와_재발급이_경쟁하면_한쪽_순서로만_처리되고_최종_활성_토큰은_남지_않는다() throws Exception {
+        Long userId = createLocalUser("lock-refresh-" + System.currentTimeMillis() + "@example.com", "닉네임A");
+        String refreshToken = authService.login(new LoginRequest(email(userId), "password1")).refreshToken();
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try (Connection holderConn = jdbc.getDataSource().getConnection()) {
+            holderConn.setAutoCommit(false);
+            lockUserRow(holderConn, userId);
+
+            Future<Outcome> deleteCall = executor.submit(() -> callDeleteMe(userId));
+            Future<Outcome> refreshCall = executor.submit(() -> callReissue(refreshToken));
+
+            Thread.sleep(500);
+            assertThat(deleteCall.isDone()).as("탈퇴 요청은 사용자 행 락에 막혀 대기 중이어야 한다").isFalse();
+            assertThat(refreshCall.isDone()).as("재발급 요청도 사용자 행 락에 막혀 대기 중이어야 한다").isFalse();
+
+            holderConn.rollback();
+
+            Outcome deleteOutcome = deleteCall.get(10, TimeUnit.SECONDS);
+            Outcome refreshOutcome = refreshCall.get(10, TimeUnit.SECONDS);
+
+            // deleteMe는 경쟁 상대가 무엇이든 상관없이(먼저 가든 나중에 가든) 항상 성공한다 -
+            // 활성 유저 하나를 지우는 것뿐이라 순서를 구분해주는 신호가 되지 못한다.
+            // 순서를 실제로 구분하는 신호는 refreshOutcome이다: 성공했으면 재발급이 먼저 간 것이고,
+            // AUTH_REFRESH_TOKEN_REVOKED로 실패했으면 탈퇴가 먼저 커밋된 것이다.
+            assertThat(deleteOutcome.success()).as("탈퇴는 어느 순서든 성공해야 한다").isTrue();
+
+            if (!refreshOutcome.success()) {
+                assertThat(refreshOutcome.error()).isInstanceOf(CustomException.class);
+                assertThat(((CustomException) refreshOutcome.error()).getErrorCode())
+                        .as("탈퇴가 먼저 커밋됐다면 재발급은 REVOKED로 실패해야 한다")
+                        .isEqualTo(AuthErrorCode.AUTH_REFRESH_TOKEN_REVOKED);
+            }
+
+            // 재발급이 먼저 성공해 새 토큰을 만들었더라도, 그 뒤 실행되는 탈퇴의
+            // revokeAllByUserId가 그 시점의 모든 활성 토큰을 지우므로 순서와 무관하게
+            // 최종 활성 토큰은 항상 0이어야 한다.
+            Integer activeTokenCount = jdbc.queryForObject(
+                    "SELECT COUNT(*) FROM refresh_tokens WHERE user_id = ? AND revoked = false",
+                    Integer.class, userId);
+            assertThat(activeTokenCount).as("최종 활성 토큰은 순서와 무관하게 0이어야 한다").isEqualTo(0);
+            assertThat(isDeleted(userId)).isTrue();
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void 탈퇴와_로그인이_경쟁하면_한쪽_순서로만_처리되고_최종_활성_토큰은_남지_않는다() throws Exception {
+        String email = "lock-login-" + System.currentTimeMillis() + "@example.com";
+        Long userId = createLocalUser(email, "닉네임B");
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try (Connection holderConn = jdbc.getDataSource().getConnection()) {
+            holderConn.setAutoCommit(false);
+            lockUserRow(holderConn, userId);
+
+            Future<Outcome> deleteCall = executor.submit(() -> callDeleteMe(userId));
+            Future<Outcome> loginCall = executor.submit(() -> callLogin(email));
+
+            Thread.sleep(500);
+            assertThat(deleteCall.isDone()).isFalse();
+            assertThat(loginCall.isDone()).isFalse();
+
+            holderConn.rollback();
+
+            Outcome deleteOutcome = deleteCall.get(10, TimeUnit.SECONDS);
+            Outcome loginOutcome = loginCall.get(10, TimeUnit.SECONDS);
+
+            // deleteMe는 순서와 무관하게 항상 성공한다 - 순서를 구분하는 신호는 loginOutcome이다.
+            assertThat(deleteOutcome.success()).as("탈퇴는 어느 순서든 성공해야 한다").isTrue();
+
+            if (!loginOutcome.success()) {
+                assertThat(loginOutcome.error()).isInstanceOf(CustomException.class);
+                assertThat(((CustomException) loginOutcome.error()).getErrorCode())
+                        .as("탈퇴가 먼저 커밋됐다면 로그인은 USER_DELETED로 실패해야 한다")
+                        .isEqualTo(UserErrorCode.USER_DELETED);
+            }
+
+            Integer activeTokenCount = jdbc.queryForObject(
+                    "SELECT COUNT(*) FROM refresh_tokens WHERE user_id = ? AND revoked = false",
+                    Integer.class, userId);
+            assertThat(activeTokenCount).as("최종 활성 토큰은 순서와 무관하게 0이어야 한다").isEqualTo(0);
+            assertThat(isDeleted(userId)).isTrue();
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void 탈퇴와_비밀번호재설정이_경쟁하면_한쪽_순서로만_처리된다() throws Exception {
+        String email = "lock-reset-" + System.currentTimeMillis() + "@example.com";
+        Long userId = createLocalUser(email, "닉네임C");
+        prepareVerifiedPasswordReset(email);
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try (Connection holderConn = jdbc.getDataSource().getConnection()) {
+            holderConn.setAutoCommit(false);
+            lockUserRow(holderConn, userId);
+
+            Future<Outcome> deleteCall = executor.submit(() -> callDeleteMe(userId));
+            Future<Outcome> resetCall = executor.submit(() -> callResetPassword(email));
+
+            Thread.sleep(500);
+            assertThat(deleteCall.isDone()).isFalse();
+            assertThat(resetCall.isDone()).isFalse();
+
+            holderConn.rollback();
+
+            Outcome deleteOutcome = deleteCall.get(10, TimeUnit.SECONDS);
+            Outcome resetOutcome = resetCall.get(10, TimeUnit.SECONDS);
+
+            assertThat(deleteOutcome.success()).as("탈퇴는 어느 순서든 성공해야 한다").isTrue();
+            if (!resetOutcome.success()) {
+                assertThat(resetOutcome.error()).isInstanceOf(CustomException.class);
+                assertThat(((CustomException) resetOutcome.error()).getErrorCode())
+                        .as("탈퇴가 먼저 커밋됐다면 비밀번호 재설정은 USER_DELETED로 실패해야 한다")
+                        .isEqualTo(UserErrorCode.USER_DELETED);
+            }
+            assertThat(isDeleted(userId)).isTrue();
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void 탈퇴와_최초닉네임설정이_경쟁하면_한쪽_순서로만_처리된다() throws Exception {
+        Long userId = createSocialUserWithoutNickname(
+                "lock-nickname-" + System.currentTimeMillis() + "@example.com");
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try (Connection holderConn = jdbc.getDataSource().getConnection()) {
+            holderConn.setAutoCommit(false);
+            lockUserRow(holderConn, userId);
+
+            Future<Outcome> deleteCall = executor.submit(() -> callDeleteMe(userId));
+            Future<Outcome> nicknameCall = executor.submit(() -> callSetInitialNickname(userId, "새닉네임"));
+
+            Thread.sleep(500);
+            assertThat(deleteCall.isDone()).isFalse();
+            assertThat(nicknameCall.isDone()).isFalse();
+
+            holderConn.rollback();
+
+            Outcome deleteOutcome = deleteCall.get(10, TimeUnit.SECONDS);
+            Outcome nicknameOutcome = nicknameCall.get(10, TimeUnit.SECONDS);
+
+            assertThat(deleteOutcome.success()).as("탈퇴는 어느 순서든 성공해야 한다").isTrue();
+            if (!nicknameOutcome.success()) {
+                assertThat(nicknameOutcome.error()).isInstanceOf(CustomException.class);
+                assertThat(((CustomException) nicknameOutcome.error()).getErrorCode())
+                        .as("탈퇴가 먼저 커밋됐다면 최초 닉네임 설정은 USER_DELETED로 실패해야 한다")
+                        .isEqualTo(UserErrorCode.USER_DELETED);
+            }
+            assertThat(isDeleted(userId)).isTrue();
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void 동시에_탈퇴하면_정확히_하나만_성공하고_최종_상태는_DELETED로_한번만_반영된다() throws Exception {
+        Long userId = createLocalUser("lock-double-delete-" + System.currentTimeMillis() + "@example.com", "닉네임D");
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<Outcome> first = executor.submit(() -> callDeleteMe(userId));
+            Future<Outcome> second = executor.submit(() -> callDeleteMe(userId));
+
+            Outcome firstOutcome = first.get(10, TimeUnit.SECONDS);
+            Outcome secondOutcome = second.get(10, TimeUnit.SECONDS);
+
+            long successCount = Stream.of(firstOutcome, secondOutcome).filter(Outcome::success).count();
+            assertThat(successCount).as("동시 탈퇴 두 건 중 정확히 하나만 성공해야 한다").isEqualTo(1);
+            assertThat(isDeleted(userId)).isTrue();
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    // ===================== 헬퍼 =====================
+
+    private void lockUserRow(Connection conn, Long userId) throws Exception {
+        try (PreparedStatement ps = conn.prepareStatement("SELECT * FROM users WHERE user_id = ? FOR UPDATE")) {
+            ps.setLong(1, userId);
+            ps.executeQuery();
+        }
+    }
+
+    private boolean isDeleted(Long userId) {
+        String status = jdbc.queryForObject("SELECT status FROM users WHERE user_id = ?", String.class, userId);
+        return "DELETED".equals(status);
+    }
+
+    private String email(Long userId) {
+        return userRepository.findById(userId).orElseThrow().getEmail();
+    }
+
+    private Outcome callDeleteMe(Long userId) {
+        try {
+            authService.deleteMe(userId);
+            return new Outcome(true, null);
+        } catch (Exception e) {
+            return new Outcome(false, e);
+        }
+    }
+
+    private Outcome callReissue(String refreshToken) {
+        try {
+            authService.reissueToken(new RefreshRequest(refreshToken));
+            return new Outcome(true, null);
+        } catch (Exception e) {
+            return new Outcome(false, e);
+        }
+    }
+
+    private Outcome callLogin(String email) {
+        try {
+            authService.login(new LoginRequest(email, "password1"));
+            return new Outcome(true, null);
+        } catch (Exception e) {
+            return new Outcome(false, e);
+        }
+    }
+
+    private Outcome callResetPassword(String email) {
+        try {
+            authService.resetPassword(new PasswordResetRequest(email, "newPassword1"));
+            return new Outcome(true, null);
+        } catch (Exception e) {
+            return new Outcome(false, e);
+        }
+    }
+
+    private Outcome callSetInitialNickname(Long userId, String nickname) {
+        try {
+            authService.setInitialNickname(userId, new NicknameSetRequest(nickname));
+            return new Outcome(true, null);
+        } catch (Exception e) {
+            return new Outcome(false, e);
+        }
+    }
+
+    private Long createLocalUser(String email, String nickname) {
+        User user = User.createLocalUser(email, passwordEncoder.encode("password1"), nickname);
+        return userRepository.save(user).getId();
+    }
+
+    private Long createSocialUserWithoutNickname(String email) {
+        User user = User.createSocialUser(email, AuthProvider.GOOGLE, "google-" + System.currentTimeMillis());
+        return userRepository.save(user).getId();
+    }
+
+    private void prepareVerifiedPasswordReset(String email) {
+        LocalDateTime now = LocalDateTime.now();
+        EmailVerification verification = EmailVerification.create(email, "123456", VerificationPurpose.PASSWORD_RESET, now.plusMinutes(10));
+        verification.verify(now);
+        emailVerificationRepository.save(verification);
+    }
+}

--- a/src/test/java/Hampouch/server/domain/auth/AuthVerificationConcurrencyTest.java
+++ b/src/test/java/Hampouch/server/domain/auth/AuthVerificationConcurrencyTest.java
@@ -1,0 +1,182 @@
+package Hampouch.server.domain.auth;
+
+import Hampouch.server.domain.auth.entity.EmailVerification;
+import Hampouch.server.domain.auth.entity.VerificationPurpose;
+import Hampouch.server.domain.auth.repository.EmailVerificationRepository;
+import Hampouch.server.domain.auth.util.EmailSender;
+import Hampouch.server.global.mysql.MySqlContainerTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+@MySqlContainerTest
+@AutoConfigureMockMvc
+class AuthVerificationConcurrencyTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    @Autowired
+    JdbcTemplate jdbc;
+
+    @Autowired
+    EmailVerificationRepository emailVerificationRepository;
+
+    @MockitoBean
+    EmailSender emailSender;
+
+    private record HttpResult(int status, String body) {
+    }
+
+    @Test
+    void 동일_이메일의_인증발송이_경쟁하면_한번만_발송되고_인증행도_하나만_남는다() throws Exception {
+        String email = "send-race-" + System.currentTimeMillis() + "@example.com";
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<HttpResult> firstCall = executor.submit(() -> callSend(email));
+            Future<HttpResult> secondCall = executor.submit(() -> callSend(email));
+
+            HttpResult first = firstCall.get(10, TimeUnit.SECONDS);
+            HttpResult second = secondCall.get(10, TimeUnit.SECONDS);
+
+            long successCount = Stream.of(first, second)
+                    .filter(result -> result.status() == 200)
+                    .count();
+            long tooManyRequestsCount = Stream.of(first, second)
+                    .filter(result -> result.status() == 429)
+                    .count();
+
+            assertThat(successCount)
+                    .as("동시 인증 발송 요청 중 정확히 하나만 성공해야 한다")
+                    .isEqualTo(1);
+            assertThat(tooManyRequestsCount)
+                    .as("나머지 요청은 발송 제한 응답이어야 한다")
+                    .isEqualTo(1);
+
+            HttpResult failed = first.status() == 429 ? first : second;
+            assertThat(failed.body()).contains("AUTH_EMAIL_SEND_TOO_FREQUENT");
+
+            Integer rowCount = jdbc.queryForObject("""
+                SELECT COUNT(*)
+                FROM email_verifications
+                WHERE email = ?
+                  AND purpose = 'SIGNUP'
+                """, Integer.class, email);
+
+            assertThat(rowCount)
+                    .as("동일 이메일과 목적의 인증 행은 하나만 남아야 한다")
+                    .isEqualTo(1);
+            verify(emailSender, times(1))
+                    .send(eq(email), anyString(), eq(VerificationPurpose.SIGNUP));
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void 동일_인증행의_실패요청이_경쟁해도_시도횟수가_유실되지_않는다() throws Exception {
+        String email = "verify-race-" + System.currentTimeMillis() + "@example.com";
+        LocalDateTime now = LocalDateTime.now();
+
+        EmailVerification verification = EmailVerification.create(
+                email, "123456", VerificationPurpose.SIGNUP, now.plusMinutes(10)
+        );
+        emailVerificationRepository.saveAndFlush(verification);
+
+        ExecutorService executor = Executors.newFixedThreadPool(5);
+        try {
+            List<Future<HttpResult>> calls = IntStream.range(0, 5)
+                    .mapToObj(index -> executor.submit(() -> callVerify(email, "000000")))
+                    .toList();
+
+            List<HttpResult> results = new ArrayList<>();
+            for (Future<HttpResult> call : calls) {
+                results.add(call.get(10, TimeUnit.SECONDS));
+            }
+
+            assertThat(results).allSatisfy(result -> {
+                assertThat(result.status()).isEqualTo(400);
+                assertThat(result.body()).contains("AUTH_EMAIL_CODE_MISMATCH");
+            });
+
+            Integer attemptCount = jdbc.queryForObject("""
+                    SELECT attempt_count
+                    FROM email_verifications
+                    WHERE email = ?
+                      AND purpose = 'SIGNUP'
+                    """, Integer.class, email);
+
+            assertThat(attemptCount)
+                    .as("동시 실패 요청 다섯 건이 모두 누적되어야 한다")
+                    .isEqualTo(5);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private HttpResult callSend(String email) {
+        try {
+            MvcResult result = mvc.perform(post("/api/auth/email/send")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {
+                                      "email": "%s",
+                                      "purpose": "SIGNUP"
+                                    }
+                                    """.formatted(email)))
+                    .andReturn();
+
+            return new HttpResult(
+                    result.getResponse().getStatus(),
+                    result.getResponse().getContentAsString()
+            );
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private HttpResult callVerify(String email, String code) {
+        try {
+            MvcResult result = mvc.perform(post("/api/auth/email/verify")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {
+                                      "email": "%s",
+                                      "code": "%s",
+                                      "purpose": "SIGNUP"
+                                    }
+                                    """.formatted(email, code)))
+                    .andReturn();
+
+            return new HttpResult(
+                    result.getResponse().getStatus(),
+                    result.getResponse().getContentAsString()
+            );
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/Hampouch/server/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/Hampouch/server/domain/auth/controller/AuthControllerTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.dao.CannotAcquireLockException;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -93,6 +94,24 @@ class AuthControllerTest {
                 .andExpect(jsonPath("$.data.expiresInSeconds").value(600));
     }
 
+    @Test
+    void 이메일인증발송_잠금획득에_실패하면_429를_반환한다() throws Exception {
+        when(authService.sendEmailVerification(any()))
+                .thenThrow(new CannotAcquireLockException("lock timeout"));
+
+        mvc.perform(post("/api/auth/email/send")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                            {
+                              "email": "test@example.com",
+                              "purpose": "SIGNUP"
+                            }
+                            """))
+                .andExpect(status().isTooManyRequests())
+                .andExpect(jsonPath("$.code").value("AUTH_REQUEST_IN_PROGRESS"))
+                .andExpect(jsonPath("$.status").value(429));
+    }
+
     // ---------- 이메일 인증 확인 ----------
 
     @Test
@@ -102,6 +121,25 @@ class AuthControllerTest {
                         .content("{\"email\":\"test@example.com\",\"code\":\"abc\",\"purpose\":\"SIGNUP\"}"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.fieldErrors.code").exists());
+    }
+
+    @Test
+    void 이메일인증_잠금획득에_실패하면_429를_반환한다() throws Exception {
+        when(authService.verifyEmail(any()))
+                .thenThrow(new CannotAcquireLockException("lock timeout"));
+
+        mvc.perform(post("/api/auth/email/verify")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                            {
+                              "email": "test@example.com",
+                              "code": "123456",
+                              "purpose": "SIGNUP"
+                            }
+                            """))
+                .andExpect(status().isTooManyRequests())
+                .andExpect(jsonPath("$.code").value("AUTH_REQUEST_IN_PROGRESS"))
+                .andExpect(jsonPath("$.status").value(429));
     }
 
     // ---------- 닉네임 중복확인 ----------

--- a/src/test/java/Hampouch/server/domain/auth/entity/EmailVerificationTest.java
+++ b/src/test/java/Hampouch/server/domain/auth/entity/EmailVerificationTest.java
@@ -87,4 +87,21 @@ class EmailVerificationTest {
         }
         assertThat(v.isAttemptExceeded()).isTrue();
     }
+
+    @Test
+    void 재발급하면_코드와_만료시각이_교체되고_인증상태와_시도횟수가_초기화된다() {
+        EmailVerification verification = create(now.plusMinutes(10));
+        verification.increaseAttempt();
+        verification.increaseAttempt();
+        verification.verify(now);
+
+        LocalDateTime newExpiredAt = now.plusMinutes(20);
+        verification.reissue("654321", newExpiredAt);
+
+        assertThat(verification.getVerificationCode()).isEqualTo("654321");
+        assertThat(verification.getExpiredAt()).isEqualTo(newExpiredAt);
+        assertThat(verification.getAttemptCount()).isZero();
+        assertThat(verification.isVerified()).isFalse();
+        assertThat(verification.getVerifiedAt()).isNull();
+    }
 }

--- a/src/test/java/Hampouch/server/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/auth/service/AuthServiceTest.java
@@ -115,6 +115,8 @@ class AuthServiceTest {
                 .isInstanceOf(CustomException.class)
                 .extracting(e -> ((CustomException) e).getErrorCode())
                 .isEqualTo(AuthErrorCode.AUTH_EMAIL_ALREADY_EXISTS);
+
+        verifyNoInteractions(emailVerificationRepository, emailSender);
     }
 
     @Test
@@ -128,19 +130,20 @@ class AuthServiceTest {
                 .isInstanceOf(CustomException.class)
                 .extracting(e -> ((CustomException) e).getErrorCode())
                 .isEqualTo(AuthErrorCode.AUTH_LOGIN_TYPE_MISMATCH);
+
+        verifyNoInteractions(emailVerificationRepository, emailSender);
     }
 
     @Test
     void 회원가입_인증발송_신규이메일이면_저장하고_발송한다() {
         when(userRepository.findByEmail("new@example.com")).thenReturn(Optional.empty());
-        when(emailVerificationRepository.findTopByEmailAndPurposeOrderByCreatedAtDesc(anyString(), any()))
-                .thenReturn(Optional.empty());
+        when(emailVerificationRepository.findByEmailAndPurposeForUpdate("new@example.com", VerificationPurpose.SIGNUP)).thenReturn(Optional.empty());
 
         EmailSendRequest request = new EmailSendRequest("new@example.com", "SIGNUP");
         EmailSendResponse response = authService.sendEmailVerification(request);
 
         assertThat(response.expiresInSeconds()).isEqualTo(600L);
-        verify(emailVerificationRepository).save(any(EmailVerification.class));
+        verify(emailVerificationRepository).saveAndFlush(any(EmailVerification.class));
         verify(emailSender).send(eq("new@example.com"), anyString(), eq(VerificationPurpose.SIGNUP));
     }
 
@@ -148,38 +151,43 @@ class AuthServiceTest {
     void 회원가입_인증발송_직전_발송으로부터_30초_이내면_예외() {
         when(userRepository.findByEmail("new@example.com")).thenReturn(Optional.empty());
 
-        EmailVerification lastSent = EmailVerification.create(
-                "new@example.com", "111111", VerificationPurpose.SIGNUP, FIXED_NOW.plusMinutes(10));
-        setField(lastSent, "createdAt", FIXED_NOW.minusSeconds(15));
-        when(emailVerificationRepository.findTopByEmailAndPurposeOrderByCreatedAtDesc(anyString(), any()))
-                .thenReturn(Optional.of(lastSent));
+        EmailVerification verification = EmailVerification.create("new@example.com", "111111",
+                VerificationPurpose.SIGNUP, FIXED_NOW.plusSeconds(585));
 
-        EmailSendRequest request = new EmailSendRequest("new@example.com", "SIGNUP");
+        when(emailVerificationRepository.findByEmailAndPurposeForUpdate("new@example.com", VerificationPurpose.SIGNUP))
+                .thenReturn(Optional.of(verification));
+
+        EmailSendRequest request =
+                new EmailSendRequest("new@example.com", "SIGNUP");
 
         assertThatThrownBy(() -> authService.sendEmailVerification(request))
                 .isInstanceOf(CustomException.class)
                 .extracting(e -> ((CustomException) e).getErrorCode())
                 .isEqualTo(AuthErrorCode.AUTH_EMAIL_SEND_TOO_FREQUENT);
 
-        verify(emailVerificationRepository, never()).save(any());
-        verify(emailSender, never()).send(anyString(), anyString(), any());
+        verify(emailVerificationRepository, never()).saveAndFlush(any());
+
+        verifyNoInteractions(emailSender);
     }
 
     @Test
     void 회원가입_인증발송_직전_발송으로부터_30초_지났으면_정상발송() {
         when(userRepository.findByEmail("new@example.com")).thenReturn(Optional.empty());
 
-        EmailVerification lastSent = EmailVerification.create(
-                "new@example.com", "111111", VerificationPurpose.SIGNUP, FIXED_NOW.plusMinutes(10));
-        setField(lastSent, "createdAt", FIXED_NOW.minusSeconds(31));
-        when(emailVerificationRepository.findTopByEmailAndPurposeOrderByCreatedAtDesc(anyString(), any()))
-                .thenReturn(Optional.of(lastSent));
+        EmailVerification verification = EmailVerification.create("new@example.com", "111111", VerificationPurpose.SIGNUP, FIXED_NOW.plusSeconds(569));
+        when(emailVerificationRepository.findByEmailAndPurposeForUpdate(
+                "new@example.com", VerificationPurpose.SIGNUP
+        )).thenReturn(Optional.of(verification));
 
         EmailSendRequest request = new EmailSendRequest("new@example.com", "SIGNUP");
         EmailSendResponse response = authService.sendEmailVerification(request);
 
         assertThat(response.expiresInSeconds()).isEqualTo(600L);
-        verify(emailVerificationRepository).save(any(EmailVerification.class));
+        assertThat(verification.getExpiredAt()).isEqualTo(FIXED_NOW.plusSeconds(600));
+        assertThat(verification.getAttemptCount()).isZero();
+        assertThat(verification.isVerified()).isFalse();
+        verify(emailVerificationRepository, never()).saveAndFlush(any());
+        verify(emailSender).send(eq("new@example.com"), anyString(), eq(VerificationPurpose.SIGNUP));
     }
 
     @Test
@@ -192,6 +200,8 @@ class AuthServiceTest {
                 .isInstanceOf(CustomException.class)
                 .extracting(e -> ((CustomException) e).getErrorCode())
                 .isEqualTo(UserErrorCode.USER_NOT_FOUND);
+
+        verifyNoInteractions(emailVerificationRepository, emailSender);
     }
 
     @Test
@@ -205,14 +215,19 @@ class AuthServiceTest {
                 .isInstanceOf(CustomException.class)
                 .extracting(e -> ((CustomException) e).getErrorCode())
                 .isEqualTo(AuthErrorCode.AUTH_PASSWORD_RESET_NOT_ALLOWED);
+
+        verifyNoInteractions(emailVerificationRepository, emailSender);
     }
 
     @Test
     void 인증발송_메일전송_실패시_발송실패_예외() {
         when(userRepository.findByEmail("new@example.com")).thenReturn(Optional.empty());
-        when(emailVerificationRepository.findTopByEmailAndPurposeOrderByCreatedAtDesc(anyString(), any()))
-                .thenReturn(Optional.empty());
-        doThrow(new RuntimeException("smtp down")).when(emailSender).send(anyString(), anyString(), any());
+        when(emailVerificationRepository.findByEmailAndPurposeForUpdate(
+                "new@example.com", VerificationPurpose.SIGNUP
+        )).thenReturn(Optional.empty());
+        doThrow(new RuntimeException("smtp down"))
+                .when(emailSender)
+                .send(anyString(), anyString(), any());
 
         EmailSendRequest request = new EmailSendRequest("new@example.com", "SIGNUP");
 
@@ -220,16 +235,21 @@ class AuthServiceTest {
                 .isInstanceOf(CustomException.class)
                 .extracting(e -> ((CustomException) e).getErrorCode())
                 .isEqualTo(AuthErrorCode.AUTH_EMAIL_SEND_FAILED);
+
+        verify(emailVerificationRepository).saveAndFlush(any(EmailVerification.class));
     }
 
     // ========== 2. verifyEmail ==========
 
     @Test
     void 이메일인증_확인_요청이없으면_예외() {
-        when(emailVerificationRepository.findTopByEmailAndPurposeOrderByCreatedAtDesc(anyString(), any()))
-                .thenReturn(Optional.empty());
+        when(emailVerificationRepository.findByEmailAndPurposeForUpdate(
+                "test@example.com", VerificationPurpose.SIGNUP
+        )).thenReturn(Optional.empty());
 
-        EmailVerifyRequest request = new EmailVerifyRequest("test@example.com", "123456", "SIGNUP");
+        EmailVerifyRequest request = new EmailVerifyRequest(
+                "test@example.com", "123456", "SIGNUP"
+        );
 
         assertThatThrownBy(() -> authService.verifyEmail(request))
                 .isInstanceOf(CustomException.class)
@@ -238,13 +258,17 @@ class AuthServiceTest {
     }
 
     @Test
-    void 이메일인증_확인_코드만료시_예외() {
+    void 이메일인증_확인_코드만료면_예외() {
         EmailVerification verification = EmailVerification.create(
-                "test@example.com", "123456", VerificationPurpose.SIGNUP, FIXED_NOW.minusMinutes(1));
-        when(emailVerificationRepository.findTopByEmailAndPurposeOrderByCreatedAtDesc(anyString(), any()))
-                .thenReturn(Optional.of(verification));
+                "test@example.com", "123456", VerificationPurpose.SIGNUP, FIXED_NOW.minusMinutes(1)
+        );
+        when(emailVerificationRepository.findByEmailAndPurposeForUpdate(
+                "test@example.com", VerificationPurpose.SIGNUP
+        )).thenReturn(Optional.of(verification));
 
-        EmailVerifyRequest request = new EmailVerifyRequest("test@example.com", "123456", "SIGNUP");
+        EmailVerifyRequest request = new EmailVerifyRequest(
+                "test@example.com", "123456", "SIGNUP"
+        );
 
         assertThatThrownBy(() -> authService.verifyEmail(request))
                 .isInstanceOf(CustomException.class)
@@ -253,52 +277,67 @@ class AuthServiceTest {
     }
 
     @Test
-    void 이메일인증_확인_시도횟수초과시_예외() {
+    void 이메일인증_확인_시도횟수초과면_예외() {
         EmailVerification verification = EmailVerification.create(
-                "test@example.com", "123456", VerificationPurpose.SIGNUP, FIXED_NOW.plusMinutes(10));
+                "test@example.com", "123456", VerificationPurpose.SIGNUP, FIXED_NOW.plusMinutes(10)
+        );
         for (int i = 0; i < 5; i++) {
             verification.increaseAttempt();
         }
-        when(emailVerificationRepository.findTopByEmailAndPurposeOrderByCreatedAtDesc(anyString(), any()))
-                .thenReturn(Optional.of(verification));
+        when(emailVerificationRepository.findByEmailAndPurposeForUpdate(
+                "test@example.com", VerificationPurpose.SIGNUP
+        )).thenReturn(Optional.of(verification));
 
-        EmailVerifyRequest request = new EmailVerifyRequest("test@example.com", "999999", "SIGNUP");
+        EmailVerifyRequest request = new EmailVerifyRequest(
+                "test@example.com", "999999", "SIGNUP"
+        );
 
         assertThatThrownBy(() -> authService.verifyEmail(request))
                 .isInstanceOf(CustomException.class)
                 .extracting(e -> ((CustomException) e).getErrorCode())
                 .isEqualTo(AuthErrorCode.AUTH_EMAIL_CODE_ATTEMPT_EXCEEDED);
+
+        assertThat(verification.getAttemptCount()).isEqualTo(5);
     }
 
     @Test
     void 이메일인증_확인_코드불일치시_예외이고_시도횟수가_증가한다() {
         EmailVerification verification = EmailVerification.create(
-                "test@example.com", "123456", VerificationPurpose.SIGNUP, FIXED_NOW.plusMinutes(10));
-        when(emailVerificationRepository.findTopByEmailAndPurposeOrderByCreatedAtDesc(anyString(), any()))
-                .thenReturn(Optional.of(verification));
+                "test@example.com", "123456", VerificationPurpose.SIGNUP, FIXED_NOW.plusMinutes(10)
+        );
+        when(emailVerificationRepository.findByEmailAndPurposeForUpdate(
+                "test@example.com", VerificationPurpose.SIGNUP
+        )).thenReturn(Optional.of(verification));
 
-        EmailVerifyRequest request = new EmailVerifyRequest("test@example.com", "000000", "SIGNUP");
+        EmailVerifyRequest request = new EmailVerifyRequest(
+                "test@example.com", "000000", "SIGNUP"
+        );
 
         assertThatThrownBy(() -> authService.verifyEmail(request))
                 .isInstanceOf(CustomException.class)
                 .extracting(e -> ((CustomException) e).getErrorCode())
                 .isEqualTo(AuthErrorCode.AUTH_EMAIL_CODE_MISMATCH);
 
-        assertThat(verification.isAttemptExceeded()).isFalse();
+        assertThat(verification.getAttemptCount()).isEqualTo(1);
     }
 
     @Test
     void 이메일인증_확인_성공하면_인증완료로_변경된다() {
         EmailVerification verification = EmailVerification.create(
-                "test@example.com", "123456", VerificationPurpose.SIGNUP, FIXED_NOW.plusMinutes(10));
-        when(emailVerificationRepository.findTopByEmailAndPurposeOrderByCreatedAtDesc(anyString(), any()))
-                .thenReturn(Optional.of(verification));
+                "test@example.com", "123456", VerificationPurpose.SIGNUP, FIXED_NOW.plusMinutes(10)
+        );
+        when(emailVerificationRepository.findByEmailAndPurposeForUpdate(
+                "test@example.com", VerificationPurpose.SIGNUP
+        )).thenReturn(Optional.of(verification));
 
-        EmailVerifyRequest request = new EmailVerifyRequest("test@example.com", "123456", "SIGNUP");
+        EmailVerifyRequest request = new EmailVerifyRequest(
+                "test@example.com", "123456", "SIGNUP"
+        );
         EmailVerifyResponse response = authService.verifyEmail(request);
 
         assertThat(response.verified()).isTrue();
         assertThat(verification.isVerified()).isTrue();
+        assertThat(verification.getVerifiedAt()).isEqualTo(FIXED_NOW);
     }
 
     // ========== 3. checkNickname ==========
@@ -340,12 +379,15 @@ class AuthServiceTest {
     }
 
     @Test
-    void 회원가입_이메일_인증기록이_없으면_예외() {
+    void 회원가입_이메일인증기록이_없으면_예외() {
         when(userRepository.findByEmail("new@example.com")).thenReturn(Optional.empty());
-        when(emailVerificationRepository.findTopByEmailAndPurposeOrderByCreatedAtDesc(anyString(), any()))
-                .thenReturn(Optional.empty());
+        when(emailVerificationRepository.findByEmailAndPurpose(
+                "new@example.com", VerificationPurpose.SIGNUP
+        )).thenReturn(Optional.empty());
 
-        SignupRequest request = new SignupRequest("new@example.com", "password1!", "닉네임");
+        SignupRequest request = new SignupRequest(
+                "new@example.com", "password1!", "닉네임"
+        );
 
         assertThatThrownBy(() -> authService.signup(request))
                 .isInstanceOf(CustomException.class)
@@ -354,16 +396,20 @@ class AuthServiceTest {
     }
 
     @Test
-    void 회원가입_인증은됐지만_1시간_지났으면_예외() {
+    void 회원가입_인증됐지만_1시간_지났으면_예외() {
         when(userRepository.findByEmail("new@example.com")).thenReturn(Optional.empty());
 
         EmailVerification verification = EmailVerification.create(
-                "new@example.com", "123456", VerificationPurpose.SIGNUP, FIXED_NOW.minusHours(2));
+                "new@example.com", "123456", VerificationPurpose.SIGNUP, FIXED_NOW.minusHours(2)
+        );
         verification.verify(FIXED_NOW.minusHours(2));
-        when(emailVerificationRepository.findTopByEmailAndPurposeOrderByCreatedAtDesc(anyString(), any()))
-                .thenReturn(Optional.of(verification));
+        when(emailVerificationRepository.findByEmailAndPurpose(
+                "new@example.com", VerificationPurpose.SIGNUP
+        )).thenReturn(Optional.of(verification));
 
-        SignupRequest request = new SignupRequest("new@example.com", "password1!", "닉네임");
+        SignupRequest request = new SignupRequest(
+                "new@example.com", "password1!", "닉네임"
+        );
 
         assertThatThrownBy(() -> authService.signup(request))
                 .isInstanceOf(CustomException.class)
@@ -372,15 +418,22 @@ class AuthServiceTest {
     }
 
     @Test
-    void 회원가입_정상흐름이면_유저가_생성된다() {
+    void 회원가입_정상요청이면_유저가_생성된다() {
+        when(userRepository.findByEmail("new@example.com")).thenReturn(Optional.empty());
+        when(userRepository.existsByNickname("닉네임")).thenReturn(false);
+
         EmailVerification verification = EmailVerification.create(
-                "new@example.com", "123456", VerificationPurpose.SIGNUP, FIXED_NOW.minusMinutes(30));
+                "new@example.com", "123456", VerificationPurpose.SIGNUP, FIXED_NOW.plusMinutes(10)
+        );
         verification.verify(FIXED_NOW.minusMinutes(10));
-        when(emailVerificationRepository.findTopByEmailAndPurposeOrderByCreatedAtDesc(anyString(), any()))
-                .thenReturn(Optional.of(verification));
+        when(emailVerificationRepository.findByEmailAndPurpose(
+                "new@example.com", VerificationPurpose.SIGNUP
+        )).thenReturn(Optional.of(verification));
         when(passwordEncoder.encode("password1!")).thenReturn("encoded-password");
 
-        SignupRequest request = new SignupRequest("new@example.com", "password1!", "닉네임");
+        SignupRequest request = new SignupRequest(
+                "new@example.com", "password1!", "닉네임"
+        );
         SignupResponse response = authService.signup(request);
 
         assertThat(response.email()).isEqualTo("new@example.com");
@@ -506,7 +559,7 @@ class AuthServiceTest {
         SocialLoginResponse response = authService.socialLogin(request);
 
         assertThat(response.isNewUser()).isTrue();
-        verify(userRepository).save(any(User.class));
+        verify(userRepository).saveAndFlush(any(User.class));
         verifyNoInteractions(userOperationLock);
     }
 
@@ -689,10 +742,13 @@ class AuthServiceTest {
 
     @Test
     void 비밀번호재설정_인증기록이_없으면_예외() {
-        when(emailVerificationRepository.findTopByEmailAndPurposeOrderByCreatedAtDesc(anyString(), any()))
-                .thenReturn(Optional.empty());
+        when(emailVerificationRepository.findByEmailAndPurpose(
+                "test@example.com", VerificationPurpose.PASSWORD_RESET
+        )).thenReturn(Optional.empty());
 
-        PasswordResetRequest request = new PasswordResetRequest("test@example.com", "newPassword1!");
+        PasswordResetRequest request = new PasswordResetRequest(
+                "test@example.com", "newPassword1!"
+        );
 
         assertThatThrownBy(() -> authService.resetPassword(request))
                 .isInstanceOf(CustomException.class)
@@ -702,15 +758,16 @@ class AuthServiceTest {
 
     @Test
     void 비밀번호재설정_가입안된_이메일이면_예외() {
-        EmailVerification verification = EmailVerification.create(
-                "test@example.com", "123456", VerificationPurpose.PASSWORD_RESET, FIXED_NOW.minusMinutes(30));
-        verification.verify(FIXED_NOW.minusMinutes(10));
-        when(emailVerificationRepository.findTopByEmailAndPurposeOrderByCreatedAtDesc(anyString(), any()))
-                .thenReturn(Optional.of(verification));
-        when(passwordEncoder.encode("newPassword1!")).thenReturn("new-encoded");
-        when(userRepository.findByEmailForUpdate("test@example.com")).thenReturn(Optional.empty());
+        EmailVerification verification = verifiedPasswordResetVerification();
+        when(emailVerificationRepository.findByEmailAndPurpose(
+                "test@example.com", VerificationPurpose.PASSWORD_RESET
+        )).thenReturn(Optional.of(verification));
+        when(userRepository.findByEmailForUpdate("test@example.com"))
+                .thenReturn(Optional.empty());
 
-        PasswordResetRequest request = new PasswordResetRequest("test@example.com", "newPassword1!");
+        PasswordResetRequest request = new PasswordResetRequest(
+                "test@example.com", "newPassword1!"
+        );
 
         assertThatThrownBy(() -> authService.resetPassword(request))
                 .isInstanceOf(CustomException.class)
@@ -720,17 +777,18 @@ class AuthServiceTest {
 
     @Test
     void 비밀번호재설정_소셜계정이면_예외() {
-        EmailVerification verification = EmailVerification.create(
-                "test@example.com", "123456", VerificationPurpose.PASSWORD_RESET, FIXED_NOW.minusMinutes(30));
-        verification.verify(FIXED_NOW.minusMinutes(10));
-        when(emailVerificationRepository.findTopByEmailAndPurposeOrderByCreatedAtDesc(anyString(), any()))
-                .thenReturn(Optional.of(verification));
-        when(passwordEncoder.encode("newPassword1!")).thenReturn("new-encoded");
+        EmailVerification verification = verifiedPasswordResetVerification();
+        when(emailVerificationRepository.findByEmailAndPurpose(
+                "test@example.com", VerificationPurpose.PASSWORD_RESET
+        )).thenReturn(Optional.of(verification));
 
         User user = socialUser(AuthProvider.GOOGLE, "test@example.com");
-        when(userRepository.findByEmailForUpdate("test@example.com")).thenReturn(Optional.of(user));
+        when(userRepository.findByEmailForUpdate("test@example.com"))
+                .thenReturn(Optional.of(user));
 
-        PasswordResetRequest request = new PasswordResetRequest("test@example.com", "newPassword1!");
+        PasswordResetRequest request = new PasswordResetRequest(
+                "test@example.com", "newPassword1!"
+        );
 
         assertThatThrownBy(() -> authService.resetPassword(request))
                 .isInstanceOf(CustomException.class)
@@ -740,17 +798,18 @@ class AuthServiceTest {
 
     @Test
     void 비밀번호재설정_탈퇴한_회원이면_예외() {
-        EmailVerification verification = EmailVerification.create(
-                "test@example.com", "123456", VerificationPurpose.PASSWORD_RESET, FIXED_NOW.minusMinutes(30));
-        verification.verify(FIXED_NOW.minusMinutes(10));
-        when(emailVerificationRepository.findTopByEmailAndPurposeOrderByCreatedAtDesc(anyString(), any()))
-                .thenReturn(Optional.of(verification));
-        when(passwordEncoder.encode("newPassword1!")).thenReturn("new-encoded");
+        EmailVerification verification = verifiedPasswordResetVerification();
+        when(emailVerificationRepository.findByEmailAndPurpose(
+                "test@example.com", VerificationPurpose.PASSWORD_RESET
+        )).thenReturn(Optional.of(verification));
 
         User user = localUser("test@example.com", "old-encoded", true);
-        when(userRepository.findByEmailForUpdate("test@example.com")).thenReturn(Optional.of(user));
+        when(userRepository.findByEmailForUpdate("test@example.com"))
+                .thenReturn(Optional.of(user));
 
-        PasswordResetRequest request = new PasswordResetRequest("test@example.com", "newPassword1!");
+        PasswordResetRequest request = new PasswordResetRequest(
+                "test@example.com", "newPassword1!"
+        );
 
         assertThatThrownBy(() -> authService.resetPassword(request))
                 .isInstanceOf(CustomException.class)
@@ -759,18 +818,20 @@ class AuthServiceTest {
     }
 
     @Test
-    void 비밀번호재설정_정상흐름이면_비밀번호가_변경된다() {
-        EmailVerification verification = EmailVerification.create(
-                "test@example.com", "123456", VerificationPurpose.PASSWORD_RESET, FIXED_NOW.minusMinutes(30));
-        verification.verify(FIXED_NOW.minusMinutes(10));
-        when(emailVerificationRepository.findTopByEmailAndPurposeOrderByCreatedAtDesc(anyString(), any()))
-                .thenReturn(Optional.of(verification));
+    void 비밀번호재설정_정상요청이면_비밀번호가_변경된다() {
+        EmailVerification verification = verifiedPasswordResetVerification();
+        when(emailVerificationRepository.findByEmailAndPurpose(
+                "test@example.com", VerificationPurpose.PASSWORD_RESET
+        )).thenReturn(Optional.of(verification));
 
         User user = localUser("test@example.com", "old-encoded", false);
-        when(userRepository.findByEmailForUpdate("test@example.com")).thenReturn(Optional.of(user));
+        when(userRepository.findByEmailForUpdate("test@example.com"))
+                .thenReturn(Optional.of(user));
         when(passwordEncoder.encode("newPassword1!")).thenReturn("new-encoded");
 
-        PasswordResetRequest request = new PasswordResetRequest("test@example.com", "newPassword1!");
+        PasswordResetRequest request = new PasswordResetRequest(
+                "test@example.com", "newPassword1!"
+        );
         authService.resetPassword(request);
 
         assertThat(user.getPassword()).isEqualTo("new-encoded");
@@ -929,5 +990,17 @@ class AuthServiceTest {
         assertThat(response.needsNickname()).isFalse();
         assertThat(response.role()).isEqualTo("USER");
         assertThat(response.status()).isEqualTo("ACTIVE");
+    }
+
+    //help 메서드
+    private EmailVerification verifiedPasswordResetVerification() {
+        EmailVerification verification = EmailVerification.create(
+                "test@example.com",
+                "123456",
+                VerificationPurpose.PASSWORD_RESET,
+                FIXED_NOW.plusMinutes(10)
+        );
+        verification.verify(FIXED_NOW.minusMinutes(10));
+        return verification;
     }
 }

--- a/src/test/java/Hampouch/server/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/auth/service/AuthServiceTest.java
@@ -13,6 +13,7 @@ import Hampouch.server.domain.user.entity.AuthProvider;
 import Hampouch.server.domain.user.entity.User;
 import Hampouch.server.domain.user.entity.UserRole;
 import Hampouch.server.domain.user.repository.UserRepository;
+import Hampouch.server.domain.user.service.UserOperationLock;
 import Hampouch.server.global.common.exception.CustomException;
 import Hampouch.server.global.common.exception.domain.AuthErrorCode;
 import Hampouch.server.global.common.exception.domain.UserErrorCode;
@@ -50,13 +51,14 @@ class AuthServiceTest {
     @Mock
     JwtProvider jwtProvider;
     @Mock
+    UserOperationLock userOperationLock;
+    @Mock
     EmailSender emailSender;
     @Mock
     SocialTokenVerifier socialTokenVerifier;
 
     AuthService authService;
 
-    // 테스트 결정성을 위해 Clock을 고정 시각으로 주입 (프로젝트 공용 Clock 컨벤션과 동일한 방식)
     final LocalDateTime FIXED_NOW = LocalDateTime.of(2026, 7, 22, 12, 0);
     final Clock clock = Clock.fixed(FIXED_NOW.atZone(ZoneId.of("Asia/Seoul")).toInstant(), ZoneId.of("Asia/Seoul"));
 
@@ -68,6 +70,7 @@ class AuthServiceTest {
                 refreshTokenRepository,
                 passwordEncoder,
                 jwtProvider,
+                userOperationLock,
                 clock,
                 emailSender,
                 List.of(socialTokenVerifier)
@@ -131,7 +134,7 @@ class AuthServiceTest {
     void 회원가입_인증발송_신규이메일이면_저장하고_발송한다() {
         when(userRepository.findByEmail("new@example.com")).thenReturn(Optional.empty());
         when(emailVerificationRepository.findTopByEmailAndPurposeOrderByCreatedAtDesc(anyString(), any()))
-                .thenReturn(Optional.empty()); // 이전 발송 기록 없음 -> 쿨다운 통과
+                .thenReturn(Optional.empty());
 
         EmailSendRequest request = new EmailSendRequest("new@example.com", "SIGNUP");
         EmailSendResponse response = authService.sendEmailVerification(request);
@@ -147,7 +150,7 @@ class AuthServiceTest {
 
         EmailVerification lastSent = EmailVerification.create(
                 "new@example.com", "111111", VerificationPurpose.SIGNUP, FIXED_NOW.plusMinutes(10));
-        setField(lastSent, "createdAt", FIXED_NOW.minusSeconds(15)); // 15초 전 발송 -> 30초 쿨다운 안 지남
+        setField(lastSent, "createdAt", FIXED_NOW.minusSeconds(15));
         when(emailVerificationRepository.findTopByEmailAndPurposeOrderByCreatedAtDesc(anyString(), any()))
                 .thenReturn(Optional.of(lastSent));
 
@@ -168,7 +171,7 @@ class AuthServiceTest {
 
         EmailVerification lastSent = EmailVerification.create(
                 "new@example.com", "111111", VerificationPurpose.SIGNUP, FIXED_NOW.plusMinutes(10));
-        setField(lastSent, "createdAt", FIXED_NOW.minusSeconds(31)); // 31초 전 발송 -> 쿨다운 지남
+        setField(lastSent, "createdAt", FIXED_NOW.minusSeconds(31));
         when(emailVerificationRepository.findTopByEmailAndPurposeOrderByCreatedAtDesc(anyString(), any()))
                 .thenReturn(Optional.of(lastSent));
 
@@ -208,7 +211,7 @@ class AuthServiceTest {
     void 인증발송_메일전송_실패시_발송실패_예외() {
         when(userRepository.findByEmail("new@example.com")).thenReturn(Optional.empty());
         when(emailVerificationRepository.findTopByEmailAndPurposeOrderByCreatedAtDesc(anyString(), any()))
-                .thenReturn(Optional.empty()); // 이전 발송 기록 없음 -> 쿨다운 통과
+                .thenReturn(Optional.empty());
         doThrow(new RuntimeException("smtp down")).when(emailSender).send(anyString(), anyString(), any());
 
         EmailSendRequest request = new EmailSendRequest("new@example.com", "SIGNUP");
@@ -281,7 +284,7 @@ class AuthServiceTest {
                 .extracting(e -> ((CustomException) e).getErrorCode())
                 .isEqualTo(AuthErrorCode.AUTH_EMAIL_CODE_MISMATCH);
 
-        assertThat(verification.isAttemptExceeded()).isFalse(); // 1회 실패는 아직 초과 아님
+        assertThat(verification.isAttemptExceeded()).isFalse();
     }
 
     @Test
@@ -356,7 +359,7 @@ class AuthServiceTest {
 
         EmailVerification verification = EmailVerification.create(
                 "new@example.com", "123456", VerificationPurpose.SIGNUP, FIXED_NOW.minusHours(2));
-        verification.verify(FIXED_NOW.minusHours(2)); // 2시간 전에 인증 완료 -> 1시간 유효시간 지남
+        verification.verify(FIXED_NOW.minusHours(2));
         when(emailVerificationRepository.findTopByEmailAndPurposeOrderByCreatedAtDesc(anyString(), any()))
                 .thenReturn(Optional.of(verification));
 
@@ -372,7 +375,7 @@ class AuthServiceTest {
     void 회원가입_정상흐름이면_유저가_생성된다() {
         EmailVerification verification = EmailVerification.create(
                 "new@example.com", "123456", VerificationPurpose.SIGNUP, FIXED_NOW.minusMinutes(30));
-        verification.verify(FIXED_NOW.minusMinutes(10)); // 10분 전 인증 완료 -> 유효
+        verification.verify(FIXED_NOW.minusMinutes(10));
         when(emailVerificationRepository.findTopByEmailAndPurposeOrderByCreatedAtDesc(anyString(), any()))
                 .thenReturn(Optional.of(verification));
         when(passwordEncoder.encode("password1!")).thenReturn("encoded-password");
@@ -390,7 +393,7 @@ class AuthServiceTest {
 
     @Test
     void 로그인_존재하지않는_이메일이면_로그인실패_예외() {
-        when(userRepository.findByEmail("unknown@example.com")).thenReturn(Optional.empty());
+        when(userRepository.findByEmailForUpdate("unknown@example.com")).thenReturn(Optional.empty());
 
         LoginRequest request = new LoginRequest("unknown@example.com", "password1!");
 
@@ -403,7 +406,7 @@ class AuthServiceTest {
     @Test
     void 로그인_소셜계정이면_로그인타입불일치_예외() {
         User user = socialUser(AuthProvider.GOOGLE, "test@example.com");
-        when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
+        when(userRepository.findByEmailForUpdate("test@example.com")).thenReturn(Optional.of(user));
 
         LoginRequest request = new LoginRequest("test@example.com", "password1!");
 
@@ -416,7 +419,7 @@ class AuthServiceTest {
     @Test
     void 로그인_비밀번호_불일치시_예외() {
         User user = localUser("test@example.com", "encoded", false);
-        when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
+        when(userRepository.findByEmailForUpdate("test@example.com")).thenReturn(Optional.of(user));
         when(passwordEncoder.matches("wrong", "encoded")).thenReturn(false);
 
         LoginRequest request = new LoginRequest("test@example.com", "wrong");
@@ -430,7 +433,7 @@ class AuthServiceTest {
     @Test
     void 로그인_탈퇴한_회원이면_예외() {
         User user = localUser("test@example.com", "encoded", true);
-        when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
+        when(userRepository.findByEmailForUpdate("test@example.com")).thenReturn(Optional.of(user));
         when(passwordEncoder.matches("password1!", "encoded")).thenReturn(true);
 
         LoginRequest request = new LoginRequest("test@example.com", "password1!");
@@ -444,7 +447,7 @@ class AuthServiceTest {
     @Test
     void 로그인_정상흐름이면_토큰이_발급된다() {
         User user = localUser("test@example.com", "encoded", false);
-        when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
+        when(userRepository.findByEmailForUpdate("test@example.com")).thenReturn(Optional.of(user));
         when(passwordEncoder.matches("password1!", "encoded")).thenReturn(true);
         when(jwtProvider.createAccessToken(1L, UserRole.USER)).thenReturn("access-token");
         when(jwtProvider.createRefreshToken(1L)).thenReturn("refresh-token");
@@ -493,7 +496,7 @@ class AuthServiceTest {
         when(socialTokenVerifier.supports("GOOGLE")).thenReturn(true);
         when(socialTokenVerifier.verify("provider-token"))
                 .thenReturn(new SocialTokenVerifier.SocialUserInfo("new@example.com", "provider-id"));
-        when(userRepository.findByEmail("new@example.com")).thenReturn(Optional.empty());
+        when(userRepository.findByEmailForUpdate("new@example.com")).thenReturn(Optional.empty());
         when(jwtProvider.createAccessToken(any(), any())).thenReturn("access-token");
         when(jwtProvider.createRefreshToken(any())).thenReturn("refresh-token");
         when(jwtProvider.getRefreshTokenExpiresInMs()).thenReturn(1_209_600_000L);
@@ -504,6 +507,7 @@ class AuthServiceTest {
 
         assertThat(response.isNewUser()).isTrue();
         verify(userRepository).save(any(User.class));
+        verifyNoInteractions(userOperationLock);
     }
 
     @Test
@@ -513,7 +517,7 @@ class AuthServiceTest {
                 .thenReturn(new SocialTokenVerifier.SocialUserInfo("test@example.com", "provider-id"));
 
         User existing = socialUser(AuthProvider.KAKAO, "test@example.com");
-        when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(existing));
+        when(userRepository.findByEmailForUpdate("test@example.com")).thenReturn(Optional.of(existing));
 
         SocialLoginRequest request = new SocialLoginRequest("GOOGLE", "provider-token");
 
@@ -531,7 +535,7 @@ class AuthServiceTest {
 
         User existing = socialUser(AuthProvider.GOOGLE, "test@example.com");
         existing.delete();
-        when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(existing));
+        when(userRepository.findByEmailForUpdate("test@example.com")).thenReturn(Optional.of(existing));
 
         SocialLoginRequest request = new SocialLoginRequest("GOOGLE", "provider-token");
 
@@ -548,7 +552,7 @@ class AuthServiceTest {
                 .thenReturn(new SocialTokenVerifier.SocialUserInfo("test@example.com", "provider-id"));
 
         User existing = socialUser(AuthProvider.GOOGLE, "test@example.com");
-        when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(existing));
+        when(userRepository.findByEmailForUpdate("test@example.com")).thenReturn(Optional.of(existing));
         when(jwtProvider.createAccessToken(any(), any())).thenReturn("access-token");
         when(jwtProvider.createRefreshToken(any())).thenReturn("refresh-token");
         when(jwtProvider.getRefreshTokenExpiresInMs()).thenReturn(1_209_600_000L);
@@ -639,7 +643,8 @@ class AuthServiceTest {
         TokenReissueResponse response = authService.reissueToken(request);
 
         assertThat(response.accessToken()).isEqualTo("new-access-token");
-        assertThat(saved.isRevoked()).isTrue(); // 기존 토큰 rotation 폐기 확인
+        assertThat(saved.isRevoked()).isTrue();
+        verify(userOperationLock).lock(1L);
     }
 
     // ========== 8. logout ==========
@@ -663,7 +668,6 @@ class AuthServiceTest {
 
         RefreshRequest request = new RefreshRequest("refresh-token");
 
-        // 토큰 소유자는 userId=1L인데 로그아웃 요청자는 999L -> 남의 토큰으로 로그아웃 시도 차단
         assertThatThrownBy(() -> authService.logout(999L, request))
                 .isInstanceOf(CustomException.class)
                 .extracting(e -> ((CustomException) e).getErrorCode())
@@ -703,7 +707,8 @@ class AuthServiceTest {
         verification.verify(FIXED_NOW.minusMinutes(10));
         when(emailVerificationRepository.findTopByEmailAndPurposeOrderByCreatedAtDesc(anyString(), any()))
                 .thenReturn(Optional.of(verification));
-        when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.empty());
+        when(passwordEncoder.encode("newPassword1!")).thenReturn("new-encoded");
+        when(userRepository.findByEmailForUpdate("test@example.com")).thenReturn(Optional.empty());
 
         PasswordResetRequest request = new PasswordResetRequest("test@example.com", "newPassword1!");
 
@@ -720,9 +725,10 @@ class AuthServiceTest {
         verification.verify(FIXED_NOW.minusMinutes(10));
         when(emailVerificationRepository.findTopByEmailAndPurposeOrderByCreatedAtDesc(anyString(), any()))
                 .thenReturn(Optional.of(verification));
+        when(passwordEncoder.encode("newPassword1!")).thenReturn("new-encoded");
 
         User user = socialUser(AuthProvider.GOOGLE, "test@example.com");
-        when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
+        when(userRepository.findByEmailForUpdate("test@example.com")).thenReturn(Optional.of(user));
 
         PasswordResetRequest request = new PasswordResetRequest("test@example.com", "newPassword1!");
 
@@ -739,9 +745,10 @@ class AuthServiceTest {
         verification.verify(FIXED_NOW.minusMinutes(10));
         when(emailVerificationRepository.findTopByEmailAndPurposeOrderByCreatedAtDesc(anyString(), any()))
                 .thenReturn(Optional.of(verification));
+        when(passwordEncoder.encode("newPassword1!")).thenReturn("new-encoded");
 
         User user = localUser("test@example.com", "old-encoded", true);
-        when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
+        when(userRepository.findByEmailForUpdate("test@example.com")).thenReturn(Optional.of(user));
 
         PasswordResetRequest request = new PasswordResetRequest("test@example.com", "newPassword1!");
 
@@ -760,7 +767,7 @@ class AuthServiceTest {
                 .thenReturn(Optional.of(verification));
 
         User user = localUser("test@example.com", "old-encoded", false);
-        when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
+        when(userRepository.findByEmailForUpdate("test@example.com")).thenReturn(Optional.of(user));
         when(passwordEncoder.encode("newPassword1!")).thenReturn("new-encoded");
 
         PasswordResetRequest request = new PasswordResetRequest("test@example.com", "newPassword1!");
@@ -801,6 +808,7 @@ class AuthServiceTest {
 
         assertThat(user.isDeleted()).isTrue();
         verify(refreshTokenRepository).revokeAllByUserId(1L);
+        verify(userOperationLock).lock(1L);
     }
 
     // ========== 11. setInitialNickname ==========
@@ -832,7 +840,6 @@ class AuthServiceTest {
 
     @Test
     void 닉네임최초설정_이미_닉네임이_설정된_유저면_예외() {
-        // localUser 헬퍼는 이미 "닉네임"으로 설정된 유저를 만들어줌 -> hasNickname() true
         User user = localUser("test@example.com", "encoded", false);
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
 
@@ -848,7 +855,6 @@ class AuthServiceTest {
 
     @Test
     void 닉네임최초설정_이미_존재하는_닉네임이면_예외() {
-        // socialUser 헬퍼는 닉네임 없이(null) 생성된 유저 -> hasNickname() false
         User user = socialUser(AuthProvider.GOOGLE, "test@example.com");
         when(userRepository.findById(2L)).thenReturn(Optional.of(user));
         when(userRepository.existsByNickname("중복닉네임")).thenReturn(true);
@@ -874,6 +880,7 @@ class AuthServiceTest {
         assertThat(response.nickname()).isEqualTo("새닉네임");
         assertThat(user.getNickname()).isEqualTo("새닉네임");
         assertThat(user.hasNickname()).isTrue();
+        verify(userOperationLock).lock(2L);
     }
 
     // ========== 12. getMe ==========

--- a/src/test/java/Hampouch/server/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/auth/service/AuthServiceTest.java
@@ -446,7 +446,7 @@ class AuthServiceTest {
 
     @Test
     void 로그인_존재하지않는_이메일이면_로그인실패_예외() {
-        when(userRepository.findByEmailForUpdate("unknown@example.com")).thenReturn(Optional.empty());
+        when(userRepository.findLoginCredentialByEmail("unknown@example.com")).thenReturn(Optional.empty());
 
         LoginRequest request = new LoginRequest("unknown@example.com", "password1!");
 
@@ -454,12 +454,15 @@ class AuthServiceTest {
                 .isInstanceOf(CustomException.class)
                 .extracting(e -> ((CustomException) e).getErrorCode())
                 .isEqualTo(AuthErrorCode.AUTH_LOGIN_FAILED);
+
+        verify(userRepository, never())
+                .findByEmailForUpdate(anyString());
     }
 
     @Test
     void 로그인_소셜계정이면_로그인타입불일치_예외() {
-        User user = socialUser(AuthProvider.GOOGLE, "test@example.com");
-        when(userRepository.findByEmailForUpdate("test@example.com")).thenReturn(Optional.of(user));
+        when(userRepository.findLoginCredentialByEmail("test@example.com"))
+                .thenReturn(Optional.of(loginCredential(AuthProvider.GOOGLE, null)));
 
         LoginRequest request = new LoginRequest("test@example.com", "password1!");
 
@@ -467,12 +470,16 @@ class AuthServiceTest {
                 .isInstanceOf(CustomException.class)
                 .extracting(e -> ((CustomException) e).getErrorCode())
                 .isEqualTo(AuthErrorCode.AUTH_LOGIN_TYPE_MISMATCH);
+
+        verifyNoInteractions(passwordEncoder);
+        verify(userRepository, never()).findByEmailForUpdate(anyString());
     }
 
     @Test
-    void 로그인_비밀번호_불일치시_예외() {
-        User user = localUser("test@example.com", "encoded", false);
-        when(userRepository.findByEmailForUpdate("test@example.com")).thenReturn(Optional.of(user));
+    void 로그인_비밀번호_불일치시_락을_잡지않고_예외() {
+        when(userRepository.findLoginCredentialByEmail("test@example.com"))
+                .thenReturn(Optional.of(loginCredential(AuthProvider.LOCAL, "encoded")));
+
         when(passwordEncoder.matches("wrong", "encoded")).thenReturn(false);
 
         LoginRequest request = new LoginRequest("test@example.com", "wrong");
@@ -481,13 +488,20 @@ class AuthServiceTest {
                 .isInstanceOf(CustomException.class)
                 .extracting(e -> ((CustomException) e).getErrorCode())
                 .isEqualTo(AuthErrorCode.AUTH_LOGIN_FAILED);
+
+        verify(userRepository, never()).findByEmailForUpdate(anyString());
     }
 
     @Test
     void 로그인_탈퇴한_회원이면_예외() {
         User user = localUser("test@example.com", "encoded", true);
-        when(userRepository.findByEmailForUpdate("test@example.com")).thenReturn(Optional.of(user));
+
+        when(userRepository.findLoginCredentialByEmail("test@example.com"))
+                .thenReturn(Optional.of(loginCredential(AuthProvider.LOCAL, "encoded")));
+
         when(passwordEncoder.matches("password1!", "encoded")).thenReturn(true);
+
+        when(userRepository.findByEmailForUpdate("test@example.com")).thenReturn(Optional.of(user));
 
         LoginRequest request = new LoginRequest("test@example.com", "password1!");
 
@@ -500,20 +514,69 @@ class AuthServiceTest {
     @Test
     void 로그인_정상흐름이면_토큰이_발급된다() {
         User user = localUser("test@example.com", "encoded", false);
-        when(userRepository.findByEmailForUpdate("test@example.com")).thenReturn(Optional.of(user));
+        when(userRepository.findLoginCredentialByEmail("test@example.com")).
+                thenReturn(Optional.of(loginCredential(AuthProvider.LOCAL, "encoded")));
+
         when(passwordEncoder.matches("password1!", "encoded")).thenReturn(true);
+        when(userRepository.findByEmailForUpdate("test@example.com")).thenReturn(Optional.of(user));
         when(jwtProvider.createAccessToken(1L, UserRole.USER)).thenReturn("access-token");
         when(jwtProvider.createRefreshToken(1L)).thenReturn("refresh-token");
         when(jwtProvider.getRefreshTokenExpiresInMs()).thenReturn(1_209_600_000L);
         when(jwtProvider.getAccessTokenExpiresInMs()).thenReturn(3_600_000L);
 
         LoginRequest request = new LoginRequest("test@example.com", "password1!");
+
         LoginResponse response = authService.login(request);
 
         assertThat(response.accessToken()).isEqualTo("access-token");
         assertThat(response.refreshToken()).isEqualTo("refresh-token");
         assertThat(response.user().userId()).isEqualTo(1L);
+
         verify(refreshTokenRepository).save(any(RefreshToken.class));
+    }
+
+    @Test
+    void 로그인_비밀번호검증후_해시가_변경됐으면_로그인실패() {
+        User user = localUser(
+                "test@example.com",
+                "new-encoded",
+                false
+        );
+
+        when(userRepository.findLoginCredentialByEmail(
+                "test@example.com"
+        )).thenReturn(Optional.of(
+                loginCredential(
+                        AuthProvider.LOCAL,
+                        "old-encoded"
+                )
+        ));
+
+        when(passwordEncoder.matches(
+                "old-password",
+                "old-encoded"
+        )).thenReturn(true);
+
+        when(userRepository.findByEmailForUpdate(
+                "test@example.com"
+        )).thenReturn(Optional.of(user));
+
+        LoginRequest request = new LoginRequest(
+                "test@example.com",
+                "old-password"
+        );
+
+        assertThatThrownBy(() -> authService.login(request))
+                .isInstanceOf(CustomException.class)
+                .extracting(e ->
+                        ((CustomException) e).getErrorCode()
+                )
+                .isEqualTo(AuthErrorCode.AUTH_LOGIN_FAILED);
+
+        verifyNoInteractions(
+                refreshTokenRepository,
+                jwtProvider
+        );
     }
 
     // ========== 6. socialLogin ==========
@@ -1002,5 +1065,19 @@ class AuthServiceTest {
         );
         verification.verify(FIXED_NOW.minusMinutes(10));
         return verification;
+    }
+
+    private UserRepository.LoginCredentialView loginCredential(AuthProvider provider, String password) {
+        return new UserRepository.LoginCredentialView() {
+            @Override
+            public AuthProvider getProvider() {
+                return provider;
+            }
+
+            @Override
+            public String getPassword() {
+                return password;
+            }
+        };
     }
 }

--- a/src/test/java/Hampouch/server/global/mysql/MySqlBaselineTransitionTest.java
+++ b/src/test/java/Hampouch/server/global/mysql/MySqlBaselineTransitionTest.java
@@ -73,7 +73,7 @@ class MySqlBaselineTransitionTest {
             assertThat(appliedSqlVersions)
                     .as("V1은 baseline으로만 기록되고 현재 브랜치의 후속 마이그레이션은 SQL로 기록되어야 한다")
                     .doesNotContain("1")
-                    .contains("2", "3", "4", "6", "7", "8");
+                    .contains("2", "3", "4", "6", "7", "8", "10");
 
             // 3) V3에서 도입한 제약 이름까지 실제 스키마에 반영됐는지 확인
             List<String> uniqueConstraints = schema.jdbc().queryForList("""

--- a/src/test/java/Hampouch/server/global/mysql/MySqlSchemaCreationTest.java
+++ b/src/test/java/Hampouch/server/global/mysql/MySqlSchemaCreationTest.java
@@ -172,6 +172,31 @@ class MySqlSchemaCreationTest {
         assertThat(applied).isEqualTo(1);
         assertThat(indexColumns).isEqualTo("status,id");
     }
+
+    @Test
+    @DisplayName("V10이 이메일과 인증 목적의 복합 유니크 제약을 생성한다")
+    void addsEmailVerificationEmailPurposeUniqueConstraint() {
+        Integer applied = jdbc.queryForObject("""
+            SELECT COUNT(*)
+            FROM flyway_schema_history
+            WHERE version = '9'
+              AND type = 'SQL'
+              AND success = 1
+            """, Integer.class);
+
+        String indexColumns = jdbc.queryForObject("""
+            SELECT GROUP_CONCAT(column_name ORDER BY seq_in_index SEPARATOR ',')
+            FROM information_schema.statistics
+            WHERE table_schema = DATABASE()
+              AND table_name = 'email_verifications'
+              AND index_name = 'uk_email_verification_email_purpose'
+              AND non_unique = 0
+            """, String.class);
+
+        assertThat(applied).isEqualTo(1);
+        assertThat(indexColumns).isEqualTo("email,purpose");
+    }
+
     @DisplayName("Flyway V4가 목표 조정 DB ENUM에 PLUS_30을 추가한다")
     void appliesPlusThirtyAdjustmentOptionMigration() {
         Integer applied = jdbc.queryForObject("""

--- a/src/test/java/Hampouch/server/global/mysql/MySqlSchemaCreationTest.java
+++ b/src/test/java/Hampouch/server/global/mysql/MySqlSchemaCreationTest.java
@@ -179,7 +179,7 @@ class MySqlSchemaCreationTest {
         Integer applied = jdbc.queryForObject("""
             SELECT COUNT(*)
             FROM flyway_schema_history
-            WHERE version = '9'
+            WHERE version = '10'
               AND type = 'SQL'
               AND success = 1
             """, Integer.class);

--- a/src/test/java/Hampouch/server/global/mysql/MySqlSchemaCreationTest.java
+++ b/src/test/java/Hampouch/server/global/mysql/MySqlSchemaCreationTest.java
@@ -197,6 +197,7 @@ class MySqlSchemaCreationTest {
         assertThat(indexColumns).isEqualTo("email,purpose");
     }
 
+    @Test
     @DisplayName("Flyway V4가 목표 조정 DB ENUM에 PLUS_30을 추가한다")
     void appliesPlusThirtyAdjustmentOptionMigration() {
         Integer applied = jdbc.queryForObject("""


### PR DESCRIPTION
## 📎연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) closes #[issue number]

- close: #176
- close: #180 

## 📄 작업 내용 요약
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
- AuthService의 기존 사용자 대상 요청(재발급·로그인·기존 소셜 로그인·최초 닉네임 설정·
비밀번호 재설정·회원 탈퇴)이 같은 사용자 행 락(UserOperationLock, #177)을 공유하도록 직렬화
- 외부 토큰 검증, bcrypt 해싱처럼 오래 걸리는 작업은 사용자 락 밖에서 먼저 처리하고,
  기존 사용자 재조회부터 상태 검증·DB 변경까지만 같은 사용자 락 구간으로 통일
- login/socialLogin(기존 유저)/resetPassword는 UserRepository.findByEmailForUpdate로
  조회 자체를 처음부터 잠금 조회로 구현
- deleteMe와 reissueToken/login/resetPassword/setInitialNickname, 그리고 동시 deleteMe를 @MySqlContainerTest에서 실제로 겹치게 실행해 응답과 최종 사용자·refresh token 상태를 함께 단언하는 동시성 테스트를 추가

- 동일한 인증 대상에 요청이 동시에 들어왔을 때 발생할 수 있는 이메일 중복 발송, 인증 실패 횟수 유실, 사용자 중복 생성 및 닉네임 상태 불일치 문제를 수정
  - 이메일 인증 행을 이메일·인증 목적당 하나만 유지하도록 복합 유니크 제약 추가
  - 인증번호 재발급 시 새로운 행을 생성하지 않고 기존 인증 행 갱신
  - 인증 발송 시 인증 행을 잠금 조회하여 쿨다운 검사와 저장을 직렬화
  - 인증번호 검증 시 인증 행을 잠금 조회하여 실패 횟수 유실 방지
  - 인증번호 불일치 예외 발생 시 증가한 시도 횟수가 롤백되지 않도록 처리
  - 최초 소셜 로그인 경쟁 시 DB 유니크 제약 위반이 500으로 노출되지 않도록 변환
  - 최초 닉네임 설정 시 사용자 행을 잠그고 닉네임 유니크 충돌을 409로 변환
  - 탈퇴와 로그인·비밀번호 재설정·닉네임 설정 경쟁 시 사용자 상태를 잠금 조회
- 실제 MySQL 기반 동시성 회귀 테스트 추가

## 👀 중요 변경 사항
> API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요
- 기존에는 인증번호를 발송할 때마다 새로운 `email_verifications` 행을 생성했지만 이제 `(email, purpose)` 조합당 하나의 행만 유지하기 때문에, 재발송 시 인증번호, 만료시각, 인증 완료 및 인증 시각, 실패 시도 횟수 등의 값이 초기화됩니다.
- email_verifications 테이블에 uk_email_verification_email_purpose (email, purpose) 복합 유니크 제약을 추가했습니다.

## 🔖 Uncompleted Tasks
> 후속 작업 예정인 사항이 있다면 작성해주세요.

## 📢 To Reviewers
> Reviewer가 주로 확인해주었으면 하는 부분을 적어주세요.
- 비밀번호 검증이 락 안에서 일어나는 트레이드오프가 괜찮은지 확인해주세요. (이제 정합성은 보장되지만 login의 비밀번호 검증이 사용자 락을 잡은 채로 일어남)
- 이메일 인증 행을 (email, purpose)당 하나로 유지하고 재발급 시 갱신하는 방식이 적절한지 확인해주세요.