### PR TITLE
fix(deploy): 마이그레이션 반영 후 구이미지 자동 롤백 차단 (#238) [base: develop]

### DIFF
--- a/scripts/deployment/README.md
+++ b/scripts/deployment/README.md
@@ -7,6 +7,7 @@
 - 앱과 MySQL health, DB를 포함한 앱 readiness, MySQL의 읽기 전용 `SELECT 1`, 호스트와 컨테이너 메모리를 확인한다.
 - Datadog 서비스가 있으면 Agent의 MySQL, OpenMetrics, HTTP check를 확인한다.
 - 검증 실패 시 배포 전에 실행되던 이미지 ID를 `latest`로 지정하고 앱 컨테이너를 다시 만든 뒤 health를 확인한다.
+- `flyway_schema_history`에 새 마이그레이션 적용이 감지되면 구이미지로의 자동 롤백은 수행하지 않는다.
 
 기본 임계치는 호스트 가용 메모리 256MB 이상, 각 컨테이너 메모리 상한 대비 사용률 90% 이하이다. 운영 실측 후 승인된 값은 `MIN_AVAILABLE_MEMORY_MB`, `MAX_CONTAINER_MEMORY_PERCENT`로 변경한다.
 

--- a/scripts/deployment/deploy-and-verify.sh
+++ b/scripts/deployment/deploy-and-verify.sh
@@ -17,6 +17,7 @@ meminfo_file="${MEMINFO_FILE:-/proc/meminfo}"
 
 compose=(docker compose -f "$compose_file")
 previous_image_id=""
+previous_flyway_schema_history_count=0
 deployment_started=false
 deployment_started_epoch=""
 staged_compose=false
@@ -186,6 +187,36 @@ verify_resources() {
     done <<<"$stats"
 }
 
+read_flyway_schema_history_count() {
+    local migration_count
+    local table_name
+
+    table_name="$(docker exec hampouch-mysql sh -ec 'MYSQL_PWD="$MYSQL_PASSWORD" mysql --protocol=TCP --host=127.0.0.1 --user="$MYSQL_USER" "$MYSQL_DATABASE" --skip-column-names --execute="SHOW TABLES LIKE '\''flyway_schema_history'\''"')" || true
+    if [ "$table_name" != "flyway_schema_history" ]; then
+        echo 0
+        return 0
+    fi
+
+    migration_count="$(docker exec hampouch-mysql sh -ec 'MYSQL_PWD="$MYSQL_PASSWORD" mysql --protocol=TCP --host=127.0.0.1 --user="$MYSQL_USER" "$MYSQL_DATABASE" --skip-column-names --execute="SELECT COUNT(*) FROM flyway_schema_history"' \
+        | tr -dc '0-9')"
+    if [ -z "${migration_count:-}" ]; then
+        migration_count=0
+    fi
+    echo "$migration_count"
+}
+
+schema_migration_detected() {
+    local before_count="$1"
+    local after_count
+
+    after_count="$(read_flyway_schema_history_count)"
+    if [ "${after_count:-0}" -gt "${before_count:-0}" ]; then
+        echo "마이그레이션이 반영된 상태에서 배포 검증이 실패해 구이미지 자동 롤백을 건너뜁니다."
+        return 0
+    fi
+    return 1
+}
+
 print_diagnostics() {
     "${compose[@]}" ps -a || true
     for container in hampouch-server hampouch-mysql hampouch-datadog; do
@@ -246,12 +277,17 @@ handle_failure() {
     echo "$message" >&2
     print_diagnostics
     if [ "$deployment_started" = true ]; then
-        rollback
-        rollback_exit_code="$?"
-        if [ "$rollback_exit_code" -ne 0 ]; then
-            echo "자동 롤백도 실패했습니다." >&2
-        else
+        if schema_migration_detected "$previous_flyway_schema_history_count" >/dev/null; then
+            echo "구이미지 자동 롤백을 건너뛰었습니다." >&2
             discard_staged_compose
+        else
+            rollback
+            rollback_exit_code="$?"
+            if [ "$rollback_exit_code" -ne 0 ]; then
+                echo "자동 롤백도 실패했습니다." >&2
+            else
+                discard_staged_compose
+            fi
         fi
     else
         discard_staged_compose
@@ -309,6 +345,7 @@ previous_image_id="$(docker inspect --format='{{.Image}}' hampouch-server 2>/dev
 if [ -z "$previous_image_id" ]; then
     previous_image_id="$(docker image inspect hampouch-server:latest --format='{{.Id}}' 2>/dev/null || true)"
 fi
+previous_flyway_schema_history_count="$(read_flyway_schema_history_count)"
 
 docker load -i "$image_tar"
 rm -f "$image_tar"

--- a/scripts/deployment/test-deploy-and-verify.sh
+++ b/scripts/deployment/test-deploy-and-verify.sh
@@ -53,6 +53,10 @@ docker() {
                     ;;
                 up)
                     write_state current_image "$(read_state latest_image)"
+                    if [ -n "${FAKE_FLYWAY_SCHEMA_HISTORY_COUNT_AFTER:-}" ]; then
+                        write_state flyway_schema_history_count \
+                            "$FAKE_FLYWAY_SCHEMA_HISTORY_COUNT_AFTER"
+                    fi
                     printf 'compose-up:%s\n' "$selected_compose_file" >>"$FAKE_STATE_DIR/events"
                     ;;
                 ps)
@@ -115,6 +119,7 @@ docker() {
             fi
             local container="${1:-}"
             shift || true
+            local mysql_query=""
             case "$container" in
                 hampouch-server)
                     if [ "${FAKE_APP_CHECK_FAIL:-0}" = "1" ]; then
@@ -123,7 +128,31 @@ docker() {
                     echo '{"status":"UP"}'
                     ;;
                 hampouch-mysql)
-                    echo "1"
+                    for arg in "$@"; do
+                        case "$arg" in
+                            *--execute=* )
+                                mysql_query="${arg#*--execute=}"
+                                ;;
+                        esac
+                    done
+                    case "$mysql_query" in
+                        *"SELECT 1"* )
+                            echo "1"
+                            ;;
+                        *"SHOW TABLES LIKE 'flyway_schema_history'"* )
+                            if [ -n "${FAKE_FLYWAY_SCHEMA_HISTORY_COUNT_BEFORE:-}" ]; then
+                                printf 'flyway_schema_history\n'
+                            fi
+                            ;;
+                        *"SELECT COUNT(*) FROM flyway_schema_history"* )
+                            if [ -f "$FAKE_STATE_DIR/flyway_schema_history_count" ]; then
+                                read_state flyway_schema_history_count
+                            fi
+                            ;;
+                        * )
+                            echo "1"
+                            ;;
+                    esac
                     ;;
                 hampouch-datadog)
                     echo "Datadog Agent is running"
@@ -267,6 +296,13 @@ run_case() {
     local deployment_status=0
     local deployment_pid=""
     local attempt
+    local flyway_schema_history_count_before="${6:-1}"
+    local flyway_schema_history_count_after="${7:-$flyway_schema_history_count_before}"
+    local expect_no_rollback=0
+
+    if [ "$flyway_schema_history_count_after" -gt "$flyway_schema_history_count_before" ]; then
+        expect_no_rollback=1
+    fi
 
     if [ "$app_check_fail" = "1" ] \
         || [ "$datadog_delivery_fail" = "1" ] \
@@ -290,6 +326,7 @@ run_case() {
     printf 'old-image\n' >"$state_dir/current_image"
     printf 'old-image\n' >"$state_dir/latest_image"
     printf 'new-image\n' >"$state_dir/new_image"
+    printf '%s\n' "$flyway_schema_history_count_before" >"$state_dir/flyway_schema_history_count"
     : >"$state_dir/events"
 
     export FAKE_STATE_DIR="$state_dir"
@@ -297,6 +334,8 @@ run_case() {
     export FAKE_DATADOG_DELIVERY_FAIL="$datadog_delivery_fail"
     export FAKE_DATADOG_TIMEOUT="$datadog_timeout"
     export FAKE_DATADOG_SIGNAL="$datadog_signal"
+    export FAKE_FLYWAY_SCHEMA_HISTORY_COUNT_BEFORE="$flyway_schema_history_count_before"
+    export FAKE_FLYWAY_SCHEMA_HISTORY_COUNT_AFTER="$flyway_schema_history_count_after"
 
     if [ "$datadog_signal" = "1" ]; then
         (
@@ -392,17 +431,31 @@ run_case() {
             || fail "검증을 통과한 Compose가 활성 파일로 승격되지 않았습니다"
         grep -q '운영 환경 검증을 통과했습니다' "$log_file" || fail "성공 로그가 없습니다"
     else
-        [ "$(read_state current_image)" = "old-image" ] || fail "이전 이미지로 롤백되지 않았습니다"
-        [ "$(read_state latest_image)" = "old-image" ] || fail "latest가 이전 이미지로 복구되지 않았습니다"
-        grep -qx 'compose-up:docker-compose.prod.next.yml' "$state_dir/events" \
-            || fail "새 Compose로 배포하지 않았습니다"
-        grep -qx 'compose-up:docker-compose.prod.yml' "$state_dir/events" \
-            || fail "기존 Compose로 롤백하지 않았습니다"
-        [ ! -f "$case_dir/docker-compose.prod.next.yml" ] || fail "롤백 뒤 임시 Compose가 남았습니다"
-        grep -qx 'active compose' "$case_dir/docker-compose.prod.yml" \
-            || fail "롤백 뒤 활성 Compose가 바뀌었습니다"
-        grep -q '이전 이미지로 앱 컨테이너를 복구하고 health를 확인했습니다' "$log_file" \
-            || fail "롤백 성공 로그가 없습니다"
+        if [ "$expect_no_rollback" = "1" ]; then
+            [ "$(read_state current_image)" = "new-image" ] || fail "롤백이 차단된 상황에서 새 이미지가 남지 않았습니다"
+            [ "$(read_state latest_image)" = "new-image" ] || fail "latest가 새 이미지로 남지 않았습니다"
+            grep -qx 'compose-up:docker-compose.prod.next.yml' "$state_dir/events" \
+                || fail "새 Compose로 배포하지 않았습니다"
+            grep -q 'compose-up:docker-compose.prod.yml' "$state_dir/events" \
+                && fail "구이미지 롤백 compose-up이 실행됐습니다"
+            [ ! -f "$case_dir/docker-compose.prod.next.yml" ] || fail "롤백 뒤 임시 Compose가 남았습니다"
+            grep -q '구이미지 자동 롤백을 건너뛰었습니다.' "$log_file" \
+                || fail "구이미지 자동 롤백 차단 로그가 없습니다"
+            grep -q '이전 이미지로 앱 컨테이너를 복구하고 health를 확인했습니다' "$log_file" \
+                && fail "구이미지 롤백 완료 로그가 있어 안 됩니다"
+        else
+            [ "$(read_state current_image)" = "old-image" ] || fail "이전 이미지로 롤백되지 않았습니다"
+            [ "$(read_state latest_image)" = "old-image" ] || fail "latest가 이전 이미지로 복구되지 않았습니다"
+            grep -qx 'compose-up:docker-compose.prod.next.yml' "$state_dir/events" \
+                || fail "새 Compose로 배포하지 않았습니다"
+            grep -qx 'compose-up:docker-compose.prod.yml' "$state_dir/events" \
+                || fail "기존 Compose로 롤백하지 않았습니다"
+            [ ! -f "$case_dir/docker-compose.prod.next.yml" ] || fail "롤백 뒤 임시 Compose가 남았습니다"
+            grep -qx 'active compose' "$case_dir/docker-compose.prod.yml" \
+                || fail "롤백 뒤 활성 Compose가 바뀌었습니다"
+            grep -q '이전 이미지로 앱 컨테이너를 복구하고 health를 확인했습니다' "$log_file" \
+                || fail "롤백 성공 로그가 없습니다"
+        fi
         if [ "$datadog_signal" = "1" ]; then
             grep -q 'TERM 신호로 중단됐습니다' "$log_file" \
                 || fail "취소 신호 원인이 배포 로그에 남지 않았습니다"
@@ -415,4 +468,5 @@ run_case app-check-rollback 1 0 0 0
 run_case datadog-delivery-rollback 0 1 0 0
 run_case datadog-timeout-rollback 0 0 1 0
 run_case datadog-signal-rollback 0 0 0 1
+run_case migration-after-no-rollback 0 1 0 0 1 2
 echo "deployment verification script tests passed"


### PR DESCRIPTION
## 📎연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) closes #[issue number]

- close: #238

## 📄 작업 내용 요약
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.

- 배포 시작 전에 `flyway_schema_history` 행 수를 기록해 두고, 검증 실패로 롤백하려는 시점에 행 수가 늘어 있으면(=이번 배포가 새 마이그레이션을 반영) 구이미지 자동 롤백을 건너뛰고 새 이미지를 유지한 채 실패로 종료하도록 `deploy-and-verify.sh`를 수정했습니다.
- 테스트 스크립트에 마이그레이션 반영 후 검증 실패 케이스(`migration-after-no-rollback`)를 추가했습니다. 새 이미지 유지·롤백 compose-up 미실행·차단 로그 출력까지 단언합니다.
- README에 롤백 차단 동작 한 줄을 추가했습니다.

## 👀 중요 변경 사항
> API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요

- 마이그레이션이 반영된 배포에서 검증이 실패하면 이제 서비스가 새 이미지로 뜬 채 CD만 실패로 끝납니다(fail-forward). 8/17 #235 배포처럼 구이미지가 새 스키마에서 기동하지 못해 다운되는 경로가 사라집니다.
- `flyway_schema_history` 테이블이 없거나 조회에 실패하면 행 수를 0으로 보고 기존대로 롤백을 시도합니다(동작 변화 없음).

## 🔖 Uncompleted Tasks
> 후속 작업 예정인 사항이 있다면 작성해주세요.

- 검증 실패 자체의 비치명화·재시도는 별건 #237에서 다룹니다.

## 📢 To Reviewers
> Reviewer가 주로 확인해주었으면 하는 부분을 적어주세요.

- 롤백 차단 판정을 "행 수 증가"로 잡았습니다. 이슈 조치안의 "최고 버전 기록"과 감지 결과는 동일하지만(새 행이 생기면 곧 전진), 더 단순한 쪽을 골랐습니다 — 이 판정이 충분한지 봐 주세요.
- `handle_failure`에서 차단 시 `discard_staged_compose`로 임시 compose만 정리하고 새 이미지를 그대로 두는 흐름이 맞는지 확인 부탁드립니다.
