### PR TITLE
fix(security): 전이 의존성 log4j-api·httpclient5 취약 버전 핀 (#225, #226) [base: develop]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ buildscript {
 	configurations.classpath {
 		resolutionStrategy.force(
 				'org.apache.commons:commons-lang3:3.20.0',
+				'org.apache.httpcomponents.client5:httpclient5:5.6.4',
 				'org.apache.httpcomponents.core5:httpcore5:5.4.3',
 				'org.apache.httpcomponents.core5:httpcore5-h2:5.4.3',
 				'tools.jackson:jackson-bom:3.2.1',
@@ -19,7 +20,10 @@ plugins {
 }
 
 // Spring Boot 4.1.0 BOM의 취약 버전을 각 보안 권고의 패치 버전으로 올린다.
+// httpclient5 는 AWS SDK apache5-client 가 요청하는 5.6.4 로 맞춘다(패치 최소선은 5.6.3, BOM 기본은 취약한 5.6.1).
+ext['httpclient5.version'] = '5.6.4'
 ext['httpcore5.version'] = '5.4.3'
+ext['log4j2.version'] = '2.25.5'
 ext['jackson-2-bom.version'] = '2.22.2' // databind 3.2.x가 annotations 2.22의 JsonApplyView를 참조 — 이보다 내리면 런타임 NoClassDefFoundError로 부팅 실패
 ext['jackson-bom.version'] = '3.2.1'
 ext['netty.version'] = '4.2.16.Final'
@@ -102,22 +106,32 @@ tasks.named('test') {
 	systemProperty 'user.timezone', 'Asia/Seoul'
 }
 
-def expectedHttpCoreVersion = '5.4.3'
-def httpCoreCoordinates = [
-		'org.apache.httpcomponents.core5:httpcore5',
-		'org.apache.httpcomponents.core5:httpcore5-h2'
+// log4j 계열은 빌드스크립트 classpath 에 없어서 classpath 별로 검증 목록이 다르다.
+def pinnedVersionExpectations = [
+		runtimeClasspath: [
+				'org.apache.httpcomponents.client5:httpclient5': '5.6.4',
+				'org.apache.httpcomponents.core5:httpcore5'    : '5.4.3',
+				'org.apache.httpcomponents.core5:httpcore5-h2' : '5.4.3',
+				'org.apache.logging.log4j:log4j-api'           : '2.25.5',
+				'org.apache.logging.log4j:log4j-to-slf4j'      : '2.25.5'
+		],
+		buildscriptClasspath: [
+				'org.apache.httpcomponents.client5:httpclient5': '5.6.4',
+				'org.apache.httpcomponents.core5:httpcore5'    : '5.4.3',
+				'org.apache.httpcomponents.core5:httpcore5-h2' : '5.4.3'
+		]
 ]
-def httpCoreVerificationConfigurations = [
+def pinnedVerificationConfigurations = [
 		runtimeClasspath: configurations.getByName('runtimeClasspath'),
 		buildscriptClasspath: buildscript.configurations.getByName('classpath')
 ]
 
-tasks.register('verifyHttpCore5Version') {
+tasks.register('verifyPinnedDependencyVersions') {
 	group = 'verification'
-	description = 'Verifies patched HttpCore5 versions in runtime and build classpaths.'
+	description = 'Verifies patched dependency versions in runtime and build classpaths.'
 
 	doLast {
-		httpCoreVerificationConfigurations.each { pathName, configuration ->
+		pinnedVerificationConfigurations.each { pathName, configuration ->
 			def resolvedVersions = configuration.incoming.resolutionResult.allComponents
 					.findAll { it.moduleVersion != null }
 					.collectEntries {
@@ -125,12 +139,12 @@ tasks.register('verifyHttpCore5Version') {
 						[("${module.group}:${module.name}".toString()): module.version]
 					}
 
-			httpCoreCoordinates.each { coordinate ->
+			pinnedVersionExpectations[pathName].each { coordinate, expectedVersion ->
 				def resolvedVersion = resolvedVersions[coordinate]
-				if (resolvedVersion != expectedHttpCoreVersion) {
+				if (resolvedVersion != expectedVersion) {
 					throw new GradleException(
 							"${pathName} resolves ${coordinate} to ${resolvedVersion ?: 'missing'}, " +
-									"expected ${expectedHttpCoreVersion}"
+									"expected ${expectedVersion}"
 					)
 				}
 			}
@@ -139,7 +153,7 @@ tasks.register('verifyHttpCore5Version') {
 }
 
 tasks.named('check') {
-	dependsOn tasks.named('verifyHttpCore5Version')
+	dependsOn tasks.named('verifyPinnedDependencyVersions')
 }
 
 def verifyDocker = tasks.register('verifyDocker', Exec) {


### PR DESCRIPTION
## 📎연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) closes #[issue number]

- close: #225
- close: #226

## 📄 작업 내용 요약
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.

- `ext['log4j2.version'] = '2.25.5'` — 전이 의존성 log4j-api·log4j-to-slf4j 를 2.25.4 → 2.25.5 로 상향해 CVE-2026-49844([Dependabot 경고 #18](https://github.com/Hampouch/Hampouch-Server/security/dependabot/18)) 해소
- `ext['httpclient5.version'] = '5.6.4'` + buildscript force 추가 — httpclient5 를 런타임·빌드스크립트 classpath 모두 5.6.1 → 5.6.4 로 상향해 CVE-2026-64607([Dependabot 경고 #19](https://github.com/Hampouch/Hampouch-Server/security/dependabot/19)) 해소
- 기존 `verifyHttpCore5Version` 태스크를 `verifyPinnedDependencyVersions` 로 일반화 — classpath 별 좌표→기대 버전 맵으로 httpcore5·httpclient5·log4j 5개 좌표를 전부 검사, 기존처럼 `check` 에 걸려 CI `clean build` 에서 실행

## 👀 중요 변경 사항
> API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요

- httpclient5 핀은 이슈(#225)에 적힌 5.6.3 이 아니라 **5.6.4** 입니다 — AWS SDK apache5-client 가 5.6.4 를 요청하는데 Boot BOM 이 5.6.1 로 끌어내리는 구조라, 5.6.3 핀은 요청 버전보다 다운그레이드가 됩니다. 5.6.4 도 취약 범위(< 5.6.3) 밖입니다.

## 🔖 Uncompleted Tasks
> 후속 작업 예정인 사항이 있다면 작성해주세요.

- 머지 후 Dependency Submission 갱신 뒤 Dependabot 경고 #18·#19 닫힘 확인

## 📢 To Reviewers
> Reviewer가 주로 확인해주었으면 하는 부분을 적어주세요.

- 검증 실측: `verifyPinnedDependencyVersions` 통과, runtimeClasspath 에서 log4j-api 2.25.5·httpclient5 5.6.4, buildEnvironment 에서 httpclient5 5.6.1 → 5.6.4 해석 확인
