### PR TITLE
test(challenge): 집중 카테고리 엔드포인트 404 확인 테스트 추가 (#243)

### DIFF
--- a/src/test/java/Hampouch/server/domain/challenge/controller/ChallengeControllerTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/controller/ChallengeControllerTest.java
@@ -29,8 +29,7 @@ import static org.hamcrest.Matchers.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(ChallengeController.class)
@@ -465,6 +464,16 @@ class ChallengeControllerTest {
                 .andExpect(jsonPath("$.status").value(409));
     }
 
+    @Test
+    @DisplayName("집중 카테고리 수정 엔드포인트가 제거돼 PUT /{id}/focus-categories는 404를 반환한다 (#194)")
+    void focusCategoriesRoute_404() throws Exception {
+        mvc.perform(put("/api/challenges/1/focus-categories")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "categories": ["배달"] }
+                                """))
+                .andExpect(status().isNotFound());
+    }
 
     @Test
     @DisplayName("직전 종료 챌린지가 있으면 추천 조회가 message만 돌려준다")


### PR DESCRIPTION
## 📎연관된 이슈
- close: #248

## 📄 작업 내용 요약
PR #243(#194)에서 `PUT /api/challenges/{id}/focus-categories` 엔드포인트를 삭제했으나, 실제로 404를 반환하는지 확인하는 테스트가 없었습니다.

엔드포인트 삭제를 검증하는 테스트를 `ChallengeControllerTest`에 추가했습니다.

## 👀 중요 변경 사항
- 삭제된 엔드포인트가 실제로 404를 반환하는지 단언하는 테스트 1개 추가

## 📢 To Reviewers
이는 PR #243의 누락된 테스트를 사후 보충하는 것입니다. 기존 엔드포인트가 제거되었으므로 이 테스트는 앞으로 회귀 방지 역할을 합니다.