### PR TITLE
리뷰 안 해도 됨 fix(deploy): 배포 로그 도착 검증 실패 비치명화 및 재시도 (#237) [base: develop]

### DIFF
--- a/scripts/deployment/README.md
+++ b/scripts/deployment/README.md
@@ -30,7 +30,7 @@ Datadog 서비스가 있는 배포에서는 `datadog_verification.py deployment`
 4. `datadog-verification.json`에 기록된 여섯 모니터의 이름, 종류, 쿼리, 임계치, 필수 옵션과 태그가 실제 설정과 같은지 확인한다.
 5. 각 모니터가 `published` 상태이고 활성 downtime이 없으며, 승인된 알림 수신처가 메시지에 포함됐는지 확인한다.
 
-수집 지연 검증은 API 응답시간과 polling 간격을 모두 포함해 최대 5분만 기다린다. 이미 도착한 항목은 다음 polling에서 제외하고 미도착 항목을 즉시 로그에 남긴다. `DD_DATA_VERIFY_ATTEMPTS`와 `DD_DATA_VERIFY_INTERVAL_SECONDS`로 polling을 조정할 수 있고, `DD_DATA_VERIFY_TIMEOUT_SECONDS`는 1~300초 안에서만 줄일 수 있다. 검증 프로세스는 310초에 강제 종료되며 timeout이나 취소 신호에서도 로그 프로브를 정리하고 앱 롤백을 실행한다. CD job 전체 상한은 빌드와 전송을 포함해 20분이다. 하나라도 확인되지 않으면 배포는 실패하고 앱 롤백을 실행한다.
+수집 지연 검증은 API 응답시간과 polling 간격을 모두 포함해 최대 5분만 기다린다. 이미 도착한 항목은 다음 polling에서 제외하고 미도착 항목을 즉시 로그에 남긴다. `DD_DATA_VERIFY_ATTEMPTS`와 `DD_DATA_VERIFY_INTERVAL_SECONDS`로 polling을 조정할 수 있고, `DD_DATA_VERIFY_TIMEOUT_SECONDS`는 1~300초 안에서만 줄일 수 있다. 검증 프로세스는 310초에 강제 종료되며 timeout이나 취소 신호에서도 로그 프로브를 정리하고 앱 롤백을 실행한다. CD job 전체 상한은 빌드와 전송을 포함해 20분이다. 지표 미도착이나 API 오류는 배포 실패로 처리하고 앱 롤백을 실행한다. 로그 표식만 도착하지 않은 경우는 Datadog 로그 인덱싱 지연일 수 있어 종료 코드 3으로 구분하고, 배포 스크립트가 검증을 1회 재시도한 뒤 그래도 로그만 미확인이면 경고만 남기고 배포를 유지한다.
 
 운영 EC2의 `.env`에 다음 값을 설정한다. 값은 저장소, PR, GitHub Actions 로그에 넣지 않는다.
 

--- a/scripts/deployment/datadog_verification.py
+++ b/scripts/deployment/datadog_verification.py
@@ -18,6 +18,10 @@ class VerificationError(RuntimeError):
     pass
 
 
+class LogArrivalPending(VerificationError):
+    pass
+
+
 DATADOG_API_BASES = {
     "datadoghq.com": "https://api.datadoghq.com",
     "us3.datadoghq.com": "https://api.us3.datadoghq.com",
@@ -32,6 +36,7 @@ DATADOG_API_BASES = {
 DISCORD_API_BASE = "https://discord.com/api/v10"
 MAX_DEPLOYMENT_TIMEOUT_SECONDS = 300
 DEPLOYMENT_TIMEOUT_MESSAGE = "Datadog 배포 데이터 검증의 전체 제한시간을 초과했습니다."
+LOG_ARRIVAL_PENDING_EXIT_CODE = 3
 
 
 def load_env_file(path):
@@ -329,6 +334,16 @@ def pending_deployment_data(client, config, from_epoch, sha, previous_pending=No
     return pending
 
 
+def pending_is_log_only(pending):
+    return bool(pending) and all(key.startswith("log:") for key in pending)
+
+
+def deployment_data_error(message, pending):
+    if pending_is_log_only(pending):
+        return LogArrivalPending(f"{message} 미도착: {', '.join(pending)}")
+    return VerificationError(message)
+
+
 def wait_for_deployment_data(
     client,
     config,
@@ -345,10 +360,15 @@ def wait_for_deployment_data(
     pending = None
     for attempt in range(1, attempts + 1):
         if clock() >= deadline:
-            raise VerificationError(DEPLOYMENT_TIMEOUT_MESSAGE)
-        pending = pending_deployment_data(client, config, from_epoch, sha, pending)
+            raise deployment_data_error(DEPLOYMENT_TIMEOUT_MESSAGE, pending)
+        try:
+            pending = pending_deployment_data(client, config, from_epoch, sha, pending)
+        except VerificationError as error:
+            if str(error) == DEPLOYMENT_TIMEOUT_MESSAGE and pending_is_log_only(pending):
+                raise deployment_data_error(DEPLOYMENT_TIMEOUT_MESSAGE, pending) from error
+            raise
         if clock() >= deadline:
-            raise VerificationError(DEPLOYMENT_TIMEOUT_MESSAGE)
+            raise deployment_data_error(DEPLOYMENT_TIMEOUT_MESSAGE, pending)
         if not pending:
             print(
                 "이번 배포 뒤의 Datadog 호스트·컨테이너·JVM·MySQL 지표와 앱·MySQL 로그를 확인했습니다.",
@@ -362,9 +382,11 @@ def wait_for_deployment_data(
         if attempt < attempts:
             remaining_seconds = deadline - clock()
             if remaining_seconds <= 0:
-                raise VerificationError(DEPLOYMENT_TIMEOUT_MESSAGE)
+                raise deployment_data_error(DEPLOYMENT_TIMEOUT_MESSAGE, pending)
             sleeper(min(interval_seconds, remaining_seconds))
-    raise VerificationError("이번 배포에서 생성된 필수 Datadog 지표 또는 로그가 제한 시간 안에 도착하지 않았습니다.")
+    raise deployment_data_error(
+        "이번 배포에서 생성된 필수 Datadog 지표 또는 로그가 제한 시간 안에 도착하지 않았습니다.", pending
+    )
 
 
 def validate_api_key(client):
@@ -569,6 +591,9 @@ def main():
                 os.environ.get("DD_ALERT_VERIFY_INTERVAL_SECONDS", "10")
             )
             run_alert_path(client, config, args)
+    except LogArrivalPending as error:
+        print(f"Datadog 로그 도착만 확인하지 못했습니다: {error}", file=sys.stderr)
+        return LOG_ARRIVAL_PENDING_EXIT_CODE
     except (VerificationError, ValueError) as error:
         print(f"Datadog 운영 검증 실패: {error}", file=sys.stderr)
         return 1

--- a/scripts/deployment/deploy-and-verify.sh
+++ b/scripts/deployment/deploy-and-verify.sh
@@ -12,6 +12,8 @@ maximum_container_memory_percent="${MAX_CONTAINER_MEMORY_PERCENT:-90}"
 health_attempts="${HEALTH_ATTEMPTS:-24}"
 health_interval_seconds="${HEALTH_INTERVAL_SECONDS:-5}"
 datadog_process_timeout_seconds=310
+# datadog_verification.py 의 LOG_ARRIVAL_PENDING_EXIT_CODE 와 같은 값이어야 한다.
+datadog_log_pending_exit_code=3
 os_release_file="${OS_RELEASE_FILE:-/etc/os-release}"
 meminfo_file="${MEMINFO_FILE:-/proc/meminfo}"
 
@@ -145,14 +147,27 @@ verify_datadog_delivery() {
         'while :; do printf "%s\n" "$HAMPOUCH_DEPLOY_MARKER"; sleep 5; done' >/dev/null
     echo "Datadog 로그 도착 검증용 임시 앱·MySQL 로그 표식을 기록했습니다."
 
+    run_datadog_deployment_verification || verification_exit_code="$?"
+    if [ "$verification_exit_code" -eq "$datadog_log_pending_exit_code" ]; then
+        echo "Datadog 로그 도착만 확인되지 않아 검증을 1회 재시도합니다." >&2
+        verification_exit_code=0
+        run_datadog_deployment_verification || verification_exit_code="$?"
+        if [ "$verification_exit_code" -eq "$datadog_log_pending_exit_code" ]; then
+            echo "경고: Datadog 로그 도착을 끝내 확인하지 못했지만 앱 health·DB·지표 검증이 통과해 배포를 유지합니다." >&2
+            verification_exit_code=0
+        fi
+    fi
+    cleanup_log_probes
+    return "$verification_exit_code"
+}
+
+run_datadog_deployment_verification() {
     timeout --signal=TERM --kill-after=5s "${datadog_process_timeout_seconds}s" \
         python3 -u scripts/deployment/datadog_verification.py \
             --env-file .env \
             deployment \
             --from-epoch "$deployment_started_epoch" \
-            --sha "$sha_tag" || verification_exit_code="$?"
-    cleanup_log_probes
-    return "$verification_exit_code"
+            --sha "$sha_tag"
 }
 
 verify_resources() {

--- a/scripts/deployment/test-deploy-and-verify.sh
+++ b/scripts/deployment/test-deploy-and-verify.sh
@@ -248,6 +248,9 @@ python3() {
     [ "${1:-}" = "scripts/deployment/datadog_verification.py" ] \
         || fail "지원하지 않는 Python 실행: $*"
     printf 'datadog-verification\n' >>"$FAKE_STATE_DIR/events"
+    if [ "${FAKE_DATADOG_LOG_PENDING:-0}" = "1" ]; then
+        return 3
+    fi
     [ "${FAKE_DATADOG_DELIVERY_FAIL:-0}" != "1" ]
 }
 
@@ -260,6 +263,7 @@ run_case() {
     local datadog_delivery_fail="$3"
     local datadog_timeout="$4"
     local datadog_signal="$5"
+    local datadog_log_pending="${6:-0}"
     local case_dir="$test_root/$case_name"
     local state_dir="$case_dir/state"
     local log_file="$case_dir/run.log"
@@ -297,6 +301,7 @@ run_case() {
     export FAKE_DATADOG_DELIVERY_FAIL="$datadog_delivery_fail"
     export FAKE_DATADOG_TIMEOUT="$datadog_timeout"
     export FAKE_DATADOG_SIGNAL="$datadog_signal"
+    export FAKE_DATADOG_LOG_PENDING="$datadog_log_pending"
 
     if [ "$datadog_signal" = "1" ]; then
         (
@@ -381,6 +386,17 @@ run_case() {
         elif grep -qx 'datadog-verification' "$state_dir/events"; then
             fail "timeout 또는 취소 신호 뒤 Datadog 검증기가 실행됐습니다"
         fi
+        if [ "$datadog_log_pending" = "1" ]; then
+            [ "$(grep -c '^datadog-verification$' "$state_dir/events")" = "2" ] \
+                || fail "로그 도착 미확인 시 검증이 1회 재시도되지 않았습니다"
+            grep -q '검증을 1회 재시도합니다' "$log_file" \
+                || fail "로그 도착 재시도 안내가 배포 로그에 없습니다"
+            grep -q '경고: Datadog 로그 도착을 끝내 확인하지 못했지만' "$log_file" \
+                || fail "로그 도착 경고 강등 안내가 배포 로그에 없습니다"
+        elif [ "$datadog_delivery_fail" = "1" ]; then
+            [ "$(grep -c '^datadog-verification$' "$state_dir/events")" = "1" ] \
+                || fail "치명 실패에서 Datadog 검증이 재시도됐습니다"
+        fi
     fi
 
     if [ "$expected_failure" = "0" ]; then
@@ -415,4 +431,5 @@ run_case app-check-rollback 1 0 0 0
 run_case datadog-delivery-rollback 0 1 0 0
 run_case datadog-timeout-rollback 0 0 1 0
 run_case datadog-signal-rollback 0 0 0 1
+run_case datadog-log-pending-keep 0 0 0 0 1
 echo "deployment verification script tests passed"

--- a/scripts/deployment/test_datadog_verification.py
+++ b/scripts/deployment/test_datadog_verification.py
@@ -25,6 +25,9 @@ class FakeClient:
         self.metric_calls = 0
         self.log_calls = 0
 
+    def set_deadline(self, deadline):
+        pass
+
     def request(self, method, path, params=None, body=None, require_app_key=True):
         if path == "/api/v1/validate":
             return {"valid": True}
@@ -293,6 +296,94 @@ class DatadogVerificationTest(unittest.TestCase):
 
         self.assertEqual(1, client.metric_calls)
         self.assertEqual(2, client.log_calls)
+
+    def test_deployment_wait_raises_log_pending_when_only_logs_are_missing(self):
+        from_epoch = 1_700_000_000
+        client = FakeClient(actual_monitor())
+        client.metric_response = {"series": [{"pointlist": [[from_epoch * 1000, 1.0]]}]}
+        config = {
+            "metrics": [{"name": "host", "query": "system.mem.pct_usable"}],
+            "logs": [{"name": "app", "query": "service:hampouch-server"}],
+        }
+
+        with self.assertRaises(verification.LogArrivalPending):
+            verification.wait_for_deployment_data(
+                client,
+                config,
+                from_epoch,
+                "abcdef12",
+                attempts=2,
+                interval_seconds=0,
+                deadline=300,
+                clock=lambda: 0,
+                sleeper=lambda _seconds: None,
+            )
+
+    def test_deployment_wait_deadline_with_log_only_pending_raises_log_pending(self):
+        from_epoch = 1_700_000_000
+        client = FakeClient(actual_monitor())
+        client.metric_response = {"series": [{"pointlist": [[from_epoch * 1000, 1.0]]}]}
+        config = {
+            "metrics": [{"name": "host", "query": "system.mem.pct_usable"}],
+            "logs": [{"name": "app", "query": "service:hampouch-server"}],
+        }
+        clock = FakeClock()
+
+        with self.assertRaises(verification.LogArrivalPending):
+            verification.wait_for_deployment_data(
+                client,
+                config,
+                from_epoch,
+                "abcdef12",
+                attempts=24,
+                interval_seconds=10,
+                deadline=15,
+                clock=clock,
+                sleeper=clock.sleep,
+            )
+
+    def test_deployment_wait_metric_pending_stays_fatal(self):
+        client = FakeClient(actual_monitor())
+        client.log_response = {"data": [{"id": "log"}]}
+        config = {
+            "metrics": [{"name": "host", "query": "system.mem.pct_usable"}],
+            "logs": [{"name": "app", "query": "service:hampouch-server"}],
+        }
+
+        with self.assertRaises(verification.VerificationError) as raised:
+            verification.wait_for_deployment_data(
+                client,
+                config,
+                1_700_000_000,
+                "abcdef12",
+                attempts=2,
+                interval_seconds=0,
+                deadline=300,
+                clock=lambda: 0,
+                sleeper=lambda _seconds: None,
+            )
+
+        self.assertNotIsInstance(raised.exception, verification.LogArrivalPending)
+
+    def test_main_maps_log_pending_to_dedicated_exit_code(self):
+        with patch.object(verification, "load_env_file"), patch.object(
+            verification, "load_config", return_value={}
+        ), patch.object(
+            verification, "create_client", return_value=FakeClient(actual_monitor())
+        ), patch.object(verification, "validate_api_key"), patch.object(
+            verification, "verify_all_monitors"
+        ), patch.object(
+            verification,
+            "wait_for_deployment_data",
+            side_effect=verification.LogArrivalPending("로그 대기"),
+        ), patch.object(
+            verification.sys,
+            "argv",
+            ["datadog_verification.py", "deployment", "--from-epoch", "1700000000", "--sha", "abcdef12"],
+        ):
+            self.assertEqual(
+                verification.LOG_ARRIVAL_PENDING_EXIT_CODE, verification.main()
+            )
 
     def test_alert_path_confirms_alert_and_recovery(self):
         client = FakeClient(actual_monitor())


### PR DESCRIPTION
## 📎연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) closes #[issue number]

- close: #237

## 📄 작업 내용 요약
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.

- datadog_verification.py: 배포 데이터 대기 실패 시점에 미도착 항목이 로그 표식뿐이면 LogArrivalPending으로 구분해 종료 코드 3으로 종료합니다. 전체 제한시간 초과도 마지막 pending이 로그뿐이면 같은 코드로 갑니다. 지표 미도착·API 오류·모니터 검증 실패는 기존대로 종료 코드 1(치명)입니다.
- deploy-and-verify.sh: 검증기가 종료 코드 3으로 끝나면 같은 배포 시작 시각 기준으로 검증을 1회 재시도하고(새 310초 창), 재시도도 3이면 경고만 남기고 배포를 유지합니다(롤백 없음). 그 외 비정상 종료(1, timeout 124 포함)는 기존대로 롤백합니다.
- 계약 테스트 갱신: 파이썬 4건 추가(로그만 미도착·데드라인 초과+로그만 pending → LogArrivalPending, 지표 pending은 치명 유지, main의 종료 코드 3 매핑), bash에 datadog-log-pending-keep 케이스 추가(재시도 정확히 1회 + 경고 로그 + 배포 유지 단언, 치명 실패에서는 재시도 0회 단언).
- README에 로그 전용 실패의 비치명 처리 서술을 반영했습니다.

## 👀 중요 변경 사항
> API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요

- 8/17 09:25 배포 1차 시도처럼 앱 healthy·지표 검증 통과 후 Datadog 로그 인덱싱 지연만으로 배포가 실패 처리되던 경로가 사라집니다. 로그 도착 미확인은 이제 배포를 뒤집지 않고 경고로 남습니다.
- 재시도 최악 케이스에서 검증 구간이 최대 약 10분으로 늘어나지만 CD job 상한 20분 안입니다.
- 종료 코드 3은 두 스크립트 간 계약 값입니다(셸 상수 datadog_log_pending_exit_code = 파이썬 LOG_ARRIVAL_PENDING_EXIT_CODE).

## 🔖 Uncompleted Tasks
> 후속 작업 예정인 사항이 있다면 작성해주세요.

- 구이미지 롤백 자체가 기동 불가로 실패하는 문제는 #238(PR #239)에서 별도로 다룹니다.

## 📢 To Reviewers
> Reviewer가 주로 확인해주었으면 하는 부분을 적어주세요.

- "로그만 미도착"의 판정 기준: 대기 루프의 pending 목록이 전부 log: 항목일 때만 비치명으로 강등합니다. 첫 라운드가 끝나기 전(미관측 상태) 제한시간이 끝나면 치명 유지가 맞는지 봐주세요.
