### PR TITLE
feat: 마이페이지 알림 설정 조회·변경 API

### DIFF
--- a/src/main/java/Hampouch/server/domain/auth/service/AuthService.java
+++ b/src/main/java/Hampouch/server/domain/auth/service/AuthService.java
@@ -10,7 +10,9 @@ import Hampouch.server.domain.auth.repository.RefreshTokenRepository;
 import Hampouch.server.domain.auth.util.EmailSender;
 import Hampouch.server.domain.auth.util.SocialTokenVerifier;
 import Hampouch.server.domain.user.entity.AuthProvider;
+import Hampouch.server.domain.user.entity.NotificationSchedule;
 import Hampouch.server.domain.user.entity.User;
+import Hampouch.server.domain.user.repository.NotificationScheduleRepository;
 import Hampouch.server.domain.user.repository.UserRepository;
 import Hampouch.server.global.common.exception.CustomException;
 import Hampouch.server.global.common.exception.domain.AuthErrorCode;
@@ -42,6 +44,7 @@ public class AuthService {
     private static final int EMAIL_CODE_LENGTH = 6;
 
     private final UserRepository userRepository;
+    private final NotificationScheduleRepository notificationScheduleRepository;
     private final EmailVerificationRepository emailVerificationRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final PasswordEncoder passwordEncoder;
@@ -196,6 +199,8 @@ public class AuthService {
             throw e;
         }
 
+        notificationScheduleRepository.save(NotificationSchedule.createDefault(user));
+
         return SignupResponse.of(user.getId(), user.getEmail(), user.getNickname(), user.getProvider().name());
     }
 
@@ -254,6 +259,7 @@ public class AuthService {
                     socialInfo.providerId()
             );
             userRepository.save(user);
+            notificationScheduleRepository.save(NotificationSchedule.createDefault(user));
             isNewUser = true;
         } else {
             if (user.getProvider() != provider) {

--- a/src/main/java/Hampouch/server/domain/user/controller/NotificationScheduleController.java
+++ b/src/main/java/Hampouch/server/domain/user/controller/NotificationScheduleController.java
@@ -1,0 +1,38 @@
+package Hampouch.server.domain.user.controller;
+
+import Hampouch.server.domain.user.dto.request.NotificationScheduleUpdateRequest;
+import Hampouch.server.domain.user.dto.response.NotificationScheduleResponse;
+import Hampouch.server.domain.user.service.NotificationScheduleService;
+import Hampouch.server.global.common.response.ApiResponse;
+import Hampouch.server.global.security.LoginUserId;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/users/me/notification/schedule")
+@RequiredArgsConstructor
+public class NotificationScheduleController {
+
+    private final NotificationScheduleService notificationScheduleService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<NotificationScheduleResponse>> getSchedule(@LoginUserId Long userId) {
+        NotificationScheduleResponse response = notificationScheduleService.getSchedule(userId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PutMapping
+    public ResponseEntity<ApiResponse<NotificationScheduleResponse>> updateSchedule(
+            @LoginUserId Long userId,
+            @RequestBody @Valid NotificationScheduleUpdateRequest request
+    ) {
+        NotificationScheduleResponse response = notificationScheduleService.updateSchedule(userId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/Hampouch/server/domain/user/dto/request/NotificationScheduleUpdateRequest.java
+++ b/src/main/java/Hampouch/server/domain/user/dto/request/NotificationScheduleUpdateRequest.java
@@ -1,0 +1,51 @@
+package Hampouch.server.domain.user.dto.request;
+
+import Hampouch.server.domain.user.entity.NotificationDay;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+import java.util.Set;
+
+/** PUT은 전체 교체 방식 - 요청에 실린 필드 전체가 저장된 전체 설정을 덮어쓴다. */
+public record NotificationScheduleUpdateRequest(
+        boolean challengeAlert,
+        boolean battleAlert,
+        boolean communityAlert,
+
+        @NotNull(message = "기록 알림 설정은 필수입니다.")
+        @Valid
+        RecordAlert recordAlert
+) {
+    public record RecordAlert(
+            boolean enabled,
+
+            @NotNull(message = "미입력 알림 설정은 필수입니다.")
+            @Valid
+            MissingInput missingInput,
+
+            @NotNull(message = "한도 초과 알림 설정은 필수입니다.")
+            @Valid
+            LimitExceeded limitExceeded
+    ) {
+    }
+
+    public record MissingInput(
+            boolean enabled,
+
+            @NotEmpty(message = "요일을 1개 이상 선택해주세요.")
+            Set<NotificationDay> days,
+
+            @NotBlank(message = "시각은 HH:mm 형식으로 입력해주세요.")
+            @Pattern(regexp = "^([01]\\d|2[0-3]):[0-5]\\d$", message = "시각은 HH:mm 형식으로 입력해주세요.")
+            String time
+    ) {
+    }
+
+    public record LimitExceeded(
+            boolean enabled
+    ) {
+    }
+}

--- a/src/main/java/Hampouch/server/domain/user/dto/request/NotificationScheduleUpdateRequest.java
+++ b/src/main/java/Hampouch/server/domain/user/dto/request/NotificationScheduleUpdateRequest.java
@@ -9,18 +9,29 @@ import jakarta.validation.constraints.Pattern;
 
 import java.util.Set;
 
-/** PUT은 전체 교체 방식 - 요청에 실린 필드 전체가 저장된 전체 설정을 덮어쓴다. */
+/**
+ * PUT은 전체 교체 방식 - 요청에 실린 필드 전체가 저장된 전체 설정을 덮어쓴다.
+ * enabled류 필드는 primitive boolean이 아니라 Boolean + @NotNull이다 - primitive였다면 필드가
+ * 요청에서 통째로 빠져도 Jackson이 기본값 false로 채워서 검증 오류 없이 조용히 꺼짐으로 처리됐다
+ * (PR #229 리뷰 지적).
+ */
 public record NotificationScheduleUpdateRequest(
-        boolean challengeAlert,
-        boolean battleAlert,
-        boolean communityAlert,
+        @NotNull(message = "챌린지 알림 여부는 필수입니다.")
+        Boolean challengeAlert,
+
+        @NotNull(message = "햄배틀 알림 여부는 필수입니다.")
+        Boolean battleAlert,
+
+        @NotNull(message = "커뮤니티 알림 여부는 필수입니다.")
+        Boolean communityAlert,
 
         @NotNull(message = "기록 알림 설정은 필수입니다.")
         @Valid
         RecordAlert recordAlert
 ) {
     public record RecordAlert(
-            boolean enabled,
+            @NotNull(message = "기록 알림 여부는 필수입니다.")
+            Boolean enabled,
 
             @NotNull(message = "미입력 알림 설정은 필수입니다.")
             @Valid
@@ -33,7 +44,8 @@ public record NotificationScheduleUpdateRequest(
     }
 
     public record MissingInput(
-            boolean enabled,
+            @NotNull(message = "미입력 알림 여부는 필수입니다.")
+            Boolean enabled,
 
             @NotEmpty(message = "요일을 1개 이상 선택해주세요.")
             Set<NotificationDay> days,
@@ -45,7 +57,8 @@ public record NotificationScheduleUpdateRequest(
     }
 
     public record LimitExceeded(
-            boolean enabled
+            @NotNull(message = "한도 초과 알림 여부는 필수입니다.")
+            Boolean enabled
     ) {
     }
 }

--- a/src/main/java/Hampouch/server/domain/user/dto/response/NotificationScheduleResponse.java
+++ b/src/main/java/Hampouch/server/domain/user/dto/response/NotificationScheduleResponse.java
@@ -1,0 +1,51 @@
+package Hampouch.server.domain.user.dto.response;
+
+import Hampouch.server.domain.user.entity.NotificationDay;
+import Hampouch.server.domain.user.entity.NotificationSchedule;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalTime;
+import java.util.Set;
+
+public record NotificationScheduleResponse(
+        boolean challengeAlert,
+        boolean battleAlert,
+        boolean communityAlert,
+        RecordAlert recordAlert
+) {
+    public record RecordAlert(
+            boolean enabled,
+            MissingInput missingInput,
+            LimitExceeded limitExceeded
+    ) {
+    }
+
+    public record MissingInput(
+            boolean enabled,
+            Set<NotificationDay> days,
+            @JsonFormat(pattern = "HH:mm") LocalTime time
+    ) {
+    }
+
+    public record LimitExceeded(
+            boolean enabled
+    ) {
+    }
+
+    public static NotificationScheduleResponse of(NotificationSchedule schedule) {
+        return new NotificationScheduleResponse(
+                schedule.isChallengeAlert(),
+                schedule.isBattleAlert(),
+                schedule.isCommunityAlert(),
+                new RecordAlert(
+                        schedule.isRecordAlertEnabled(),
+                        new MissingInput(
+                                schedule.isMissingInputEnabled(),
+                                schedule.getMissingInputDays(),
+                                schedule.getMissingInputTime()
+                        ),
+                        new LimitExceeded(schedule.isLimitExceededEnabled())
+                )
+        );
+    }
+}

--- a/src/main/java/Hampouch/server/domain/user/entity/NotificationDay.java
+++ b/src/main/java/Hampouch/server/domain/user/entity/NotificationDay.java
@@ -1,0 +1,5 @@
+package Hampouch.server.domain.user.entity;
+
+public enum NotificationDay {
+    MON, TUE, WED, THU, FRI, SAT, SUN
+}

--- a/src/main/java/Hampouch/server/domain/user/entity/NotificationMissingInputDay.java
+++ b/src/main/java/Hampouch/server/domain/user/entity/NotificationMissingInputDay.java
@@ -1,0 +1,37 @@
+package Hampouch.server.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 미입력 알림을 보낼 요일 1개. 저장 단위 = 알림 설정(NotificationSchedule)별.
+ * uq_notification_missing_input_day = (user_id, day_of_week) 유니크 — 같은 유저가 같은 요일을 중복 저장하는 것을 DB가 최종 차단.
+ * 컬럼명은 day가 아니라 day_of_week — H2(MySQL 호환 모드로 테스트에 씀)가 DAY를 예약어로 취급해
+ * unquoted 컬럼명으로 쓰면 CREATE TABLE 자체가 조용히 실패한다(실 MySQL에서는 문제없지만 테스트 DB 호환을 위해 회피).
+ */
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "notification_schedule_missing_input_day", uniqueConstraints =
+        @UniqueConstraint(name = "uq_notification_missing_input_day", columnNames = {"user_id", "day_of_week"}))
+public class NotificationMissingInputDay {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false) // 이 테이블에 생기는 FK 컬럼 이름 — notification_schedule.user_id를 참조
+    private NotificationSchedule notificationSchedule;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "day_of_week", nullable = false, length = 10)
+    private NotificationDay day;
+
+    NotificationMissingInputDay(NotificationSchedule notificationSchedule, NotificationDay day) {
+        this.notificationSchedule = notificationSchedule;
+        this.day = day;
+    }
+}

--- a/src/main/java/Hampouch/server/domain/user/entity/NotificationSchedule.java
+++ b/src/main/java/Hampouch/server/domain/user/entity/NotificationSchedule.java
@@ -1,0 +1,141 @@
+package Hampouch.server.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
+
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * 마이페이지 알림 설정 1건. PK를 users.user_id와 공유해 유저당 정확히 1행을 강제한다(ExpenseDetail과 동일한 1:1 패턴).
+ * User 쪽엔 역참조를 두지 않는다 - 더 자주 조회되는 User에 N+1 위험을 얹지 않기 위해 단방향 유지.
+ * 미입력 알림 요일은 콤마문자열이 아니라 NotificationMissingInputDay 자식 엔티티(요일당 1행)로 정규화해서 저장한다.
+ */
+@Getter
+@Entity
+@DynamicUpdate
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "notification_schedule")
+public class NotificationSchedule {
+
+    private static final LocalTime DEFAULT_MISSING_INPUT_TIME = LocalTime.of(21, 0);
+
+    @Id
+    @Column(name = "user_id")
+    private Long userId;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @MapsId
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(name = "challenge_alert", nullable = false)
+    private boolean challengeAlert;
+
+    @Column(name = "battle_alert", nullable = false)
+    private boolean battleAlert;
+
+    @Column(name = "community_alert", nullable = false)
+    private boolean communityAlert;
+
+    @Column(name = "record_alert_enabled", nullable = false)
+    private boolean recordAlertEnabled;
+
+    @Column(name = "missing_input_enabled", nullable = false)
+    private boolean missingInputEnabled;
+
+    // 원본 행 컬렉션은 외부에 노출하지 않는다 - 외부엔 getMissingInputDays()가 반환하는 Set<NotificationDay>만 공개.
+    @Getter(AccessLevel.NONE)
+    @OneToMany(mappedBy = "notificationSchedule", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<NotificationMissingInputDay> missingInputDayRows = new ArrayList<>();
+
+    @Column(name = "missing_input_time", nullable = false)
+    private LocalTime missingInputTime;
+
+    @Column(name = "limit_exceeded_enabled", nullable = false)
+    private boolean limitExceededEnabled;
+
+    private NotificationSchedule(
+            User user,
+            boolean challengeAlert,
+            boolean battleAlert,
+            boolean communityAlert,
+            boolean recordAlertEnabled,
+            boolean missingInputEnabled,
+            Set<NotificationDay> missingInputDays,
+            LocalTime missingInputTime,
+            boolean limitExceededEnabled
+    ) {
+        this.user = user;
+        this.challengeAlert = challengeAlert;
+        this.battleAlert = battleAlert;
+        this.communityAlert = communityAlert;
+        this.recordAlertEnabled = recordAlertEnabled;
+        this.missingInputEnabled = missingInputEnabled;
+        replaceMissingInputDays(missingInputDays);
+        this.missingInputTime = missingInputTime;
+        this.limitExceededEnabled = limitExceededEnabled;
+    }
+
+    /** 가입 직후 기본값 - PM 확정 답변대로 전 알림 켜짐, 미입력 알림은 매일 21:00. */
+    public static NotificationSchedule createDefault(User user) {
+        return new NotificationSchedule(
+                user, true, true, true, true, true,
+                EnumSet.allOf(NotificationDay.class),
+                DEFAULT_MISSING_INPUT_TIME,
+                true
+        );
+    }
+
+    /** PUT은 전체 교체 방식 - 요청에 실린 필드 전체로 덮어쓴다. */
+    public void replaceWith(
+            boolean challengeAlert,
+            boolean battleAlert,
+            boolean communityAlert,
+            boolean recordAlertEnabled,
+            boolean missingInputEnabled,
+            Set<NotificationDay> missingInputDays,
+            LocalTime missingInputTime,
+            boolean limitExceededEnabled
+    ) {
+        this.challengeAlert = challengeAlert;
+        this.battleAlert = battleAlert;
+        this.communityAlert = communityAlert;
+        this.recordAlertEnabled = recordAlertEnabled;
+        this.missingInputEnabled = missingInputEnabled;
+        replaceMissingInputDays(missingInputDays);
+        this.missingInputTime = missingInputTime;
+        this.limitExceededEnabled = limitExceededEnabled;
+    }
+
+    public Set<NotificationDay> getMissingInputDays() {
+        return missingInputDayRows.stream()
+                .map(NotificationMissingInputDay::getDay)
+                .collect(Collectors.toCollection(() -> EnumSet.noneOf(NotificationDay.class)));
+    }
+
+    /**
+     * clear() 후 통째로 재추가하면 안 된다 - Hibernate의 flush 순서는 새 INSERT를 orphanRemoval DELETE보다
+     * 먼저 실행해서, 이전·이후 요일 집합이 하나라도 겹치면(흔한 경우) 아직 안 지워진 기존 행과 새로 넣는
+     * 행이 같은 (user_id, day_of_week)로 충돌해 uq_notification_missing_input_day 위반이 난다
+     * (H2 통합테스트에서 실제로 재현됨). 그래서 빠진 요일만 지우고 새로 생긴 요일만 추가하는 차이만
+     * 반영한다 - 겹치는 요일 행은 아예 건드리지 않으므로 삭제·삽입이 같은 요일에서 충돌할 일이 없다.
+     */
+    private void replaceMissingInputDays(Set<NotificationDay> days) {
+        this.missingInputDayRows.removeIf(row -> !days.contains(row.getDay()));
+
+        Set<NotificationDay> remaining = getMissingInputDays();
+        Arrays.stream(NotificationDay.values())
+                .filter(days::contains)
+                .filter(day -> !remaining.contains(day))
+                .forEach(day -> this.missingInputDayRows.add(new NotificationMissingInputDay(this, day)));
+    }
+}

--- a/src/main/java/Hampouch/server/domain/user/repository/NotificationScheduleRepository.java
+++ b/src/main/java/Hampouch/server/domain/user/repository/NotificationScheduleRepository.java
@@ -1,0 +1,7 @@
+package Hampouch.server.domain.user.repository;
+
+import Hampouch.server.domain.user.entity.NotificationSchedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationScheduleRepository extends JpaRepository<NotificationSchedule, Long> {
+}

--- a/src/main/java/Hampouch/server/domain/user/service/NotificationScheduleService.java
+++ b/src/main/java/Hampouch/server/domain/user/service/NotificationScheduleService.java
@@ -1,0 +1,60 @@
+package Hampouch.server.domain.user.service;
+
+import Hampouch.server.domain.user.dto.request.NotificationScheduleUpdateRequest;
+import Hampouch.server.domain.user.dto.response.NotificationScheduleResponse;
+import Hampouch.server.domain.user.entity.NotificationSchedule;
+import Hampouch.server.domain.user.repository.NotificationScheduleRepository;
+import Hampouch.server.global.common.exception.CustomException;
+import Hampouch.server.global.common.exception.domain.UserErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotificationScheduleService {
+
+    private final NotificationScheduleRepository notificationScheduleRepository;
+    private final UserService userService;
+    private final UserOperationLock userOperationLock;
+
+    public NotificationScheduleResponse getSchedule(Long userId) {
+        userService.getUser(userId);
+        return NotificationScheduleResponse.of(getScheduleOrThrow(userId));
+    }
+
+    @Transactional
+    public NotificationScheduleResponse updateSchedule(Long userId, NotificationScheduleUpdateRequest request) {
+        // missingInputDayRows는 clear()+재추가 방식이라, 같은 유저의 PUT 두 개가 겹치는 요일로
+        // 동시에 들어오면 각자 자기 트랜잭션이 읽은 스냅샷 기준으로만 DELETE하고 INSERT하게 된다 -
+        // 서로의 커밋을 모른 채 같은 (user_id, day)를 동시에 INSERT하면 uq_notification_missing_input_day에
+        // 걸려 500이 날 수 있다. UserOperationLock으로 같은 유저의 PUT을 먼저 직렬화해 이 경쟁을 없앤다.
+        userOperationLock.lock(userId);
+        userService.getUser(userId);
+        NotificationSchedule schedule = getScheduleOrThrow(userId);
+
+        NotificationScheduleUpdateRequest.RecordAlert recordAlert = request.recordAlert();
+        NotificationScheduleUpdateRequest.MissingInput missingInput = recordAlert.missingInput();
+
+        schedule.replaceWith(
+                request.challengeAlert(),
+                request.battleAlert(),
+                request.communityAlert(),
+                recordAlert.enabled(),
+                missingInput.enabled(),
+                missingInput.days(),
+                LocalTime.parse(missingInput.time()),
+                recordAlert.limitExceeded().enabled()
+        );
+
+        return NotificationScheduleResponse.of(schedule);
+    }
+
+    private NotificationSchedule getScheduleOrThrow(Long userId) {
+        return notificationScheduleRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(UserErrorCode.NOTIFICATION_SCHEDULE_NOT_FOUND));
+    }
+}

--- a/src/main/java/Hampouch/server/global/common/exception/domain/UserErrorCode.java
+++ b/src/main/java/Hampouch/server/global/common/exception/domain/UserErrorCode.java
@@ -12,7 +12,8 @@ public enum UserErrorCode implements BaseErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다."),
     USER_DELETED(HttpStatus.FORBIDDEN, "USER_DELETED", "탈퇴한 회원입니다."),
     USER_NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "USER_NICKNAME_ALREADY_EXISTS", "이미 존재하는 닉네임입니다."),
-    USER_NICKNAME_ALREADY_SET(HttpStatus.CONFLICT, "USER_NICKNAME_ALREADY_SET", "이미 닉네임이 설정된 계정입니다.");
+    USER_NICKNAME_ALREADY_SET(HttpStatus.CONFLICT, "USER_NICKNAME_ALREADY_SET", "이미 닉네임이 설정된 계정입니다."),
+    NOTIFICATION_SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION_SCHEDULE_NOT_FOUND", "알림 설정을 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/resources/db/migration/V11__add_notification_schedule.sql
+++ b/src/main/resources/db/migration/V11__add_notification_schedule.sql
@@ -1,0 +1,37 @@
+CREATE TABLE notification_schedule (
+    user_id BIGINT NOT NULL,
+    challenge_alert BIT NOT NULL,
+    battle_alert BIT NOT NULL,
+    community_alert BIT NOT NULL,
+    record_alert_enabled BIT NOT NULL,
+    missing_input_enabled BIT NOT NULL,
+    missing_input_time TIME NOT NULL,
+    limit_exceeded_enabled BIT NOT NULL,
+    CONSTRAINT pk_notification_schedule PRIMARY KEY (user_id),
+    CONSTRAINT fk_notification_schedule_user FOREIGN KEY (user_id) REFERENCES users (user_id)
+) ENGINE = InnoDB DEFAULT CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
+
+CREATE TABLE notification_schedule_missing_input_day (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    user_id BIGINT NOT NULL,
+    day_of_week ENUM ('FRI', 'MON', 'SAT', 'SUN', 'THU', 'TUE', 'WED') NOT NULL,
+    CONSTRAINT pk_notification_schedule_missing_input_day PRIMARY KEY (id),
+    CONSTRAINT uq_notification_missing_input_day UNIQUE (user_id, day_of_week),
+    CONSTRAINT fk_notification_missing_input_day_schedule FOREIGN KEY (user_id) REFERENCES notification_schedule (user_id)
+) ENGINE = InnoDB DEFAULT CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
+
+-- 이 마이그레이션 이전에 이미 가입한 유저도 GET에서 404 없이 조회되도록
+INSERT INTO notification_schedule (
+    user_id, challenge_alert, battle_alert, community_alert,
+    record_alert_enabled, missing_input_enabled, missing_input_time, limit_exceeded_enabled
+)
+SELECT user_id, 1, 1, 1, 1, 1, '21:00:00', 1
+FROM users;
+
+INSERT INTO notification_schedule_missing_input_day (user_id, day_of_week)
+SELECT u.user_id, d.day_of_week
+FROM users u
+CROSS JOIN (
+    SELECT 'MON' AS day_of_week UNION ALL SELECT 'TUE' UNION ALL SELECT 'WED' UNION ALL
+    SELECT 'THU' UNION ALL SELECT 'FRI' UNION ALL SELECT 'SAT' UNION ALL SELECT 'SUN'
+) d;

--- a/src/test/java/Hampouch/server/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/auth/service/AuthServiceTest.java
@@ -10,8 +10,10 @@ import Hampouch.server.domain.auth.repository.RefreshTokenRepository;
 import Hampouch.server.domain.auth.util.EmailSender;
 import Hampouch.server.domain.auth.util.SocialTokenVerifier;
 import Hampouch.server.domain.user.entity.AuthProvider;
+import Hampouch.server.domain.user.entity.NotificationSchedule;
 import Hampouch.server.domain.user.entity.User;
 import Hampouch.server.domain.user.entity.UserRole;
+import Hampouch.server.domain.user.repository.NotificationScheduleRepository;
 import Hampouch.server.domain.user.repository.UserRepository;
 import Hampouch.server.global.common.exception.CustomException;
 import Hampouch.server.global.common.exception.domain.AuthErrorCode;
@@ -42,6 +44,8 @@ class AuthServiceTest {
     @Mock
     UserRepository userRepository;
     @Mock
+    NotificationScheduleRepository notificationScheduleRepository;
+    @Mock
     EmailVerificationRepository emailVerificationRepository;
     @Mock
     RefreshTokenRepository refreshTokenRepository;
@@ -64,6 +68,7 @@ class AuthServiceTest {
     void setUp() {
         authService = new AuthService(
                 userRepository,
+                notificationScheduleRepository,
                 emailVerificationRepository,
                 refreshTokenRepository,
                 passwordEncoder,
@@ -384,6 +389,7 @@ class AuthServiceTest {
         assertThat(response.nickname()).isEqualTo("닉네임");
         assertThat(response.provider()).isEqualTo("LOCAL");
         verify(userRepository).saveAndFlush(any(User.class));
+        verify(notificationScheduleRepository).save(any(NotificationSchedule.class));
     }
 
     // ========== 5. login ==========
@@ -504,6 +510,7 @@ class AuthServiceTest {
 
         assertThat(response.isNewUser()).isTrue();
         verify(userRepository).save(any(User.class));
+        verify(notificationScheduleRepository).save(any(NotificationSchedule.class));
     }
 
     @Test

--- a/src/test/java/Hampouch/server/domain/user/NotificationScheduleConcurrencyMySqlTest.java
+++ b/src/test/java/Hampouch/server/domain/user/NotificationScheduleConcurrencyMySqlTest.java
@@ -1,0 +1,171 @@
+package Hampouch.server.domain.user;
+
+import Hampouch.server.domain.user.dto.request.NotificationScheduleUpdateRequest;
+import Hampouch.server.domain.user.dto.response.NotificationScheduleResponse;
+import Hampouch.server.domain.user.entity.NotificationDay;
+import Hampouch.server.domain.user.entity.NotificationSchedule;
+import Hampouch.server.domain.user.entity.User;
+import Hampouch.server.domain.user.repository.NotificationScheduleRepository;
+import Hampouch.server.domain.user.repository.UserRepository;
+import Hampouch.server.domain.user.service.NotificationScheduleService;
+import Hampouch.server.global.mysql.MySqlContainerTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * NotificationScheduleService.updateSchedule의 UserOperationLock과 uq_notification_missing_input_day가
+ * 동시 요청에서 요일 행 경쟁·중복 저장을 막는지 검증(#181).
+ *
+ * NotificationSchedule.replaceMissingInputDays()는 이전·이후 요일 집합의 차이만 반영한다(겹치는
+ * 요일 행은 건드리지 않음) - 그래서 레이스가 나려면 두 동시 PUT이 "현재 없는 같은 요일"을 새로
+ * INSERT하려는 상황이어야 한다. 서로의 커밋을 모른 채 같은 (user_id, day_of_week)를 INSERT하면
+ * uq_notification_missing_input_day에 걸려 500이 날 수 있다(BattleConcurrencyMySqlTest가
+ * uq_battle_participant에서 검증한 것과 동일 계열의 레이스). NotificationScheduleService.updateSchedule은
+ * UserOperationLock으로 같은 유저의 PUT을 먼저 직렬화해 이 경쟁을 없앤다 - 이 테스트는 그 직렬화가
+ * 실제로 500 없이 동작하는지 확인한다.
+ */
+@MySqlContainerTest
+class NotificationScheduleConcurrencyMySqlTest {
+
+    @Autowired
+    NotificationScheduleService notificationScheduleService;
+    @Autowired
+    NotificationScheduleRepository notificationScheduleRepository;
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    JdbcTemplate jdbc;
+
+    /**
+     * 동시성 없이도 검증 가능한 전제조건: uq_notification_missing_input_day 제약이 실제로 DB에
+     * 존재하는지를 직접 확인한다(BattleConcurrencyMySqlTest의 uniqueConstraintRejectsDuplicateParticipantRow와
+     * 동일 원칙) - 이 제약을 지우면(마이그레이션 롤백 등) 이 테스트가 실패한다.
+     */
+    @Test
+    @DisplayName("uq_notification_missing_input_day 제약이 동일 유저·동일 요일의 중복 저장을 막는다")
+    void uniqueConstraintRejectsDuplicateMissingInputDayRow() {
+        Long userId = newUserWithDefaultSchedule("unique-constraint");
+
+        // 가입 기본값에 이미 MON이 들어있다 - 같은 (user_id, day_of_week)를 raw JDBC로 한 번 더 넣으면 막혀야 한다.
+        assertThatThrownBy(() -> jdbc.update(
+                "INSERT INTO notification_schedule_missing_input_day (user_id, day_of_week) VALUES (?, ?)", userId, "MON"))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    @DisplayName("같은 유저의 PUT 두 개가 현재 없는 같은 요일을 동시에 새로 추가하려 해도 UserOperationLock이 " +
+            "직렬화해 500 없이 둘 다 성공하고, 최종 요일 행이 승자 요청 하나와 정확히 일치한다")
+    void concurrentUpdateAddingSameNewDay_serializesWithoutConstraintViolation() throws Exception {
+        Long userId = newUserWithDefaultSchedule("concurrent-update");
+        // 겹치는 요일 행은 diff 로직이 아예 건드리지 않으므로, 레이스를 재현하려면 "현재 없는" 요일을
+        // 두 요청이 동시에 새로 추가하려는 상황이 필요하다 - 먼저 MON 하나로 줄여 TUE가 없는 상태를 만든다.
+        notificationScheduleService.updateSchedule(userId, updateRequest(
+                true, true, true, true, true, Set.of(NotificationDay.MON), "21:00", true));
+
+        Set<NotificationDay> daysA = Set.of(NotificationDay.MON, NotificationDay.TUE, NotificationDay.WED);
+        Set<NotificationDay> daysB = Set.of(NotificationDay.MON, NotificationDay.TUE, NotificationDay.THU);
+        NotificationScheduleUpdateRequest requestA = updateRequest(
+                true, true, true, true, true, daysA, "07:00", true);
+        NotificationScheduleUpdateRequest requestB = updateRequest(
+                false, false, false, true, true, daysB, "22:30", false);
+
+        List<Outcome<NotificationScheduleResponse>> outcomes = race(
+                () -> notificationScheduleService.updateSchedule(userId, requestA),
+                () -> notificationScheduleService.updateSchedule(userId, requestB));
+
+        assertThat(outcomes)
+                .as("UserOperationLock으로 직렬화되므로 uq_notification_missing_input_day 위반 없이 둘 다 성공해야 한다")
+                .allSatisfy(outcome -> assertThat(outcome.succeeded())
+                        .as(() -> "예외 발생: " + outcome.error())
+                        .isTrue());
+
+        // 서비스의 실제 조회 경로로 재확인 — 엔티티를 트랜잭션 밖에서 직접 만지면 missingInputDayRows가
+        // LazyInitializationException을 던진다.
+        NotificationScheduleResponse finalSchedule = notificationScheduleService.getSchedule(userId);
+        Set<NotificationDay> finalDays = finalSchedule.recordAlert().missingInput().days();
+        assertThat(finalDays)
+                .as("최종 요일 집합은 두 요청 중 정확히 하나와 일치해야 한다 - 경쟁으로 섞이면 안 된다")
+                .isIn(daysA, daysB);
+
+        Integer rowCount = jdbc.queryForObject(
+                "SELECT COUNT(*) FROM notification_schedule_missing_input_day WHERE user_id = ?",
+                Integer.class, userId);
+        assertThat(rowCount)
+                .as("승자 요청의 요일 개수만큼만 행이 남아야 한다 - 패자 요청의 잔여·중복 행이 있으면 안 된다")
+                .isEqualTo(finalDays.size());
+    }
+
+    private <T> List<Outcome<T>> race(Callable<? extends T> first, Callable<? extends T> second) throws Exception {
+        CyclicBarrier barrier = new CyclicBarrier(2);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<Outcome<T>> firstFuture = executor.submit(() -> runAfterBarrier(barrier, first));
+            Future<Outcome<T>> secondFuture = executor.submit(() -> runAfterBarrier(barrier, second));
+
+            return List.of(firstFuture.get(15, TimeUnit.SECONDS), secondFuture.get(15, TimeUnit.SECONDS));
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    /** barrier.await()는 두 워커 모두 도착해야만 반환되므로, 이후 request.call()은 항상 동시에 출발한다. */
+    private <T> Outcome<T> runAfterBarrier(CyclicBarrier barrier, Callable<? extends T> request) {
+        try {
+            barrier.await(5, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            return new Outcome<>(null, e);
+        }
+        return capture(request);
+    }
+
+    private <T> Outcome<T> capture(Callable<? extends T> request) {
+        try {
+            return new Outcome<>(request.call(), null);
+        } catch (Throwable error) {
+            return new Outcome<>(null, error);
+        }
+    }
+
+    private Long newUserWithDefaultSchedule(String scenario) {
+        User user = userRepository.save(User.createLocalUser(
+                scenario + "-" + System.nanoTime() + "@hampouch.test", "encoded", "동시성" + System.nanoTime() % 100000));
+        notificationScheduleRepository.save(NotificationSchedule.createDefault(user));
+        return user.getId();
+    }
+
+    private static NotificationScheduleUpdateRequest updateRequest(
+            boolean challengeAlert, boolean battleAlert, boolean communityAlert,
+            boolean recordAlertEnabled, boolean missingInputEnabled,
+            Set<NotificationDay> days, String time, boolean limitExceededEnabled
+    ) {
+        return new NotificationScheduleUpdateRequest(
+                challengeAlert, battleAlert, communityAlert,
+                new NotificationScheduleUpdateRequest.RecordAlert(
+                        recordAlertEnabled,
+                        new NotificationScheduleUpdateRequest.MissingInput(missingInputEnabled, days, time),
+                        new NotificationScheduleUpdateRequest.LimitExceeded(limitExceededEnabled)
+                )
+        );
+    }
+
+    private record Outcome<T>(T value, Throwable error) {
+        boolean succeeded() {
+            return error == null;
+        }
+    }
+}

--- a/src/test/java/Hampouch/server/domain/user/NotificationScheduleTransactionIntegrationTest.java
+++ b/src/test/java/Hampouch/server/domain/user/NotificationScheduleTransactionIntegrationTest.java
@@ -1,0 +1,136 @@
+package Hampouch.server.domain.user;
+
+import Hampouch.server.domain.auth.dto.request.SignupRequest;
+import Hampouch.server.domain.auth.dto.response.SignupResponse;
+import Hampouch.server.domain.auth.entity.EmailVerification;
+import Hampouch.server.domain.auth.entity.VerificationPurpose;
+import Hampouch.server.domain.auth.repository.EmailVerificationRepository;
+import Hampouch.server.domain.auth.service.AuthService;
+import Hampouch.server.domain.user.dto.request.NotificationScheduleUpdateRequest;
+import Hampouch.server.domain.user.dto.response.NotificationScheduleResponse;
+import Hampouch.server.domain.user.entity.NotificationDay;
+import Hampouch.server.domain.user.entity.NotificationSchedule;
+import Hampouch.server.domain.user.entity.User;
+import Hampouch.server.domain.user.repository.NotificationScheduleRepository;
+import Hampouch.server.domain.user.repository.UserRepository;
+import Hampouch.server.domain.user.service.NotificationScheduleService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.EnumSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * H2 test DB에 실제로 커밋되는지 검증 — 테스트 레벨 @Transactional을 일부러 안 붙인다(롤백되면
+ * "커밋됐다"는 걸 증명 못 함, BattleTransactionIntegrationTest와 동일 원칙).
+ * #181: 회원가입 시 알림 설정 기본값 생성, PUT 전체교체가 자식 테이블(미입력 요일)까지 정확히
+ * 반영되는지, 유저 간 격리가 되는지를 서비스 호출 뒤 별도 조회로 재확인한다.
+ */
+@SpringBootTest
+class NotificationScheduleTransactionIntegrationTest {
+
+    @Autowired
+    AuthService authService;
+    @Autowired
+    NotificationScheduleService notificationScheduleService;
+    @Autowired
+    NotificationScheduleRepository notificationScheduleRepository;
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    EmailVerificationRepository emailVerificationRepository;
+
+    @Test
+    @DisplayName("회원가입하면 PM이 확정한 기본값(전체 알림 켜짐, 미입력 알림 매일 21:00)이 함께 커밋된다")
+    void signup_commitsDefaultNotificationSchedule() {
+        String email = "notification-default-" + System.currentTimeMillis() + "@hampouch.test";
+        prepareVerifiedEmail(email);
+
+        SignupResponse signupResponse = authService.signup(
+                new SignupRequest(email, "password1!", "기본값유저"));
+
+        // 서비스의 실제 조회 경로(트랜잭션 안에서 lazy 컬렉션까지 읽어 DTO로 변환)로 재조회 —
+        // 엔티티를 트랜잭션 밖에서 직접 만지면 missingInputDayRows가 LazyInitializationException을 던진다.
+        NotificationScheduleResponse schedule = notificationScheduleService.getSchedule(signupResponse.userId());
+        assertThat(schedule.challengeAlert()).isTrue();
+        assertThat(schedule.battleAlert()).isTrue();
+        assertThat(schedule.communityAlert()).isTrue();
+        assertThat(schedule.recordAlert().enabled()).isTrue();
+        assertThat(schedule.recordAlert().missingInput().enabled()).isTrue();
+        assertThat(schedule.recordAlert().missingInput().days()).isEqualTo(EnumSet.allOf(NotificationDay.class));
+        assertThat(schedule.recordAlert().missingInput().time()).isEqualTo(LocalTime.of(21, 0));
+        assertThat(schedule.recordAlert().limitExceeded().enabled()).isTrue();
+    }
+
+    @Test
+    @DisplayName("PUT으로 전체 교체하면 이전 미입력 요일 행은 사라지고 새 요일만 남아 커밋된다")
+    void updateSchedule_replacesMissingInputDayRowsAndCommits() {
+        Long userId = newUserWithDefaultSchedule("notification-replace");
+
+        notificationScheduleService.updateSchedule(userId, updateRequest(
+                false, false, true, true, false,
+                Set.of(NotificationDay.WED, NotificationDay.THU), "08:15", false));
+
+        // 서비스 호출이 끝난 뒤 별도 조회(1차 캐시가 아니라 재조회)로도 반영돼 있어야 진짜 커밋된 것
+        NotificationScheduleResponse reloaded = notificationScheduleService.getSchedule(userId);
+        assertThat(reloaded.challengeAlert()).isFalse();
+        assertThat(reloaded.battleAlert()).isFalse();
+        assertThat(reloaded.communityAlert()).isTrue();
+        assertThat(reloaded.recordAlert().missingInput().enabled()).isFalse();
+        assertThat(reloaded.recordAlert().missingInput().days())
+                .as("기본값이던 MON~SUN 7일 중 WED·THU만 남고 나머지는 지워져야 한다")
+                .containsExactlyInAnyOrder(NotificationDay.WED, NotificationDay.THU);
+        assertThat(reloaded.recordAlert().missingInput().time()).isEqualTo(LocalTime.of(8, 15));
+        assertThat(reloaded.recordAlert().limitExceeded().enabled()).isFalse();
+    }
+
+    @Test
+    @DisplayName("한 유저의 알림 설정 변경은 다른 유저의 설정에 영향을 주지 않는다")
+    void updateSchedule_isIsolatedPerUser() {
+        Long userAId = newUserWithDefaultSchedule("notification-isolation-a");
+        Long userBId = newUserWithDefaultSchedule("notification-isolation-b");
+
+        notificationScheduleService.updateSchedule(userAId, updateRequest(
+                false, false, false, false, false, Set.of(NotificationDay.MON), "06:00", false));
+
+        NotificationScheduleResponse userBSchedule = notificationScheduleService.getSchedule(userBId);
+        assertThat(userBSchedule.challengeAlert()).as("A의 변경이 B에 새어나가면 안 된다").isTrue();
+        assertThat(userBSchedule.recordAlert().missingInput().days()).isEqualTo(EnumSet.allOf(NotificationDay.class));
+        assertThat(userBSchedule.recordAlert().missingInput().time()).isEqualTo(LocalTime.of(21, 0));
+    }
+
+    private Long newUserWithDefaultSchedule(String scenario) {
+        User user = userRepository.save(User.createLocalUser(
+                scenario + "-" + System.nanoTime() + "@hampouch.test", "encoded", "테스트유저" + System.nanoTime() % 100000));
+        notificationScheduleRepository.save(NotificationSchedule.createDefault(user));
+        return user.getId();
+    }
+
+    private static NotificationScheduleUpdateRequest updateRequest(
+            boolean challengeAlert, boolean battleAlert, boolean communityAlert,
+            boolean recordAlertEnabled, boolean missingInputEnabled,
+            Set<NotificationDay> days, String time, boolean limitExceededEnabled
+    ) {
+        return new NotificationScheduleUpdateRequest(
+                challengeAlert, battleAlert, communityAlert,
+                new NotificationScheduleUpdateRequest.RecordAlert(
+                        recordAlertEnabled,
+                        new NotificationScheduleUpdateRequest.MissingInput(missingInputEnabled, days, time),
+                        new NotificationScheduleUpdateRequest.LimitExceeded(limitExceededEnabled)
+                )
+        );
+    }
+
+    private void prepareVerifiedEmail(String email) {
+        LocalDateTime now = LocalDateTime.now();
+        EmailVerification verification = EmailVerification.create(email, "123456", VerificationPurpose.SIGNUP, now.plusMinutes(10));
+        verification.verify(now);
+        emailVerificationRepository.save(verification);
+    }
+}

--- a/src/test/java/Hampouch/server/domain/user/controller/NotificationScheduleControllerTest.java
+++ b/src/test/java/Hampouch/server/domain/user/controller/NotificationScheduleControllerTest.java
@@ -1,0 +1,207 @@
+package Hampouch.server.domain.user.controller;
+
+import Hampouch.server.domain.user.dto.response.NotificationScheduleResponse;
+import Hampouch.server.domain.user.entity.NotificationDay;
+import Hampouch.server.domain.user.service.NotificationScheduleService;
+import Hampouch.server.global.common.exception.CustomException;
+import Hampouch.server.global.common.exception.domain.UserErrorCode;
+import Hampouch.server.global.jwt.JwtProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalTime;
+import java.util.EnumSet;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(NotificationScheduleController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class NotificationScheduleControllerTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    @MockitoBean
+    NotificationScheduleService notificationScheduleService;
+
+    @MockitoBean
+    JwtProvider jwtProvider; // JwtFilter가 Filter 타입이라 슬라이스에 자동 포함되며 요구하는 의존성
+
+    @BeforeEach
+    void setUpAuthentication() {
+        var authentication = new UsernamePasswordAuthenticationToken(1L, null, List.of());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    @AfterEach
+    void clearAuthentication() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private static final String REQUEST_BODY = """
+            {
+              "challengeAlert": true,
+              "battleAlert": true,
+              "communityAlert": true,
+              "recordAlert": {
+                "enabled": true,
+                "missingInput": {
+                  "enabled": true,
+                  "days": ["MON", "TUE"],
+                  "time": "21:00"
+                },
+                "limitExceeded": {
+                  "enabled": true
+                }
+              }
+            }
+            """;
+
+    private static NotificationScheduleResponse defaultResponse() {
+        return new NotificationScheduleResponse(
+                true, true, true,
+                new NotificationScheduleResponse.RecordAlert(
+                        true,
+                        new NotificationScheduleResponse.MissingInput(
+                                true, EnumSet.allOf(NotificationDay.class), LocalTime.of(21, 0)),
+                        new NotificationScheduleResponse.LimitExceeded(true)
+                )
+        );
+    }
+
+    // ---------- 알림 설정 조회 ----------
+
+    @Test
+    @DisplayName("정상 조회면 200과 전체 알림 설정을 반환한다")
+    void getSchedule_returns200WithFullSchedule() throws Exception {
+        when(notificationScheduleService.getSchedule(1L)).thenReturn(defaultResponse());
+
+        mvc.perform(get("/api/users/me/notification/schedule"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.challengeAlert").value(true))
+                .andExpect(jsonPath("$.data.recordAlert.missingInput.time").value("21:00"))
+                .andExpect(jsonPath("$.data.recordAlert.missingInput.days[0]").value("MON"));
+    }
+
+    @Test
+    @DisplayName("탈퇴한 회원이면 403을 반환한다")
+    void getSchedule_returns403WhenUserDeleted() throws Exception {
+        when(notificationScheduleService.getSchedule(1L)).thenThrow(new CustomException(UserErrorCode.USER_DELETED));
+
+        mvc.perform(get("/api/users/me/notification/schedule"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("USER_DELETED"));
+    }
+
+    // ---------- 알림 설정 변경 ----------
+
+    @Test
+    @DisplayName("정상 변경이면 200과 바뀐 전체 설정을 반환한다")
+    void updateSchedule_returns200WithReplacedSchedule() throws Exception {
+        when(notificationScheduleService.updateSchedule(eq(1L), any())).thenReturn(defaultResponse());
+
+        mvc.perform(put("/api/users/me/notification/schedule")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(REQUEST_BODY))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("SUCCESS"));
+    }
+
+    @Test
+    @DisplayName("요일이 비어 있으면 400을 반환하고 fieldErrors에 중첩 경로가 담긴다")
+    void updateSchedule_returns400WhenDaysEmpty() throws Exception {
+        String body = """
+                {
+                  "challengeAlert": true,
+                  "battleAlert": true,
+                  "communityAlert": true,
+                  "recordAlert": {
+                    "enabled": true,
+                    "missingInput": { "enabled": true, "days": [], "time": "21:00" },
+                    "limitExceeded": { "enabled": true }
+                  }
+                }
+                """;
+
+        mvc.perform(put("/api/users/me/notification/schedule")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+                .andExpect(jsonPath("$.fieldErrors['recordAlert.missingInput.days']").exists());
+    }
+
+    @Test
+    @DisplayName("시각이 HH:mm 형식이 아니면 400을 반환하고 fieldErrors에 중첩 경로가 담긴다")
+    void updateSchedule_returns400WhenTimeFormatInvalid() throws Exception {
+        String body = """
+                {
+                  "challengeAlert": true,
+                  "battleAlert": true,
+                  "communityAlert": true,
+                  "recordAlert": {
+                    "enabled": true,
+                    "missingInput": { "enabled": true, "days": ["MON"], "time": "25:99" },
+                    "limitExceeded": { "enabled": true }
+                  }
+                }
+                """;
+
+        mvc.perform(put("/api/users/me/notification/schedule")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+                .andExpect(jsonPath("$.fieldErrors['recordAlert.missingInput.time']").exists());
+    }
+
+    @Test
+    @DisplayName("recordAlert가 통째로 빠지면 400을 반환한다")
+    void updateSchedule_returns400WhenRecordAlertMissing() throws Exception {
+        String body = """
+                {
+                  "challengeAlert": true,
+                  "battleAlert": true,
+                  "communityAlert": true
+                }
+                """;
+
+        mvc.perform(put("/api/users/me/notification/schedule")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+                .andExpect(jsonPath("$.fieldErrors.recordAlert").exists());
+    }
+
+    @Test
+    @DisplayName("탈퇴한 회원이면 403을 반환한다")
+    void updateSchedule_returns403WhenUserDeleted() throws Exception {
+        when(notificationScheduleService.updateSchedule(eq(1L), any()))
+                .thenThrow(new CustomException(UserErrorCode.USER_DELETED));
+
+        mvc.perform(put("/api/users/me/notification/schedule")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(REQUEST_BODY))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("USER_DELETED"));
+    }
+}

--- a/src/test/java/Hampouch/server/domain/user/controller/NotificationScheduleControllerTest.java
+++ b/src/test/java/Hampouch/server/domain/user/controller/NotificationScheduleControllerTest.java
@@ -193,6 +193,53 @@ class NotificationScheduleControllerTest {
     }
 
     @Test
+    @DisplayName("challengeAlert가 누락되면 기본값 false로 조용히 통과하지 않고 400을 반환한다 " +
+            "- enabled류 필드가 primitive boolean이면 Jackson이 기본값을 채워 이 검증을 통과 못 시킨다")
+    void updateSchedule_returns400WhenChallengeAlertMissing() throws Exception {
+        String body = """
+                {
+                  "battleAlert": true,
+                  "communityAlert": true,
+                  "recordAlert": {
+                    "enabled": true,
+                    "missingInput": { "enabled": true, "days": ["MON"], "time": "21:00" },
+                    "limitExceeded": { "enabled": true }
+                  }
+                }
+                """;
+
+        mvc.perform(put("/api/users/me/notification/schedule")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+                .andExpect(jsonPath("$.fieldErrors.challengeAlert").exists());
+    }
+
+    @Test
+    @DisplayName("recordAlert.enabled가 누락되면 400을 반환한다")
+    void updateSchedule_returns400WhenRecordAlertEnabledMissing() throws Exception {
+        String body = """
+                {
+                  "challengeAlert": true,
+                  "battleAlert": true,
+                  "communityAlert": true,
+                  "recordAlert": {
+                    "missingInput": { "enabled": true, "days": ["MON"], "time": "21:00" },
+                    "limitExceeded": { "enabled": true }
+                  }
+                }
+                """;
+
+        mvc.perform(put("/api/users/me/notification/schedule")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+                .andExpect(jsonPath("$.fieldErrors['recordAlert.enabled']").exists());
+    }
+
+    @Test
     @DisplayName("탈퇴한 회원이면 403을 반환한다")
     void updateSchedule_returns403WhenUserDeleted() throws Exception {
         when(notificationScheduleService.updateSchedule(eq(1L), any()))

--- a/src/test/java/Hampouch/server/domain/user/service/NotificationScheduleServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/user/service/NotificationScheduleServiceTest.java
@@ -1,0 +1,164 @@
+package Hampouch.server.domain.user.service;
+
+import Hampouch.server.domain.user.dto.request.NotificationScheduleUpdateRequest;
+import Hampouch.server.domain.user.dto.response.NotificationScheduleResponse;
+import Hampouch.server.domain.user.entity.NotificationDay;
+import Hampouch.server.domain.user.entity.NotificationSchedule;
+import Hampouch.server.domain.user.entity.User;
+import Hampouch.server.domain.user.repository.NotificationScheduleRepository;
+import Hampouch.server.global.common.exception.CustomException;
+import Hampouch.server.global.common.exception.domain.UserErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalTime;
+import java.util.EnumSet;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.when;
+
+/**
+ * 서비스 상태 전이·검증. 리포지토리는 Mockito 목 — DB 불필요
+ */
+@ExtendWith(MockitoExtension.class)
+class NotificationScheduleServiceTest {
+
+    private static final Long USER_ID = 1L;
+
+    @Mock
+    NotificationScheduleRepository notificationScheduleRepository;
+    @Mock
+    UserService userService;
+    @Mock
+    UserOperationLock userOperationLock;
+
+    private NotificationScheduleService service() {
+        return new NotificationScheduleService(notificationScheduleRepository, userService, userOperationLock);
+    }
+
+    // ---------- getSchedule ----------
+
+    @Test
+    @DisplayName("정상 조회면 저장된 알림 설정을 그대로 반환한다")
+    void getSchedule_returnsStoredSchedule() {
+        NotificationSchedule schedule = defaultSchedule(USER_ID);
+        when(notificationScheduleRepository.findById(USER_ID)).thenReturn(Optional.of(schedule));
+
+        NotificationScheduleResponse response = service().getSchedule(USER_ID);
+
+        assertThat(response.challengeAlert()).isTrue();
+        assertThat(response.recordAlert().missingInput().days())
+                .containsExactlyElementsOf(EnumSet.allOf(NotificationDay.class));
+        assertThat(response.recordAlert().missingInput().time()).isEqualTo(LocalTime.of(21, 0));
+    }
+
+    @Test
+    @DisplayName("탈퇴한 회원이면 403(USER_DELETED)을 던진다")
+    void getSchedule_throws403WhenUserDeleted() {
+        when(userService.getUser(USER_ID)).thenThrow(new CustomException(UserErrorCode.USER_DELETED));
+
+        assertThatThrownBy(() -> service().getSchedule(USER_ID))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.USER_DELETED);
+    }
+
+    @Test
+    @DisplayName("가입은 됐지만 설정 행이 없으면(방어적 상황) 404(NOTIFICATION_SCHEDULE_NOT_FOUND)를 던진다")
+    void getSchedule_throws404WhenScheduleRowMissing() {
+        when(notificationScheduleRepository.findById(USER_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service().getSchedule(USER_ID))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.NOTIFICATION_SCHEDULE_NOT_FOUND);
+    }
+
+    // ---------- updateSchedule ----------
+
+    @Test
+    @DisplayName("정상 변경이면 전체 교체되어 바뀐 설정을 반환한다")
+    void updateSchedule_returnsFullyReplacedSchedule() {
+        NotificationSchedule schedule = defaultSchedule(USER_ID);
+        when(notificationScheduleRepository.findById(USER_ID)).thenReturn(Optional.of(schedule));
+
+        NotificationScheduleResponse response = service().updateSchedule(USER_ID, updateRequest(
+                false, false, false, false, false, Set.of(NotificationDay.MON), "07:30", false));
+
+        assertThat(response.challengeAlert()).isFalse();
+        assertThat(response.battleAlert()).isFalse();
+        assertThat(response.communityAlert()).isFalse();
+        assertThat(response.recordAlert().enabled()).isFalse();
+        assertThat(response.recordAlert().missingInput().enabled()).isFalse();
+        assertThat(response.recordAlert().missingInput().days()).containsExactly(NotificationDay.MON);
+        assertThat(response.recordAlert().missingInput().time()).isEqualTo(LocalTime.of(7, 30));
+        assertThat(response.recordAlert().limitExceeded().enabled()).isFalse();
+    }
+
+    @Test
+    @DisplayName("탈퇴한 회원이면 403(USER_DELETED)을 던진다")
+    void updateSchedule_throws403WhenUserDeleted() {
+        when(userService.getUser(USER_ID)).thenThrow(new CustomException(UserErrorCode.USER_DELETED));
+
+        assertThatThrownBy(() -> service().updateSchedule(USER_ID, updateRequest(
+                true, true, true, true, true, Set.of(NotificationDay.MON), "21:00", true)))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.USER_DELETED);
+    }
+
+    @Test
+    @DisplayName("getUser()로 조회하기 전에 UserOperationLock으로 사용자 행을 먼저 잠근다 " +
+            "- 겹치는 요일로 동시에 들어오는 PUT 두 개를 직렬화해 uq_notification_missing_input_day 경쟁을 막기 위함")
+    void updateSchedule_locksUserBeforeReadingSchedule() {
+        NotificationSchedule schedule = defaultSchedule(USER_ID);
+        when(notificationScheduleRepository.findById(USER_ID)).thenReturn(Optional.of(schedule));
+
+        service().updateSchedule(USER_ID, updateRequest(
+                true, true, true, true, true, Set.of(NotificationDay.MON), "21:00", true));
+
+        InOrder order = inOrder(userOperationLock, notificationScheduleRepository);
+        order.verify(userOperationLock).lock(USER_ID);
+        order.verify(notificationScheduleRepository).findById(USER_ID);
+    }
+
+    @Test
+    @DisplayName("가입은 됐지만 설정 행이 없으면(방어적 상황) 404(NOTIFICATION_SCHEDULE_NOT_FOUND)를 던진다")
+    void updateSchedule_throws404WhenScheduleRowMissing() {
+        when(notificationScheduleRepository.findById(USER_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service().updateSchedule(USER_ID, updateRequest(
+                true, true, true, true, true, Set.of(NotificationDay.MON), "21:00", true)))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.NOTIFICATION_SCHEDULE_NOT_FOUND);
+    }
+
+    private static NotificationScheduleUpdateRequest updateRequest(
+            boolean challengeAlert, boolean battleAlert, boolean communityAlert,
+            boolean recordAlertEnabled, boolean missingInputEnabled,
+            Set<NotificationDay> days, String time, boolean limitExceededEnabled
+    ) {
+        return new NotificationScheduleUpdateRequest(
+                challengeAlert, battleAlert, communityAlert,
+                new NotificationScheduleUpdateRequest.RecordAlert(
+                        recordAlertEnabled,
+                        new NotificationScheduleUpdateRequest.MissingInput(missingInputEnabled, days, time),
+                        new NotificationScheduleUpdateRequest.LimitExceeded(limitExceededEnabled)
+                )
+        );
+    }
+
+    private static NotificationSchedule defaultSchedule(Long userId) {
+        User user = User.createLocalUser("user@hampouch.com", "encoded", "닉네임");
+        ReflectionTestUtils.setField(user, "id", userId);
+        NotificationSchedule schedule = NotificationSchedule.createDefault(user);
+        ReflectionTestUtils.setField(schedule, "userId", userId);
+        return schedule;
+    }
+}

--- a/src/test/java/Hampouch/server/global/mysql/MySqlSchemaCreationTest.java
+++ b/src/test/java/Hampouch/server/global/mysql/MySqlSchemaCreationTest.java
@@ -172,6 +172,45 @@ class MySqlSchemaCreationTest {
         assertThat(applied).isEqualTo(1);
         assertThat(indexColumns).isEqualTo("status,id");
     }
+
+    @Test
+    @DisplayName("V11이 알림 설정 테이블과 미입력 요일 UNIQUE·FK 제약을 생성한다")
+    void appliesNotificationScheduleMigration() {
+        Integer applied = jdbc.queryForObject("""
+                select count(*)
+                from flyway_schema_history
+                where version = '11' and type = 'SQL' and success = 1
+                """, Integer.class);
+        String uniqueConstraintColumns = jdbc.queryForObject("""
+                select group_concat(column_name order by seq_in_index separator ',')
+                from information_schema.statistics
+                where table_schema = database()
+                  and table_name = 'notification_schedule_missing_input_day'
+                  and index_name = 'uq_notification_missing_input_day'
+                """, String.class);
+        Integer scheduleForeignKeyCount = jdbc.queryForObject("""
+                select count(*)
+                from information_schema.table_constraints
+                where table_schema = database()
+                  and table_name = 'notification_schedule'
+                  and constraint_name = 'fk_notification_schedule_user'
+                  and constraint_type = 'FOREIGN KEY'
+                """, Integer.class);
+        Integer missingInputDayForeignKeyCount = jdbc.queryForObject("""
+                select count(*)
+                from information_schema.table_constraints
+                where table_schema = database()
+                  and table_name = 'notification_schedule_missing_input_day'
+                  and constraint_name = 'fk_notification_missing_input_day_schedule'
+                  and constraint_type = 'FOREIGN KEY'
+                """, Integer.class);
+
+        assertThat(applied).isEqualTo(1);
+        assertThat(uniqueConstraintColumns).isEqualTo("user_id,day_of_week");
+        assertThat(scheduleForeignKeyCount).isEqualTo(1);
+        assertThat(missingInputDayForeignKeyCount).isEqualTo(1);
+    }
+
     @DisplayName("Flyway V4가 목표 조정 DB ENUM에 PLUS_30을 추가한다")
     void appliesPlusThirtyAdjustmentOptionMigration() {
         Integer applied = jdbc.queryForObject("""


### PR DESCRIPTION
## 📎연관된 이슈

- close: #181

## 📄 작업 내용 요약

- `GET`/`PUT /api/users/me/notification/schedule` 구현 — 챌린지·햄배틀·커뮤니티·기록(미입력/한도초과) 알림 설정 조회·전체교체
- 가입 직후(로컬 회원가입·소셜 신규가입) 알림 설정 기본값 자동 생성 — 전체 알림 켜짐, 미입력 알림 매일 21:00(PM 확정 답변 기준)
- 미입력 알림 요일은 콤마문자열이 아니라 `NotificationMissingInputDay` 자식 엔티티(요일당 1행)로 정규화해서 저장
- 단위테스트(`NotificationScheduleServiceTest`, `NotificationScheduleControllerTest`), 실 커밋 검증 통합테스트(`NotificationScheduleTransactionIntegrationTest`), 실 MySQL 동시성 테스트(`NotificationScheduleConcurrencyMySqlTest`) 작성

## 👀 중요 변경 사항

- **`NotificationSchedule.replaceMissingInputDays()`는 clear()+재추가 방식이 아니라 이전·이후 요일 집합의 차이만 반영합니다.** Hibernate가 같은 flush 안에서 새 INSERT를 orphanRemoval DELETE보다 먼저 실행해서, 겹치는 요일이 하나라도 있으면(거의 항상 있음) `uq_notification_missing_input_day` UNIQUE 제약 위반(500)이 나는 걸 통합테스트로 발견해서 수정했습니다.
- 같은 유저의 동시 PUT이 겹치지 않는 새 요일을 동시에 추가하려는 레이스를 막기 위해 `NotificationScheduleService.updateSchedule()`에 `UserOperationLock`(닉네임 변경이 이미 쓰는 패턴)을 적용했습니다.
- `AuthService` 생성자에 `NotificationScheduleRepository` 의존성이 추가됐습니다 — 이 서비스를 목으로 만드는 기존 테스트가 있다면 생성자 파라미터를 맞춰야 합니다.

## 🔖 Uncompleted Tasks

- 이 PR은 #181 만 다룹니다. 이 설정을 실제로 읽어서 알림을 저장·발송하는 로직(#197), 미입력 알림 스케줄링(#201)은 후속 이슈에서 진행됩니다.
- 스펙 문서상 미확정으로 표시된 부분(레코드/미입력 알림을 꺼도 요일·시각 값 자체를 보존할지 여부)은 이번 PR에서 임의로 결정하지 않았고, 요청에 실린 값을 그대로 저장하는 전체교체 방식으로만 구현했습니다.

## 📢 To Reviewers

- `NotificationSchedule.replaceMissingInputDays()`의 diff 기반 교체 로직과, 그 배경이 된 `NotificationScheduleTransactionIntegrationTest`/`NotificationScheduleConcurrencyMySqlTest`를 특히 봐주시면 좋을 것 같습니다.