### PR TITLE
fix(infra): 앱 컨테이너 메모리 한도 640m 증량과 배포 ssh ServerAliveInterval 추가 (#232) [base: develop]

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -97,7 +97,8 @@ jobs:
       #10. EC2에서 배포 후 검증하고 실패하면 이전 앱 이미지로 자동 롤백
       - name: Deploy, verify, and rollback on failure
         run: |
-          ssh -i ~/.ssh/deploy_key ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }} \
+          #검증 대기가 몇 분간 무출력이라 keepalive가 없으면 유휴 절단으로 세션이 죽을 수 있다
+          ssh -i ~/.ssh/deploy_key -o ServerAliveInterval=15 ${{ secrets.EC2_USERNAME }}@${{ secrets.EC2_HOST }} \
             "cd ~/Hampouch-Server && \
             COMPOSE_FILE='docker-compose.prod.next.yml' \
             ACTIVE_COMPOSE_FILE='docker-compose.prod.yml' \

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -78,7 +78,8 @@ services:
     image: hampouch-server:latest
     container_name: hampouch-server
     restart: always
-    mem_limit: 550m
+    #Xmx300m 기준 working_set 정착점이 약 470MB라 550m에서는 85% 경보 임계와 겹친다
+    mem_limit: 640m
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## 📎연관된 이슈

- close: #232

## 📄 작업 내용 요약

- 프로드 앱 컨테이너 `mem_limit`을 550m → 640m로 증량했습니다. Datadog 실측으로 JVM(-Xmx300m)의 working_set 정착점이 약 470MB라 550m에서는 85% 경보 임계(467MB)와 겹쳐 트래픽 없이도 경보가 반복되는 구조였습니다(8/17 02:04·05:00 경보 2건, 힙 사용량은 주간 내내 평평해 릭 아님 — 상세 실측은 #232).
- 배포 워크플로의 EC2 배포 ssh에 `-o ServerAliveInterval=15`를 추가했습니다. 검증 단계의 무출력 대기(약 5분) 중 세션이 유휴 절단되면 잡이 행·실패로 끝나는 일이 8/11·8/14 두 번 있었습니다.

## 👀 중요 변경 사항

- 호스트(t3.small, 2GB) 여유는 8/11 배포 검증 로그의 가용 858MB 실측 기준으로 +90MB 증량에 충분하고, 배포 검증(`MAX_CONTAINER_MEMORY_PERCENT`)과 Datadog 모니터는 모두 비율 기반이라 추가 수정이 필요 없습니다.
- 이 compose가 반영되는 다음 배포에서 앱 컨테이너가 새 한도로 재생성됩니다(재생성 시 수 초의 재시작 구간 존재).
- CD 워크플로는 main push 시점의 deploy.yml을 실행하므로, 두 변경 모두 develop → main 승격 이후의 배포부터 적용됩니다.

## 🔖 Uncompleted Tasks

- 없음

## 📢 To Reviewers

- mem_limit 산정 근거(정착점 실측 그래프·업타임 역산)는 #232 본문에 정리돼 있습니다.
- `ServerAliveInterval=15`는 러너→EC2 세션에 15초 간격 keepalive를 보내 NAT 유휴 절단을 막고, 응답이 끊기면 기본 ServerAliveCountMax(3) 기준 약 45초 만에 세션을 끊어 잡이 20분 timeout 전에 실패로 드러나게 합니다.
