### PR TITLE
feat: 마이페이지 비밀번호 변경 API 구현

### DIFF
--- a/src/main/java/Hampouch/server/domain/user/controller/UserController.java
+++ b/src/main/java/Hampouch/server/domain/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package Hampouch.server.domain.user.controller;
 
 import Hampouch.server.domain.user.dto.request.NicknameUpdateRequest;
+import Hampouch.server.domain.user.dto.request.PasswordChangeRequest;
 import Hampouch.server.domain.user.dto.response.NicknameUpdateResponse;
 import Hampouch.server.domain.user.dto.response.UserMeResponse;
 import Hampouch.server.domain.user.service.UserService;
@@ -33,5 +34,15 @@ public class UserController {
     ) {
         NicknameUpdateResponse response = userService.updateNickname(userId, request);
         return ResponseEntity.ok(ApiResponse.success("닉네임이 변경되었습니다.", response));
+    }
+
+    //비밀번호 변경
+    @PatchMapping("/me/password")
+    public ResponseEntity<ApiResponse<Void>> changePassword(
+            @LoginUserId Long userId,
+            @RequestBody @Valid PasswordChangeRequest request
+    ) {
+        userService.changePassword(userId, request);
+        return ResponseEntity.ok(ApiResponse.success("비밀번호가 변경되었습니다.", null));
     }
 }

--- a/src/main/java/Hampouch/server/domain/user/dto/request/PasswordChangeRequest.java
+++ b/src/main/java/Hampouch/server/domain/user/dto/request/PasswordChangeRequest.java
@@ -1,0 +1,18 @@
+package Hampouch.server.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record PasswordChangeRequest(
+
+        @NotBlank(message = "현재 비밀번호를 입력해주세요.")
+        String currentPassword,
+
+        @NotBlank(message = "비밀번호를 입력해주세요.")
+        @Pattern(
+                regexp = "^(?=.*[A-Za-z])(?=.*\\d).{8,}$",
+                message = "비밀번호는 8자 이상이며 영문, 숫자를 포함해야 합니다."
+        )
+        String newPassword
+) {
+}

--- a/src/main/java/Hampouch/server/domain/user/service/UserService.java
+++ b/src/main/java/Hampouch/server/domain/user/service/UserService.java
@@ -97,17 +97,21 @@ public class UserService {
         }
 
         String encodedPassword = passwordEncoder.encode(request.newPassword());
-        self.changePasswordLocked(userId, encodedPassword);
+        self.changePasswordLocked(userId, request.currentPassword(), encodedPassword);
     }
 
-    /** 최종 반영만 담당하는 짧은 잠금 트랜잭션. isDeleted()는 잠금 조회로 다시 확인한다 - 위 사전 검사와 이 사이에 탈퇴가 끼어들 수 있다(login()/AuthService와 동일한 REPEATABLE READ 이유). */
+    /** 최종 반영만 담당하는 짧은 잠금 트랜잭션. isDeleted()와 현재 비밀번호 일치 여부를 잠금 조회로 다시 확인 */
     @Transactional
-    public void changePasswordLocked(Long userId, String encodedPassword) {
+    public void changePasswordLocked(Long userId, String currentPassword, String encodedPassword) {
         User user = userRepository.findByIdForUpdate(userId)
                 .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
 
         if (user.isDeleted()) {
             throw new CustomException(UserErrorCode.USER_DELETED);
+        }
+
+        if (!passwordEncoder.matches(currentPassword, user.getPassword())) {
+            throw new CustomException(UserErrorCode.USER_CURRENT_PASSWORD_MISMATCH);
         }
 
         user.resetPassword(encodedPassword);

--- a/src/main/java/Hampouch/server/domain/user/service/UserService.java
+++ b/src/main/java/Hampouch/server/domain/user/service/UserService.java
@@ -9,9 +9,12 @@ import Hampouch.server.domain.user.repository.UserRepository;
 import Hampouch.server.global.common.exception.CustomException;
 import Hampouch.server.global.common.exception.domain.UserErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
@@ -22,6 +25,11 @@ public class UserService {
     private final UserRepository userRepository;
     private final UserOperationLock userOperationLock;
     private final PasswordEncoder passwordEncoder;
+
+    /** changePassword()가 bcrypt 연산을 끝낸 뒤 changePasswordLocked()를 프록시로 재호출하기 위한 자기 참조 — 같은 빈 안의 this.호출은 @Transactional을 우회한다. */
+    @Lazy
+    @Autowired
+    private UserService self;
 
     public User getUser(Long userId) {
         User user = userRepository.findById(userId)
@@ -66,10 +74,14 @@ public class UserService {
         return NicknameUpdateResponse.of(user.getNickname());
     }
 
-    @Transactional
+    /**
+     * PATCH /me/password — bcrypt matches()/encode()(무거운 연산)를 트랜잭션 밖에서 먼저 끝낸 뒤
+     * self로 changePasswordLocked()를 호출한다. ExpenseImageService.attach()와 동일한 이유:
+     * 이 두 연산을 잠금 트랜잭션 안에 두면 그 시간만큼 user row 락이 불필요하게 길어진다.
+     */
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public void changePassword(Long userId, PasswordChangeRequest request) {
-        // login()/AuthService.resetPassword()와 같은 이유로 조회 자체를 잠금 조회로 만든다.
-        User user = userRepository.findByIdForUpdate(userId)
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
 
         if (user.isDeleted()) {
@@ -84,6 +96,20 @@ public class UserService {
             throw new CustomException(UserErrorCode.USER_CURRENT_PASSWORD_MISMATCH);
         }
 
-        user.resetPassword(passwordEncoder.encode(request.newPassword()));
+        String encodedPassword = passwordEncoder.encode(request.newPassword());
+        self.changePasswordLocked(userId, encodedPassword);
+    }
+
+    /** 최종 반영만 담당하는 짧은 잠금 트랜잭션. isDeleted()는 잠금 조회로 다시 확인한다 - 위 사전 검사와 이 사이에 탈퇴가 끼어들 수 있다(login()/AuthService와 동일한 REPEATABLE READ 이유). */
+    @Transactional
+    public void changePasswordLocked(Long userId, String encodedPassword) {
+        User user = userRepository.findByIdForUpdate(userId)
+                .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+
+        if (user.isDeleted()) {
+            throw new CustomException(UserErrorCode.USER_DELETED);
+        }
+
+        user.resetPassword(encodedPassword);
     }
 }

--- a/src/main/java/Hampouch/server/domain/user/service/UserService.java
+++ b/src/main/java/Hampouch/server/domain/user/service/UserService.java
@@ -1,6 +1,7 @@
 package Hampouch.server.domain.user.service;
 
 import Hampouch.server.domain.user.dto.request.NicknameUpdateRequest;
+import Hampouch.server.domain.user.dto.request.PasswordChangeRequest;
 import Hampouch.server.domain.user.dto.response.NicknameUpdateResponse;
 import Hampouch.server.domain.user.dto.response.UserMeResponse;
 import Hampouch.server.domain.user.entity.User;
@@ -9,6 +10,7 @@ import Hampouch.server.global.common.exception.CustomException;
 import Hampouch.server.global.common.exception.domain.UserErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +21,7 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final UserOperationLock userOperationLock;
+    private final PasswordEncoder passwordEncoder;
 
     public User getUser(Long userId) {
         User user = userRepository.findById(userId)
@@ -61,5 +64,26 @@ public class UserService {
         }
 
         return NicknameUpdateResponse.of(user.getNickname());
+    }
+
+    @Transactional
+    public void changePassword(Long userId, PasswordChangeRequest request) {
+        // login()/AuthService.resetPassword()와 같은 이유로 조회 자체를 잠금 조회로 만든다.
+        User user = userRepository.findByIdForUpdate(userId)
+                .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+
+        if (user.isDeleted()) {
+            throw new CustomException(UserErrorCode.USER_DELETED);
+        }
+
+        if (user.isSocialUser()) {
+            throw new CustomException(UserErrorCode.USER_SOCIAL_PASSWORD_CHANGE_NOT_ALLOWED);
+        }
+
+        if (!passwordEncoder.matches(request.currentPassword(), user.getPassword())) {
+            throw new CustomException(UserErrorCode.USER_CURRENT_PASSWORD_MISMATCH);
+        }
+
+        user.resetPassword(passwordEncoder.encode(request.newPassword()));
     }
 }

--- a/src/main/java/Hampouch/server/global/common/exception/domain/UserErrorCode.java
+++ b/src/main/java/Hampouch/server/global/common/exception/domain/UserErrorCode.java
@@ -13,6 +13,8 @@ public enum UserErrorCode implements BaseErrorCode {
     USER_DELETED(HttpStatus.FORBIDDEN, "USER_DELETED", "탈퇴한 회원입니다."),
     USER_NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "USER_NICKNAME_ALREADY_EXISTS", "이미 존재하는 닉네임입니다."),
     USER_NICKNAME_ALREADY_SET(HttpStatus.CONFLICT, "USER_NICKNAME_ALREADY_SET", "이미 닉네임이 설정된 계정입니다."),
+    USER_CURRENT_PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "USER_CURRENT_PASSWORD_MISMATCH", "현재 비밀번호가 일치하지 않습니다."),
+    USER_SOCIAL_PASSWORD_CHANGE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "USER_SOCIAL_PASSWORD_CHANGE_NOT_ALLOWED", "소셜 로그인 계정은 비밀번호를 변경할 수 없습니다."),
     NOTIFICATION_SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION_SCHEDULE_NOT_FOUND", "알림 설정을 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/test/java/Hampouch/server/domain/auth/AuthUserLockConcurrencyTest.java
+++ b/src/test/java/Hampouch/server/domain/auth/AuthUserLockConcurrencyTest.java
@@ -10,9 +10,11 @@ import Hampouch.server.domain.auth.repository.EmailVerificationRepository;
 import Hampouch.server.domain.auth.service.AuthService;
 import Hampouch.server.domain.auth.util.EmailSender;
 import Hampouch.server.domain.auth.util.SocialTokenVerifier;
+import Hampouch.server.domain.user.dto.request.PasswordChangeRequest;
 import Hampouch.server.domain.user.entity.AuthProvider;
 import Hampouch.server.domain.user.entity.User;
 import Hampouch.server.domain.user.repository.UserRepository;
+import Hampouch.server.domain.user.service.UserService;
 import Hampouch.server.global.common.exception.CustomException;
 import Hampouch.server.global.common.exception.domain.AuthErrorCode;
 import Hampouch.server.global.common.exception.domain.UserErrorCode;
@@ -52,6 +54,9 @@ class AuthUserLockConcurrencyTest {
 
     @Autowired
     AuthService authService;
+
+    @Autowired
+    UserService userService;
 
     @Autowired
     UserRepository userRepository;
@@ -201,6 +206,43 @@ class AuthUserLockConcurrencyTest {
     }
 
     @Test
+    void 탈퇴와_비밀번호변경이_경쟁하면_한쪽_순서로만_처리된다() throws Exception {
+        String email = "lock-password-change-" + System.currentTimeMillis() + "@example.com";
+        Long userId = createLocalUser(email, "닉네임F");
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try (Connection holderConn = jdbc.getDataSource().getConnection()) {
+            holderConn.setAutoCommit(false);
+            lockUserRow(holderConn, userId);
+
+            Future<Outcome> deleteCall = executor.submit(() -> callDeleteMe(userId));
+            Future<Outcome> changePasswordCall = executor.submit(() -> callChangePassword(userId));
+
+            Thread.sleep(500);
+            assertThat(deleteCall.isDone()).as("탈퇴 요청은 사용자 행 락에 막혀 대기 중이어야 한다").isFalse();
+            assertThat(changePasswordCall.isDone()).as("비밀번호 변경 요청도 사용자 행 락에 막혀 대기 중이어야 한다").isFalse();
+
+            holderConn.rollback();
+
+            Outcome deleteOutcome = deleteCall.get(10, TimeUnit.SECONDS);
+            Outcome changePasswordOutcome = changePasswordCall.get(10, TimeUnit.SECONDS);
+
+            // deleteMe는 순서와 무관하게 항상 성공한다 - 순서를 구분하는 신호는 changePasswordOutcome이다.
+            assertThat(deleteOutcome.success()).as("탈퇴는 어느 순서든 성공해야 한다").isTrue();
+
+            if (!changePasswordOutcome.success()) {
+                assertThat(changePasswordOutcome.error()).isInstanceOf(CustomException.class);
+                assertThat(((CustomException) changePasswordOutcome.error()).getErrorCode())
+                        .as("탈퇴가 먼저 커밋됐다면 비밀번호 변경은 changePasswordLocked()의 재확인에서 USER_DELETED로 실패해야 한다")
+                        .isEqualTo(UserErrorCode.USER_DELETED);
+            }
+            assertThat(isDeleted(userId)).isTrue();
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
     void 탈퇴와_최초닉네임설정이_경쟁하면_한쪽_순서로만_처리된다() throws Exception {
         Long userId = createSocialUserWithoutNickname(
                 "lock-nickname-" + System.currentTimeMillis() + "@example.com");
@@ -303,6 +345,15 @@ class AuthUserLockConcurrencyTest {
     private Outcome callResetPassword(String email) {
         try {
             authService.resetPassword(new PasswordResetRequest(email, "newPassword1"));
+            return new Outcome(true, null);
+        } catch (Exception e) {
+            return new Outcome(false, e);
+        }
+    }
+
+    private Outcome callChangePassword(Long userId) {
+        try {
+            userService.changePassword(userId, new PasswordChangeRequest("password1", "newPassword1"));
             return new Outcome(true, null);
         } catch (Exception e) {
             return new Outcome(false, e);

--- a/src/test/java/Hampouch/server/domain/auth/dto/request/PasswordPolicyTest.java
+++ b/src/test/java/Hampouch/server/domain/auth/dto/request/PasswordPolicyTest.java
@@ -1,5 +1,6 @@
 package Hampouch.server.domain.auth.dto.request;
 
+import Hampouch.server.domain.user.dto.request.PasswordChangeRequest;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
@@ -114,5 +115,39 @@ class PasswordPolicyTest {
                 .getAnnotation(jakarta.validation.constraints.Pattern.class);
 
         assertThat(signupPattern.regexp()).isEqualTo(resetPattern.regexp());
+    }
+
+    @Test
+    void 비밀번호변경_영문숫자만_있으면_통과한다() {
+        PasswordChangeRequest request = new PasswordChangeRequest("current1", "password1");
+        Set<ConstraintViolation<PasswordChangeRequest>> violations = validator.validate(request);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    void 비밀번호변경_숫자만_있으면_거부된다() {
+        PasswordChangeRequest request = new PasswordChangeRequest("current1", "12345678");
+        Set<ConstraintViolation<PasswordChangeRequest>> violations = validator.validate(request);
+        assertThat(violations).isNotEmpty();
+    }
+
+    @Test
+    void 비밀번호변경_안내문구도_회원가입과_정확히_같은_문구를_쓴다() {
+        PasswordChangeRequest request = new PasswordChangeRequest("current1", "12345678");
+        Set<ConstraintViolation<PasswordChangeRequest>> violations = validator.validate(request);
+
+        assertThat(violations)
+                .extracting(ConstraintViolation::getMessage)
+                .containsExactly(EXPECTED_PASSWORD_MESSAGE);
+    }
+
+    @Test
+    void 회원가입과_비밀번호변경의_정규식이_동일하다() throws NoSuchFieldException {
+        var signupPattern = SignupRequest.class.getDeclaredField("password")
+                .getAnnotation(jakarta.validation.constraints.Pattern.class);
+        var changePattern = PasswordChangeRequest.class.getDeclaredField("newPassword")
+                .getAnnotation(jakarta.validation.constraints.Pattern.class);
+
+        assertThat(signupPattern.regexp()).isEqualTo(changePattern.regexp());
     }
 }

--- a/src/test/java/Hampouch/server/domain/user/UserPasswordChangeTransactionBoundaryTest.java
+++ b/src/test/java/Hampouch/server/domain/user/UserPasswordChangeTransactionBoundaryTest.java
@@ -12,6 +12,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -19,7 +21,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 /**
- * changePassword()의 bcrypt matches()/encode()(무거운 연산)가 실제로 트랜잭션 밖에서 실행되는지 단언한다.
+ * changePassword()의 bcrypt matches()/encode()(무거운 연산)가 실제로 트랜잭션 밖에서 실행되는지,
+ * 그리고 changePasswordLocked()의 현재 비밀번호 재검증은 트랜잭션 안에서 실행되는지 단언한다.
  * ExpenseImageTransactionBoundaryTest와 동일한 기법: 실제 프록시를 거치는 @SpringBootTest에서
  * 연산 시점의 TransactionSynchronizationManager 상태로 직접 확인한다.
  */
@@ -36,20 +39,21 @@ class UserPasswordChangeTransactionBoundaryTest {
     PasswordEncoder passwordEncoder;
 
     @Test
-    @DisplayName("changePassword()의 현재 비밀번호 검증(matches)은 트랜잭션이 시작되기 전에 실행된다")
-    void changePasswordValidatesCurrentPasswordOutsideTransaction() {
+    @DisplayName("changePassword()의 사전 현재 비밀번호 검증(matches)은 트랜잭션 밖에서, changePasswordLocked()의 재검증은 트랜잭션 안에서 실행된다")
+    void changePasswordValidatesCurrentPasswordOutsideThenInsideTransaction() {
         User user = userRepository.saveAndFlush(User.createLocalUser(
                 "password-boundary-matches@hampouch.test", "encoded-current", "비번경계매치"));
-        AtomicBoolean transactionActiveDuringMatches = new AtomicBoolean(true);
+        // matches()는 사전 검사(락 밖)와 changePasswordLocked() 재검증(락 안), 총 두 번 호출된다 - 호출 순서대로 트랜잭션 활성 여부를 기록한다.
+        List<Boolean> transactionActiveDuringMatches = new ArrayList<>();
         when(passwordEncoder.matches(any(), any())).thenAnswer(invocation -> {
-            transactionActiveDuringMatches.set(TransactionSynchronizationManager.isActualTransactionActive());
+            transactionActiveDuringMatches.add(TransactionSynchronizationManager.isActualTransactionActive());
             return true;
         });
         when(passwordEncoder.encode(any())).thenReturn("encoded-new");
 
         userService.changePassword(user.getId(), new PasswordChangeRequest("current1", "newPassword1"));
 
-        assertThat(transactionActiveDuringMatches).isFalse();
+        assertThat(transactionActiveDuringMatches).containsExactly(false, true);
     }
 
     @Test

--- a/src/test/java/Hampouch/server/domain/user/UserPasswordChangeTransactionBoundaryTest.java
+++ b/src/test/java/Hampouch/server/domain/user/UserPasswordChangeTransactionBoundaryTest.java
@@ -1,0 +1,71 @@
+package Hampouch.server.domain.user;
+
+import Hampouch.server.domain.user.dto.request.PasswordChangeRequest;
+import Hampouch.server.domain.user.entity.User;
+import Hampouch.server.domain.user.repository.UserRepository;
+import Hampouch.server.domain.user.service.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * changePassword()의 bcrypt matches()/encode()(무거운 연산)가 실제로 트랜잭션 밖에서 실행되는지 단언한다.
+ * ExpenseImageTransactionBoundaryTest와 동일한 기법: 실제 프록시를 거치는 @SpringBootTest에서
+ * 연산 시점의 TransactionSynchronizationManager 상태로 직접 확인한다.
+ */
+@SpringBootTest
+class UserPasswordChangeTransactionBoundaryTest {
+
+    @Autowired
+    UserService userService;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @MockitoBean
+    PasswordEncoder passwordEncoder;
+
+    @Test
+    @DisplayName("changePassword()의 현재 비밀번호 검증(matches)은 트랜잭션이 시작되기 전에 실행된다")
+    void changePasswordValidatesCurrentPasswordOutsideTransaction() {
+        User user = userRepository.saveAndFlush(User.createLocalUser(
+                "password-boundary-matches@hampouch.test", "encoded-current", "비번경계매치"));
+        AtomicBoolean transactionActiveDuringMatches = new AtomicBoolean(true);
+        when(passwordEncoder.matches(any(), any())).thenAnswer(invocation -> {
+            transactionActiveDuringMatches.set(TransactionSynchronizationManager.isActualTransactionActive());
+            return true;
+        });
+        when(passwordEncoder.encode(any())).thenReturn("encoded-new");
+
+        userService.changePassword(user.getId(), new PasswordChangeRequest("current1", "newPassword1"));
+
+        assertThat(transactionActiveDuringMatches).isFalse();
+    }
+
+    @Test
+    @DisplayName("changePassword()의 새 비밀번호 인코딩(encode)은 트랜잭션이 시작되기 전에 실행된다")
+    void changePasswordEncodesNewPasswordOutsideTransaction() {
+        User user = userRepository.saveAndFlush(User.createLocalUser(
+                "password-boundary-encode@hampouch.test", "encoded-current", "비번경계인코드"));
+        AtomicBoolean transactionActiveDuringEncode = new AtomicBoolean(true);
+        when(passwordEncoder.matches(any(), any())).thenReturn(true);
+        when(passwordEncoder.encode(any())).thenAnswer(invocation -> {
+            transactionActiveDuringEncode.set(TransactionSynchronizationManager.isActualTransactionActive());
+            return "encoded-new";
+        });
+
+        userService.changePassword(user.getId(), new PasswordChangeRequest("current1", "newPassword1"));
+
+        assertThat(transactionActiveDuringEncode).isFalse();
+    }
+}

--- a/src/test/java/Hampouch/server/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/Hampouch/server/domain/user/controller/UserControllerTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -139,6 +140,68 @@ class UserControllerTest {
         mvc.perform(patch("/api/users/me/nickname")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"nickname\":\"새닉네임\"}"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("USER_DELETED"));
+    }
+
+    // ---------- 비밀번호 변경 ----------
+
+    @Test
+    @DisplayName("정상 변경이면 200을 반환한다")
+    void changePassword_returns200() throws Exception {
+        mvc.perform(patch("/api/users/me/password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"currentPassword\":\"current1\",\"newPassword\":\"newPassword1\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("SUCCESS"));
+    }
+
+    @Test
+    @DisplayName("새 비밀번호가 형식(8자 이상 + 영문/숫자)을 어기면 400을 반환한다")
+    void changePassword_returns400WhenNewPasswordViolatesPolicy() throws Exception {
+        mvc.perform(patch("/api/users/me/password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"currentPassword\":\"current1\",\"newPassword\":\"12345678\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+                .andExpect(jsonPath("$.fieldErrors.newPassword").exists());
+    }
+
+    @Test
+    @DisplayName("현재 비밀번호가 일치하지 않으면 400을 반환한다")
+    void changePassword_returns400WhenCurrentPasswordMismatch() throws Exception {
+        doThrow(new CustomException(UserErrorCode.USER_CURRENT_PASSWORD_MISMATCH))
+                .when(userService).changePassword(eq(1L), any());
+
+        mvc.perform(patch("/api/users/me/password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"currentPassword\":\"wrongPassword1\",\"newPassword\":\"newPassword1\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("USER_CURRENT_PASSWORD_MISMATCH"));
+    }
+
+    @Test
+    @DisplayName("소셜 로그인 계정이면 403을 반환한다")
+    void changePassword_returns403WhenSocialUser() throws Exception {
+        doThrow(new CustomException(UserErrorCode.USER_SOCIAL_PASSWORD_CHANGE_NOT_ALLOWED))
+                .when(userService).changePassword(eq(1L), any());
+
+        mvc.perform(patch("/api/users/me/password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"currentPassword\":\"current1\",\"newPassword\":\"newPassword1\"}"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("USER_SOCIAL_PASSWORD_CHANGE_NOT_ALLOWED"));
+    }
+
+    @Test
+    @DisplayName("탈퇴한 회원이면 403을 반환한다")
+    void changePassword_returns403WhenUserDeleted() throws Exception {
+        doThrow(new CustomException(UserErrorCode.USER_DELETED))
+                .when(userService).changePassword(eq(1L), any());
+
+        mvc.perform(patch("/api/users/me/password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"currentPassword\":\"current1\",\"newPassword\":\"newPassword1\"}"))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.code").value("USER_DELETED"));
     }

--- a/src/test/java/Hampouch/server/domain/user/service/UserServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/user/service/UserServiceTest.java
@@ -243,9 +243,23 @@ class UserServiceTest {
         User user = deletedUser(USER_ID);
         when(userRepository.findByIdForUpdate(USER_ID)).thenReturn(Optional.of(user));
 
-        assertThatThrownBy(() -> service().changePasswordLocked(USER_ID, "encoded-new"))
+        assertThatThrownBy(() -> service().changePasswordLocked(USER_ID, "current1", "encoded-new"))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.USER_DELETED);
+    }
+
+    @Test
+    @DisplayName("changePasswordLocked()는 잠금 조회 시점에 현재 비밀번호를 다시 확인해 400(USER_CURRENT_PASSWORD_MISMATCH)을 던진다 - 동시에 들어온 다른 요청이 먼저 커밋되어 비밀번호가 이미 바뀐 경우")
+    void changePasswordLocked_throws400WhenPasswordAlreadyChangedByConcurrentRequest() {
+        User user = user(USER_ID, "user1@hampouch.com", "닉네임");
+        // 락 획득 시점엔 이미 다른 동시 요청이 커밋되어 저장된 비밀번호가 사전 검사 때와 달라진 상황을 재현한다.
+        when(userRepository.findByIdForUpdate(USER_ID)).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches("current1", user.getPassword())).thenReturn(false);
+
+        assertThatThrownBy(() -> service().changePasswordLocked(USER_ID, "current1", "encoded-new"))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.USER_CURRENT_PASSWORD_MISMATCH);
+        assertThat(user.getPassword()).isNotEqualTo("encoded-new");
     }
 
     private static User user(Long id, String email, String nickname) {

--- a/src/test/java/Hampouch/server/domain/user/service/UserServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/user/service/UserServiceTest.java
@@ -1,8 +1,10 @@
 package Hampouch.server.domain.user.service;
 
 import Hampouch.server.domain.user.dto.request.NicknameUpdateRequest;
+import Hampouch.server.domain.user.dto.request.PasswordChangeRequest;
 import Hampouch.server.domain.user.dto.response.NicknameUpdateResponse;
 import Hampouch.server.domain.user.dto.response.UserMeResponse;
+import Hampouch.server.domain.user.entity.AuthProvider;
 import Hampouch.server.domain.user.entity.User;
 import Hampouch.server.domain.user.entity.UserStatus;
 import Hampouch.server.domain.user.repository.UserRepository;
@@ -26,6 +28,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -44,7 +47,10 @@ class UserServiceTest {
     PasswordEncoder passwordEncoder;
 
     private UserService service() {
-        return new UserService(userRepository, userOperationLock, passwordEncoder);
+        UserService service = new UserService(userRepository, userOperationLock, passwordEncoder);
+        // changePassword()가 self(프록시 자기참조)를 통해 changePasswordLocked()를 호출하므로 단위 테스트에서도 자기 자신을 채워준다.
+        ReflectionTestUtils.setField(service, "self", service);
+        return service;
     }
 
     // ---------- getMyInfo ----------
@@ -178,6 +184,70 @@ class UserServiceTest {
                 .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.USER_NICKNAME_ALREADY_EXISTS);
     }
 
+    // ---------- changePassword ----------
+
+    @Test
+    @DisplayName("정상 변경이면 인코딩된 새 비밀번호로 저장된다")
+    void changePassword_updatesEncodedPassword() {
+        User user = user(USER_ID, "user1@hampouch.com", "닉네임");
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+        when(userRepository.findByIdForUpdate(USER_ID)).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches("current1", user.getPassword())).thenReturn(true);
+        when(passwordEncoder.encode("newPassword1")).thenReturn("encoded-new");
+
+        service().changePassword(USER_ID, new PasswordChangeRequest("current1", "newPassword1"));
+
+        assertThat(user.getPassword()).isEqualTo("encoded-new");
+    }
+
+    @Test
+    @DisplayName("현재 비밀번호가 일치하지 않으면 400(USER_CURRENT_PASSWORD_MISMATCH)을 던지고 잠금 조회는 하지 않는다")
+    void changePassword_throws400WhenCurrentPasswordMismatch() {
+        User user = user(USER_ID, "user1@hampouch.com", "닉네임");
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches("wrongPassword1", user.getPassword())).thenReturn(false);
+
+        assertThatThrownBy(() -> service().changePassword(USER_ID, new PasswordChangeRequest("wrongPassword1", "newPassword1")))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.USER_CURRENT_PASSWORD_MISMATCH);
+        verify(userRepository, never()).findByIdForUpdate(any());
+    }
+
+    @Test
+    @DisplayName("소셜 로그인 계정이면 403(USER_SOCIAL_PASSWORD_CHANGE_NOT_ALLOWED)을 던지고 비밀번호는 비교하지 않는다")
+    void changePassword_throws403WhenSocialUser() {
+        User user = socialUser(USER_ID);
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+
+        assertThatThrownBy(() -> service().changePassword(USER_ID, new PasswordChangeRequest("current1", "newPassword1")))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.USER_SOCIAL_PASSWORD_CHANGE_NOT_ALLOWED);
+        verifyNoInteractions(passwordEncoder);
+    }
+
+    @Test
+    @DisplayName("탈퇴한 회원이면 403(USER_DELETED)을 던지고 비밀번호는 비교하지 않는다")
+    void changePassword_throws403WhenUserDeleted() {
+        User user = deletedUser(USER_ID);
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+
+        assertThatThrownBy(() -> service().changePassword(USER_ID, new PasswordChangeRequest("current1", "newPassword1")))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.USER_DELETED);
+        verifyNoInteractions(passwordEncoder);
+    }
+
+    @Test
+    @DisplayName("changePasswordLocked()는 잠금 조회 시점에 탈퇴 상태를 다시 확인해 403(USER_DELETED)을 던진다 - 사전 검사와 잠금 조회 사이에 탈퇴가 끼어드는 경우")
+    void changePasswordLocked_throws403WhenUserDeletedAtLockTime() {
+        User user = deletedUser(USER_ID);
+        when(userRepository.findByIdForUpdate(USER_ID)).thenReturn(Optional.of(user));
+
+        assertThatThrownBy(() -> service().changePasswordLocked(USER_ID, "encoded-new"))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.USER_DELETED);
+    }
+
     private static User user(Long id, String email, String nickname) {
         User user = User.createLocalUser(email, "encoded", nickname);
         ReflectionTestUtils.setField(user, "id", id);
@@ -187,6 +257,12 @@ class UserServiceTest {
     private static User deletedUser(Long id) {
         User user = user(id, "deleted@hampouch.com", "탈퇴예정");
         ReflectionTestUtils.setField(user, "status", UserStatus.DELETED);
+        return user;
+    }
+
+    private static User socialUser(Long id) {
+        User user = User.createSocialUser("social" + id + "@hampouch.com", AuthProvider.GOOGLE, "google-" + id);
+        ReflectionTestUtils.setField(user, "id", id);
         return user;
     }
 }

--- a/src/test/java/Hampouch/server/domain/user/service/UserServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/user/service/UserServiceTest.java
@@ -15,6 +15,7 @@ import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Optional;
@@ -39,9 +40,11 @@ class UserServiceTest {
     UserRepository userRepository;
     @Mock
     UserOperationLock userOperationLock;
+    @Mock
+    PasswordEncoder passwordEncoder;
 
     private UserService service() {
-        return new UserService(userRepository, userOperationLock);
+        return new UserService(userRepository, userOperationLock, passwordEncoder);
     }
 
     // ---------- getMyInfo ----------


### PR DESCRIPTION
## 📎연관된 이슈

- close: #221 

## 📄 작업 내용 요약

로그인 상태에서 현재 비밀번호를 확인하고 새 비밀번호로 바꾸는 `PATCH /api/users/me/password`를 구현했습니다.
이메일 인증 코드 기반의 `PATCH /api/auth/password/reset`(비밀번호 찾기)과는 별도 흐름으로, 재사용하지 않습니다.

- `UserErrorCode`에 `USER_CURRENT_PASSWORD_MISMATCH`(400), `USER_SOCIAL_PASSWORD_CHANGE_NOT_ALLOWED`(403) 추가
- `PasswordChangeRequest` DTO 추가 — `newPassword`는 `SignupRequest`/`PasswordResetRequest`와 동일한 정규식(8자 이상 + 영문/숫자)·문구 사용
- `UserService.changePassword()` 구현, `PATCH /api/users/me/password` 엔드포인트 추가
- `changePassword()`(락 없는 조회 + bcrypt `matches`/`encode`)와 `changePasswordLocked()`(짧은 `@Transactional` + `findByIdForUpdate` + 최종 반영)로 분리 — `ExpenseImageService.attach()`/`attachLocked()`와 동일한 self-invocation 패턴으로, 무거운 bcrypt 연산이 user row 락을 붙잡고 있지 않도록 함
- 단위 테스트(정상 변경/현재 비밀번호 불일치/소셜 계정 차단/탈퇴 회원), 트랜잭션 경계 테스트(bcrypt 연산이 트랜잭션 밖에서 실행되는지), 동시성 테스트(탈퇴와 비밀번호 변경이 경쟁할 때 직렬화되는지, `AuthUserLockConcurrencyTest`에 추가) 포함
- `PasswordPolicyTest`에 `PasswordChangeRequest` 케이스 추가해 회원가입/재설정/변경 세 DTO의 비밀번호 정책이 계속 일치하는지 검증

## 👀 중요 변경 사항

- `changePasswordLocked()`는 락 재조회 시 탈퇴 여부만 재확인합니다(REPEATABLE READ로 인해 사전 검사와 락 사이에 탈퇴가 끼어들 수 있음). 소셜 계정 여부·현재 비밀번호 일치 여부는 재확인하지 않는데, 재확인하려면 bcrypt 연산이 다시 락 안으로 들어와 트랜잭션을 짧게 유지하려는 목적이 무색해지기 때문입니다. 동일 사용자가 두 번 동시에 비밀번호 변경을 요청하는 극히 드문 경합이 아니면 문제되지 않는다고 판단했습니다.
- `UserService` 생성자에 `PasswordEncoder` 의존성이 추가됐습니다.

## 🔖 Uncompleted Tasks

- #221 로 마이페이지 관련 API 완성 예정

## 📢 To Reviewers

- `changePasswordLocked()`에서 소셜 계정/현재 비밀번호 일치 여부를 재확인하지 않는 트레이드오프(위 중요 변경 사항 참고)가 괜찮은지 의견 부탁드립니다.