### PR TITLE
refactor: 홈/캘린더/결과/히스토리/추천 읽기 경로를 ChallengeDay 대신 Expense/NoSpendDay 기반으로 전환

### DIFF
--- a/src/main/java/Hampouch/server/domain/challenge/service/ChallengeCalculator.java
+++ b/src/main/java/Hampouch/server/domain/challenge/service/ChallengeCalculator.java
@@ -94,6 +94,39 @@ public final class ChallengeCalculator {
         return day == null ? limits.on(date) : day.getDailyLimit();
     }
 
+    /**
+     * summarizeThrough의 Expense 기반 버전 — 날짜별 지출 합계 맵을 받아 한도·판정을 계산
+     * DailyLimitTimeline.on(date)는 조정 이력만으로 결정되는 순수 함수라 얼려둘 필요가 없어 항상 limits.on(date)를 쓴다.
+     */
+    public static ChallengeSummary summarizeThrough(Map<LocalDate, Integer> spentByDate, DailyLimitTimeline limits,
+                                                     LocalDate startDate, LocalDate endDate) {
+        int successDays = 0;
+        int overDays = 0;
+        int savedAmount = 0;
+        int overAmount = 0;
+        int actualSpent = 0;
+        int maxStreak = 0;
+        int currentStreak = 0;
+
+        for (LocalDate date = startDate; !date.isAfter(endDate); date = date.plusDays(1)) {
+            int spent = spentByDate.getOrDefault(date, 0);
+            int dailyLimit = limits.on(date);
+            DayStatus status = judge(spent, dailyLimit);
+            actualSpent += spent;
+            savedAmount += Math.max(0, dailyLimit - spent);
+            overAmount += Math.max(0, spent - dailyLimit);
+            if (status == DayStatus.SUCCESS) {
+                successDays++;
+                currentStreak++;
+                maxStreak = Math.max(maxStreak, currentStreak);
+            } else {
+                overDays++;
+                currentStreak = 0;
+            }
+        }
+        return new ChallengeSummary(successDays, overDays, savedAmount, overAmount, maxStreak, actualSpent);
+    }
+
     private static final int SHORT_CHALLENGE_MAX_DAYS = 14;
 
     public static int maxAdjustmentCount(int durationDays) {
@@ -103,6 +136,23 @@ public final class ChallengeCalculator {
     /** 집계 종료일부터 거꾸로 센 연속 성공일 수. 미기록일도 0원 SUCCESS로 계산한다. */
     public static int currentStreakAsOf(List<ChallengeDay> days, LocalDate startDate, LocalDate aggregationEndDate) {
         return trailingStreakAsOf(days, startDate, aggregationEndDate, DayStatus.SUCCESS);
+    }
+
+    /**
+     * currentStreakAsOf의 Expense 기반 버전.
+     * 이 버전은 status가 없으므로 judge(spent, limits.on(date))로 그 자리에서 계산 — limits 파라미터가 필요
+     */
+    public static int currentStreakAsOf(Map<LocalDate, Integer> spentByDate, DailyLimitTimeline limits,
+                                        LocalDate startDate, LocalDate aggregationEndDate) {
+        int streak = 0;
+        for (LocalDate date = aggregationEndDate; !date.isBefore(startDate); date = date.minusDays(1)) {
+            int spent = spentByDate.getOrDefault(date, 0);
+            if (judge(spent, limits.on(date)) != DayStatus.SUCCESS) {
+                break;
+            }
+            streak++;
+        }
+        return streak;
     }
 
     /** 한도 0원일 때 Infinity·NaN이 응답에 노출되지 않도록 초과 여부만 반환한다. */

--- a/src/main/java/Hampouch/server/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/Hampouch/server/domain/challenge/service/ChallengeService.java
@@ -244,11 +244,13 @@ public class ChallengeService {
     public ResultResponse getResult(Long userId, Long challengeId) {
         userOperationLock.lock(userId);
         Challenge c = loadOwned(userId, challengeId);
-        List<ChallengeDay> days = challengeDayRepository.findByChallenge_Id(challengeId);
         LocalDate aggregationEndDate = aggregationEndDate(c);
-
-        ChallengeSummary s = ChallengeCalculator.summarizeThrough(
-                days, timelineOf(c), c.getStartDate(), aggregationEndDate);
+        Map<LocalDate, Integer> spentByDate = aggregationEndDate.isBefore(c.getStartDate())
+                ? Map.of()
+                : expenseService.getDailySpending(userId, c.getStartDate(), aggregationEndDate);
+        ChallengeSummary s = aggregationEndDate.isBefore(c.getStartDate())
+                ? new ChallengeSummary(0, 0, 0, 0, 0, 0)
+                : ChallengeCalculator.summarizeThrough(spentByDate, timelineOf(c), c.getStartDate(), aggregationEndDate);
 
         if (c.isInProgress()) {
             LocalDate today = LocalDate.now(clock);
@@ -554,9 +556,9 @@ public class ChallengeService {
         if (!judgmentDate.isAfter(c.getEndDate())) {
             return;
         }
+        Map<LocalDate, Integer> spentByDate = expenseService.getDailySpending(userId, c.getStartDate(), c.getEndDate());
         ChallengeSummary s = ChallengeCalculator.summarizeThrough(
-                challengeDayRepository.findByChallenge_Id(c.getId()),
-                timelineOf(c), c.getStartDate(), c.getEndDate());
+                spentByDate, timelineOf(c), c.getStartDate(), c.getEndDate());
         c.applyResult(ChallengeCalculator.resultStatus(s.actualSpent(), c.getBudgetTotal()));
     }
 

--- a/src/main/java/Hampouch/server/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/Hampouch/server/domain/challenge/service/ChallengeService.java
@@ -377,9 +377,13 @@ public class ChallengeService {
                         userId, List.of(ChallengeStatus.SUCCESS, ChallengeStatus.FAIL, ChallengeStatus.VOID))
                 .orElseThrow(() -> new CustomException(ChallengeErrorCode.NO_ENDED_CHALLENGE));
 
-        List<ChallengeDay> days = challengeDayRepository.findByChallenge_Id(last.getId());
-        ChallengeSummary s = ChallengeCalculator.summarizeThrough(
-                days, timelineOf(last), last.getStartDate(), aggregationEndDate(last));
+        LocalDate aggregationEndDate = aggregationEndDate(last);
+        Map<LocalDate, Integer> spentByDate = aggregationEndDate.isBefore(last.getStartDate())
+                ? Map.of()
+                : expenseService.getDailySpending(userId, last.getStartDate(), aggregationEndDate);
+        ChallengeSummary s = aggregationEndDate.isBefore(last.getStartDate())
+                ? new ChallengeSummary(0, 0, 0, 0, 0, 0)
+                : ChallengeCalculator.summarizeThrough(spentByDate, timelineOf(last), last.getStartDate(), aggregationEndDate);
         int recommendedDurationDays = ChallengeCalculator.recommendedDurationDays(last.getDurationDays());
         int recommendedBudgetTotal = ChallengeCalculator.recommendedBudgetTotal(
                 last.getStatus(), last.getEndReason(), last.getBudgetTotal(), s.actualSpent());

--- a/src/main/java/Hampouch/server/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/Hampouch/server/domain/challenge/service/ChallengeService.java
@@ -100,12 +100,9 @@ public class ChallengeService {
         }
         Challenge c = challenge.get();
 
-        List<ChallengeDay> days = challengeDayRepository.findByChallenge_Id(c.getId());
         ExpenseInputState expenseInputState = evaluateExpenseInputState(userId, c, today);
-
-        Optional<ChallengeDay> todayRow = challengeDayRepository.findByChallenge_IdAndDayDate(c.getId(), today);
         DailyLimitTimeline limits = timelineOf(c);
-        return buildChallengeResponse(c, days, today, todayRow, c.getDailyLimit(), limits,
+        return buildChallengeResponse(userId, c, today, c.getDailyLimit(), limits,
                 expenseInputState, challengeAdjustmentRepository.countByChallenge_Id(c.getId()));
     }
 
@@ -126,37 +123,35 @@ public class ChallengeService {
         }
 
         Challenge c = challenge.get();
-        List<ChallengeDay> days = challengeDayRepository.findByChallenge_Id(c.getId());
         List<ChallengeAdjustment> adjustments = challengeAdjustmentRepository
                 .findByChallenge_IdOrderByEffectiveDateAscIdAsc(c.getId());
         DailyLimitTimeline limits = DailyLimitTimeline.of(c, adjustments);
-        Optional<ChallengeDay> selectedDay = days.stream()
-                .filter(day -> day.getDayDate().equals(date))
-                .findFirst();
-        int dailyLimit = selectedDay.map(ChallengeDay::getDailyLimit).orElseGet(() -> limits.on(date));
+        int dailyLimit = limits.on(date);
         int usedAdjustmentCount = (int) adjustments.stream()
                 .filter(adjustment -> !adjustment.getEffectiveDate().isAfter(date))
                 .count();
 
-        return buildChallengeResponse(c, days, date, selectedDay, dailyLimit, limits,
+        return buildChallengeResponse(userId, c, date, dailyLimit, limits,
                 ExpenseInputState.NORMAL, usedAdjustmentCount);
     }
 
     private CurrentChallengeResponse buildChallengeResponse(
+            Long userId,
             Challenge c,
-            List<ChallengeDay> days,
             LocalDate selectedDate,
-            Optional<ChallengeDay> selectedDay,
             int dailyLimit,
             DailyLimitTimeline limits,
             ExpenseInputState expenseInputState,
             int usedAdjustmentCount) {
         LocalDate aggregationEndDate = selectedDate.isAfter(c.getEndDate()) ? c.getEndDate() : selectedDate;
+        Map<LocalDate, Integer> spentByDate = aggregationEndDate.isBefore(c.getStartDate())
+                ? Map.of()
+                : expenseService.getDailySpending(userId, c.getStartDate(), aggregationEndDate);
         ChallengeSummary summary = aggregationEndDate.isBefore(c.getStartDate())
                 ? new ChallengeSummary(0, 0, 0, 0, 0, 0)
-                : ChallengeCalculator.summarizeThrough(days, limits, c.getStartDate(), aggregationEndDate);
+                : ChallengeCalculator.summarizeThrough(spentByDate, limits, c.getStartDate(), aggregationEndDate);
 
-        int spent = selectedDay.map(ChallengeDay::getSpentAmount).orElse(0);
+        int spent = expenseService.getDaySpending(userId, selectedDate).totalAmount();
         double usageRate = ChallengeCalculator.usageRate(spent, dailyLimit);
         var view = new CurrentChallengeResponse.ChallengeView(
                 c.getId(), c.getDurationDays(), c.getStartDate(), c.getEndDate(),
@@ -164,7 +159,7 @@ public class ChallengeService {
         var progress = new CurrentChallengeResponse.Progress(
                 elapsedDays(c, selectedDate), remainingDays(c, selectedDate),
                 summary.successDays(), summary.overDays(),
-                ChallengeCalculator.currentStreakAsOf(days, c.getStartDate(), aggregationEndDate),
+                ChallengeCalculator.currentStreakAsOf(spentByDate, limits, c.getStartDate(), aggregationEndDate),
                 summary.savedAmount());
         var consumption = new CurrentChallengeResponse.Consumption(
                 spent, dailyLimit - spent, dailyLimit,

--- a/src/main/java/Hampouch/server/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/Hampouch/server/domain/challenge/service/ChallengeService.java
@@ -337,7 +337,7 @@ public class ChallengeService {
             return new ChallengeHistoryResponse(List.of());
         }
 
-        Map<Long, ChallengeSummary> summariesByChallengeId = summarizeCompletedChallenges(ended);
+        Map<Long, ChallengeSummary> summariesByChallengeId = summarizeCompletedChallenges(userId, ended);
         List<ChallengeHistoryResponse.Item> items = ended.stream()
                 .map(c -> {
                     ChallengeSummary s = summariesByChallengeId.get(c.getId());
@@ -347,24 +347,23 @@ public class ChallengeService {
         return new ChallengeHistoryResponse(items);
     }
 
-    private Map<Long, ChallengeSummary> summarizeCompletedChallenges(List<Challenge> completed) {
+    private Map<Long, ChallengeSummary> summarizeCompletedChallenges(Long userId, List<Challenge> completed) {
         if (completed.isEmpty()) {
             return Map.of();
         }
         List<Long> completedIds = completed.stream().map(Challenge::getId).toList();
-        Map<Long, List<ChallengeDay>> daysByChallengeId = challengeDayRepository
-                .findByChallenge_IdIn(completedIds)
-                .stream()
-                .collect(Collectors.groupingBy(d -> d.getChallenge().getId()));
         Map<Long, List<ChallengeAdjustment>> adjustmentsByChallengeId = challengeAdjustmentRepository
                 .findByChallenge_IdInOrderByEffectiveDateAscIdAsc(completedIds)
                 .stream()
                 .collect(Collectors.groupingBy(a -> a.getChallenge().getId()));
+        LocalDate minStart = completed.stream().map(Challenge::getStartDate).min(LocalDate::compareTo).orElseThrow();
+        LocalDate maxEnd = completed.stream().map(this::aggregationEndDate).max(LocalDate::compareTo).orElseThrow();
+        Map<LocalDate, Integer> spentByDate = expenseService.getDailySpending(userId, minStart, maxEnd);
 
         return completed.stream().collect(Collectors.toMap(
                 Challenge::getId,
                 challenge -> ChallengeCalculator.summarizeThrough(
-                        daysByChallengeId.getOrDefault(challenge.getId(), List.of()),
+                        spentByDate,
                         DailyLimitTimeline.of(
                                 challenge, adjustmentsByChallengeId.getOrDefault(challenge.getId(), List.of())),
                         challenge.getStartDate(), aggregationEndDate(challenge))));

--- a/src/main/java/Hampouch/server/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/Hampouch/server/domain/challenge/service/ChallengeService.java
@@ -6,6 +6,8 @@ import Hampouch.server.domain.challenge.exception.ChallengeNotClosableException;
 import Hampouch.server.domain.challenge.repository.ChallengeAdjustmentRepository;
 import Hampouch.server.domain.challenge.repository.ChallengeDayRepository;
 import Hampouch.server.domain.challenge.repository.ChallengeRepository;
+import Hampouch.server.domain.expense.entity.NoSpendDay;
+import Hampouch.server.domain.expense.repository.NoSpendDayRepository;
 import Hampouch.server.domain.expense.service.ExpenseService;
 import Hampouch.server.domain.expense.service.ExpenseSpendingQuery;
 import Hampouch.server.domain.expense.service.PeriodSpending;
@@ -35,6 +37,7 @@ public class ChallengeService {
 
     private final ChallengeRepository challengeRepository;
     private final ChallengeDayRepository challengeDayRepository;
+    private final NoSpendDayRepository noSpendDayRepository;
     private final ExpenseService expenseService;
     private final ExpenseSpendingQuery expenseSpendingQuery;
     private final ChallengeAdjustmentRepository challengeAdjustmentRepository;
@@ -218,14 +221,26 @@ public class ChallengeService {
 
         DateRange challengeRangeInMonth = DateRange.ofMonth(year, month)
                 .intersect(new DateRange(c.getStartDate(), c.getEndDate()));
+        if (challengeRangeInMonth.isEmpty()) {
+            return new CalendarResponse(challengeId, year, month, List.of());
+        }
 
-        List<CalendarResponse.DayView> days = challengeRangeInMonth.isEmpty()
-                ? List.of()
-                : challengeDayRepository.findByChallenge_IdAndDayDateBetween(
-                                challengeId, challengeRangeInMonth.start(), challengeRangeInMonth.end()).stream()
-                        .sorted(Comparator.comparing(ChallengeDay::getDayDate))
-                        .map(d -> new CalendarResponse.DayView(d.getDayDate(), d.getStatus(), d.getSpentAmount()))
-                        .toList();
+        Map<LocalDate, Integer> spentByDate = expenseService.getDailySpending(
+                userId, challengeRangeInMonth.start(), challengeRangeInMonth.end());
+        List<LocalDate> noSpendDates = noSpendDayRepository
+                .findByUser_IdAndRecordDateBetween(userId, challengeRangeInMonth.start(), challengeRangeInMonth.end())
+                .stream().map(NoSpendDay::getRecordDate).toList();
+        DailyLimitTimeline limits = timelineOf(c);
+
+        // 지출 있는 날 ∪ 오늘은 안 썼어요 선언된 날 = 캘린더에 실릴 기록 있는 날
+        Set<LocalDate> recordedDates = new TreeSet<>(spentByDate.keySet());
+        recordedDates.addAll(noSpendDates);
+        List<CalendarResponse.DayView> days = recordedDates.stream()
+                .map(date -> {
+                    int spent = spentByDate.getOrDefault(date, 0);
+                    return new CalendarResponse.DayView(date, ChallengeCalculator.judge(spent, limits.on(date)), spent);
+                })
+                .toList();
         return new CalendarResponse(challengeId, year, month, days);
     }
 

--- a/src/main/java/Hampouch/server/domain/expense/repository/NoSpendDayRepository.java
+++ b/src/main/java/Hampouch/server/domain/expense/repository/NoSpendDayRepository.java
@@ -4,6 +4,7 @@ import Hampouch.server.domain.expense.entity.NoSpendDay;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 public interface NoSpendDayRepository extends JpaRepository<NoSpendDay, Long> {
@@ -13,4 +14,7 @@ public interface NoSpendDayRepository extends JpaRepository<NoSpendDay, Long> {
     void deleteByUser_IdAndRecordDate(Long userId, LocalDate recordDate);
 
     Optional<NoSpendDay> findTopByUser_IdOrderByRecordDateDesc(Long userId);
+
+    /** Challenge 도메인의 캘린더 조회용 — [start,end]에서 오늘은 안 썼어요로 선언된 날짜만 골라낸다. */
+    List<NoSpendDay> findByUser_IdAndRecordDateBetween(Long userId, LocalDate start, LocalDate end);
 }

--- a/src/main/java/Hampouch/server/domain/expense/service/ExpenseService.java
+++ b/src/main/java/Hampouch/server/domain/expense/service/ExpenseService.java
@@ -23,6 +23,8 @@ import java.time.Clock;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -213,6 +215,15 @@ public class ExpenseService {
     public DaySpending getDaySpending(Long userId, LocalDate date) {
         int totalAmount = expenseRepository.sumPriceByUserIdAndExpenseDateAndStatus(userId, date, ExpenseStatus.ACTIVE);
         return new DaySpending(totalAmount, hasDayRecord(userId, date));
+    }
+
+    /**
+     * Challenge 도메인의 기간 집계(getCurrent/getCalendar/getResult/getHistory/getRecommendation)용 —
+     * [start,end] 각 날짜의 ACTIVE 지출 합계.
+     */
+    public Map<LocalDate, Integer> getDailySpending(Long userId, LocalDate start, LocalDate end) {
+        return expenseRepository.sumGroupedByDate(userId, ExpenseStatus.ACTIVE, start, end).stream()
+                .collect(Collectors.toMap(ExpenseDailyTotal::date, total -> (int) total.totalAmount()));
     }
 
     /** GET/PUT/DELETE 공통 조회 진입점. DELETED 지출은 존재해도 EXPENSE_NOT_FOUND로 처리. */

--- a/src/test/java/Hampouch/server/domain/challenge/ChallengeFlowIntegrationTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/ChallengeFlowIntegrationTest.java
@@ -548,7 +548,7 @@ class ChallengeFlowIntegrationTest {
         Challenge fail = challengeRepository.save(Challenge.builder()
                 .userId(user).durationDays(7).startDate(LocalDate.of(2026, 6, 1))
                 .budgetTotal(70000).dailyLimit(10000).build());
-        challengeDayRepository.save(ChallengeDay.of(fail, LocalDate.of(2026, 6, 3), 80000, DayStatus.OVER, 10000));
+        seedExpense(user, LocalDate.of(2026, 6, 3), 80000);
 
         mvc.perform(get("/api/challenges/" + fail.getId() + "/result").header("Authorization", bearer(user)))
                 .andExpect(status().isOk())

--- a/src/test/java/Hampouch/server/domain/challenge/ChallengeFlowIntegrationTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/ChallengeFlowIntegrationTest.java
@@ -152,8 +152,7 @@ class ChallengeFlowIntegrationTest {
                 .budgetTotal(50000).dailyLimit(10000).build());
         challenge.applyResult(ChallengeStatus.SUCCESS);
         challengeRepository.save(challenge);
-        challengeDayRepository.save(ChallengeDay.of(
-                challenge, selectedDate, 7000, DayStatus.SUCCESS, 10000));
+        seedExpense(user, selectedDate, 7000);
 
         Challenge others = challengeRepository.save(Challenge.builder()
                 .userId(otherUser).durationDays(5).startDate(startDate)
@@ -229,6 +228,8 @@ class ChallengeFlowIntegrationTest {
 
         // 3) 현황: 응답 형태 {code, message, data:{challenge, progress, ...}} + 집계.
         //    홈 집계는 판정 완료 구간(시작~오늘)까지만(0714 확정) — 내일(day2)의 초과 기록은 아직 미포함.
+        //    getCurrent는 이제 실제 Expense를 읽으므로 심어준다(#101 확장) — /days는 별개 기록(upsertDay)이라 반영 안 됨.
+        seedExpense(user, start, 8000);
         mvc.perform(get("/api/challenges/current").header("Authorization", bearer(user)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.challenge.dailyLimit").value(10000))
@@ -237,8 +238,7 @@ class ChallengeFlowIntegrationTest {
                 .andExpect(jsonPath("$.data.progress.overDays").value(0))
                 .andExpect(jsonPath("$.data.progress.savedAmountSoFar").value(2000));
 
-        // 4) 캘린더: 이번 달에 시작일 기록(SUCCESS) 포함 — getCalendar는 이제 실제 Expense를 읽으므로 심어준다(#101 확장)
-        seedExpense(user, start, 8000);
+        // 4) 캘린더: 이번 달에 시작일 기록(SUCCESS) 포함 — getCalendar도 실제 Expense를 읽는다(위에서 이미 심음)
         mvc.perform(get("/api/challenges/" + id + "/calendar")
                         .header("Authorization", bearer(user))
                         .param("year", String.valueOf(start.getYear()))
@@ -489,6 +489,9 @@ class ChallengeFlowIntegrationTest {
                         .content("{\"date\":\"" + today + "\",\"spentAmount\":12000}"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.status").value("OVER"));
+        // getCurrent의 todaySpent는 이제 실제 Expense를 읽으므로 심어준다(#101 확장) — 재시작 흐름 내내 사용자·날짜만으로
+        // 고정되어 있어 아래 give-up/재시작 사이클과 무관하게 계속 유효하다.
+        seedExpense(user, today, 12000);
         Long dayId = challengeDayRepository.findByChallenge_IdAndDayDate(firstId, today).orElseThrow().getId();
         mvc.perform(post("/api/challenges/" + firstId + "/give-up")
                         .header("Authorization", bearer(user)))

--- a/src/test/java/Hampouch/server/domain/challenge/ChallengeFlowIntegrationTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/ChallengeFlowIntegrationTest.java
@@ -4,6 +4,10 @@ import Hampouch.server.domain.challenge.entity.*;
 import Hampouch.server.domain.challenge.repository.ChallengeDayRepository;
 import Hampouch.server.domain.challenge.repository.ChallengeRepository;
 import Hampouch.server.domain.challenge.service.ChallengeFinalizationScheduler;
+import Hampouch.server.domain.expense.entity.Expense;
+import Hampouch.server.domain.expense.entity.ExpenseCategory;
+import Hampouch.server.domain.expense.entity.ExpenseEmotion;
+import Hampouch.server.domain.expense.repository.ExpenseRepository;
 import Hampouch.server.domain.user.entity.User;
 import Hampouch.server.domain.user.entity.UserRole;
 import Hampouch.server.domain.user.repository.UserRepository;
@@ -50,6 +54,8 @@ class ChallengeFlowIntegrationTest {
     UserRepository userRepository;
     @Autowired
     JwtProvider jwtProvider;
+    @Autowired
+    ExpenseRepository expenseRepository;
 
     /** 실제 서명이 붙은 액세스 토큰의 Authorization 헤더 값 — 로그인 API를 거치지 않고 발급만 빌려 쓴다. */
     private String bearer(Long userId) {
@@ -61,6 +67,15 @@ class ChallengeFlowIntegrationTest {
         User user = User.createLocalUser(
                 "challenge-flow-" + suffix + "@hampouch.test", "encoded", "챌린지" + suffix);
         return userRepository.save(user).getId();
+    }
+
+    /**
+     * getCurrent/getCalendar/getResult/getHistory가 이제 ChallengeDay 대신 실제 Expense를 읽으므로
+     * (#101 확장), POST /days와 별개로 실제 지출 행을 심어야 그 값들이 응답에 반영된다.
+     */
+    private void seedExpense(Long userId, LocalDate date, int price) {
+        User user = userRepository.getReferenceById(userId);
+        expenseRepository.save(Expense.of(null, price, ExpenseCategory.ETC, ExpenseEmotion.ETC, date, user));
     }
 
     @Test
@@ -222,7 +237,8 @@ class ChallengeFlowIntegrationTest {
                 .andExpect(jsonPath("$.data.progress.overDays").value(0))
                 .andExpect(jsonPath("$.data.progress.savedAmountSoFar").value(2000));
 
-        // 4) 캘린더: 이번 달에 시작일 기록(SUCCESS) 포함
+        // 4) 캘린더: 이번 달에 시작일 기록(SUCCESS) 포함 — getCalendar는 이제 실제 Expense를 읽으므로 심어준다(#101 확장)
+        seedExpense(user, start, 8000);
         mvc.perform(get("/api/challenges/" + id + "/calendar")
                         .header("Authorization", bearer(user))
                         .param("year", String.valueOf(start.getYear()))

--- a/src/test/java/Hampouch/server/domain/challenge/ChallengeFlowIntegrationTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/ChallengeFlowIntegrationTest.java
@@ -362,7 +362,7 @@ class ChallengeFlowIntegrationTest {
         Challenge fail = challengeRepository.save(Challenge.builder()
                 .userId(user).durationDays(7).startDate(LocalDate.of(2026, 6, 1))
                 .budgetTotal(70000).dailyLimit(10000).build());
-        challengeDayRepository.save(ChallengeDay.of(fail, LocalDate.of(2026, 6, 3), 15000, DayStatus.OVER, fail.getDailyLimit()));
+        seedExpense(user, LocalDate.of(2026, 6, 3), 15000);
         fail.applyResult(ChallengeStatus.FAIL);
         challengeRepository.save(fail);
 

--- a/src/test/java/Hampouch/server/domain/challenge/service/ChallengeCalculatorTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/service/ChallengeCalculatorTest.java
@@ -8,7 +8,9 @@ import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -42,6 +44,87 @@ class ChallengeCalculatorTest {
         assertThat(s.maxStreak()).isEqualTo(14);
         assertThat(s.actualSpent()).isEqualTo(211800);
         assertThat(ChallengeCalculator.resultStatus(s.actualSpent(), ch.getBudgetTotal())).isEqualTo(ChallengeStatus.SUCCESS);
+    }
+
+    @Test
+    @DisplayName("Map 버전 summarizeThrough도 List 버전과 같은 결과를 낸다 — s1과 같은 시나리오를 날짜별 지출 맵으로 재현 (#101 확장)")
+    void summarizeThrough_map_success() {
+        int dailyLimit = ChallengeCalculator.dailyLimit(280000, 14); // 20000
+        Challenge ch = challenge(dailyLimit);
+        Map<LocalDate, Integer> spentByDate = new HashMap<>();
+        for (int i = 0; i < 13; i++) {
+            spentByDate.put(START.plusDays(i), 15000);
+        }
+        spentByDate.put(START.plusDays(13), 16800);
+
+        ChallengeSummary s = ChallengeCalculator.summarizeThrough(
+                spentByDate, DailyLimitTimeline.of(ch, List.of()), START, START.plusDays(13));
+        assertThat(s.successDays()).isEqualTo(14);
+        assertThat(s.overDays()).isZero();
+        assertThat(s.savedAmount()).isEqualTo(68200);
+        assertThat(s.overAmount()).isZero();
+        assertThat(s.maxStreak()).isEqualTo(14);
+        assertThat(s.actualSpent()).isEqualTo(211800);
+    }
+
+    @Test
+    @DisplayName("Map 버전은 맵에 없는 날짜와 명시적으로 0을 넣은 날짜를 똑같이 0원 성공으로 계산한다 (#101 확장)")
+    void summarizeThrough_map_countsMissingAndExplicitZeroAsSuccess() {
+        int dailyLimit = 10000;
+        Challenge ch = challenge(dailyLimit);
+        LocalDate end = START.plusDays(3); // 기간 4일(5/1~5/4)
+        Map<LocalDate, Integer> spentByDate = new HashMap<>();
+        spentByDate.put(START, 8000);                  // 5/1 성공(절약 2000)
+        spentByDate.put(START.plusDays(2), 12000);      // 5/3 초과(2000)
+        spentByDate.put(START.plusDays(3), 0);          // 5/4 명시적 0원 성공 · 5/2는 맵에 아예 없음(미기록)
+
+        ChallengeSummary s = ChallengeCalculator.summarizeThrough(
+                spentByDate, DailyLimitTimeline.of(ch, List.of()), START, end);
+
+        assertThat(s.successDays()).isEqualTo(3);
+        assertThat(s.overDays()).isEqualTo(1);
+        assertThat(s.savedAmount()).isEqualTo(2000 + 10000 + 10000);
+        assertThat(s.overAmount()).isEqualTo(2000);
+        assertThat(s.actualSpent()).isEqualTo(20000);
+        assertThat(s.maxStreak()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("Map 버전 currentStreakAsOf도 맵에 없는 날짜를 0원 성공으로 이어간다 (#101 확장)")
+    void currentStreakAsOf_map_countsMissingDateAsZeroSpentSuccess() {
+        int limit = 20000;
+        Challenge ch = challenge(limit);
+        DailyLimitTimeline limits = DailyLimitTimeline.of(ch, List.of());
+        Map<LocalDate, Integer> spentByDate = Map.of(
+                START.plusDays(0), 1000,    // SUCCESS
+                START.plusDays(1), 1000,    // SUCCESS
+                START.plusDays(2), 99999,   // OVER (연속 끊김)
+                START.plusDays(3), 1000);   // SUCCESS
+        // START.plusDays(4)는 맵에 없음 — 0원 성공으로 취급돼 스트릭에 포함
+
+        assertThat(ChallengeCalculator.currentStreakAsOf(spentByDate, limits, START, START.plusDays(4))).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("Map 버전 currentStreakAsOf는 저장된 status 없이 조정 경계마다 새 한도로 그 자리에서 다시 판정한다 (#101 확장)")
+    void currentStreakAsOf_map_recomputesAcrossAdjustmentBoundary() {
+        Challenge ch = Challenge.builder()
+                .userId(1L).durationDays(5).startDate(START)
+                .budgetTotal(55000).dailyLimit(11000).build();
+        LocalDate adjustedOn = START.plusDays(2); // 5/3부터 한도 11000, 이전엔 10000
+        DailyLimitTimeline limits = DailyLimitTimeline.of(ch, List.of(
+                adjustment(ch, 1, adjustedOn, 10000, 11000)));
+        // 날짜마다 전부 명시해 "맵에 없는 날 = 0원 성공"이 스트릭에 섞여 들어오지 않게 한다.
+        Map<LocalDate, Integer> spentByDate = Map.of(
+                START, 10500,                       // 5/1 — 옛 한도(10000) 기준 OVER
+                START.plusDays(1), 10500,           // 5/2 — 옛 한도 기준 OVER
+                adjustedOn, 10500,                   // 5/3 — 새 한도(11000) 기준 SUCCESS
+                adjustedOn.plusDays(1), 10500);     // 5/4 — 새 한도 기준 SUCCESS
+
+        // 옛 한도를 계속 썼다면(=날짜별로 다시 안 쟀다면) 5/1·5/2도 새 한도 11000 기준 SUCCESS가 돼 스트릭이 4가 됐을 것.
+        // 실제로는 5/2에서 옛 한도로 OVER가 나와 끊기므로, 그 자리에서 날짜별 한도를 정확히 재계산한다는 증거가 된다.
+        assertThat(ChallengeCalculator.currentStreakAsOf(spentByDate, limits, START, adjustedOn.plusDays(1)))
+                .isEqualTo(2);
     }
 
     @Test

--- a/src/test/java/Hampouch/server/domain/challenge/service/ChallengeServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/service/ChallengeServiceTest.java
@@ -882,8 +882,8 @@ class ChallengeServiceTest {
         Challenge c8 = endedWithId(8L, LocalDate.of(2026, 5, 1), 7, 70000, 10000, ChallengeStatus.SUCCESS);
         when(challengeRepository.findCompletedByUserIdOrderByEndDateDescIdDesc(USER))
                 .thenReturn(List.of(c12, c8)); // 최근 종료(6/7)가 먼저 — 정렬은 리포지토리 쿼리 몫
-        when(challengeDayRepository.findByChallenge_IdIn(List.of(12L, 8L)))
-                .thenReturn(List.of(ChallengeDay.of(c12, LocalDate.of(2026, 6, 3), 15000, DayStatus.OVER, c12.getDailyLimit())));
+        when(expenseService.getDailySpending(USER, LocalDate.of(2026, 5, 1), LocalDate.of(2026, 6, 7)))
+                .thenReturn(Map.of(LocalDate.of(2026, 6, 3), 15000));
 
         ChallengeHistoryResponse res = serviceAt(LocalDate.of(2026, 7, 17)).getHistory(USER);
 
@@ -912,10 +912,8 @@ class ChallengeServiceTest {
         ReflectionTestUtils.setField(givenUp, "id", 31L);
         when(challengeRepository.findCompletedByUserIdOrderByEndDateDescIdDesc(USER))
                 .thenReturn(List.of(givenUp));
-        when(challengeDayRepository.findByChallenge_IdIn(List.of(31L))).thenReturn(List.of(
-                ChallengeDay.of(givenUp, LocalDate.of(2026, 7, 1), 5000, DayStatus.SUCCESS, 10000),
-                ChallengeDay.of(givenUp, LocalDate.of(2026, 7, 3), 9000, DayStatus.SUCCESS, 10000),
-                ChallengeDay.of(givenUp, LocalDate.of(2026, 7, 30), 9000, DayStatus.SUCCESS, 10000)));
+        when(expenseService.getDailySpending(USER, LocalDate.of(2026, 7, 1), LocalDate.of(2026, 7, 2)))
+                .thenReturn(Map.of(LocalDate.of(2026, 7, 1), 5000));
 
         ChallengeHistoryResponse res = serviceAt(LocalDate.of(2026, 8, 1)).getHistory(USER);
 
@@ -932,7 +930,7 @@ class ChallengeServiceTest {
         ChallengeHistoryResponse res = serviceAt(LocalDate.of(2026, 7, 17)).getHistory(USER);
 
         assertThat(res.items()).isEmpty();
-        verify(challengeDayRepository, never()).findByChallenge_IdIn(any());
+        verify(expenseService, never()).getDailySpending(any(), any(), any());
     }
 
     @Test

--- a/src/test/java/Hampouch/server/domain/challenge/service/ChallengeServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/service/ChallengeServiceTest.java
@@ -7,12 +7,15 @@ import Hampouch.server.domain.challenge.repository.ChallengeAdjustmentRepository
 import Hampouch.server.domain.challenge.repository.ChallengeDayRepository;
 import Hampouch.server.domain.challenge.repository.ChallengeRepository;
 import Hampouch.server.domain.expense.entity.ExpenseEmotion;
+import Hampouch.server.domain.expense.entity.NoSpendDay;
+import Hampouch.server.domain.expense.repository.NoSpendDayRepository;
 import Hampouch.server.domain.expense.service.EmotionSpending;
 import Hampouch.server.domain.expense.service.ExpenseService;
 import Hampouch.server.domain.expense.service.ExpenseSpendingQuery;
 import Hampouch.server.domain.expense.service.PeriodSpending;
 import Hampouch.server.domain.rest.entity.UserRest;
 import Hampouch.server.domain.rest.repository.UserRestRepository;
+import Hampouch.server.domain.user.entity.User;
 import Hampouch.server.domain.user.service.UserOperationLock;
 import Hampouch.server.global.common.exception.CustomException;
 import Hampouch.server.global.common.exception.domain.ChallengeErrorCode;
@@ -32,6 +35,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -51,6 +55,8 @@ class ChallengeServiceTest {
     ChallengeRepository challengeRepository;
     @Mock
     ChallengeDayRepository challengeDayRepository;
+    @Mock
+    NoSpendDayRepository noSpendDayRepository;
     @Mock
     ExpenseService expenseService;
     @Mock
@@ -73,7 +79,7 @@ class ChallengeServiceTest {
 
     private ChallengeService serviceAt(LocalDate today) {
         Clock clock = Clock.fixed(today.atTime(12, 0).atZone(SEOUL).toInstant(), SEOUL);
-        return new ChallengeService(challengeRepository, challengeDayRepository,
+        return new ChallengeService(challengeRepository, challengeDayRepository, noSpendDayRepository,
                 expenseService, expenseSpendingQuery, challengeAdjustmentRepository, userRestRepository,
                 userOperationLock, clock);
     }
@@ -858,14 +864,34 @@ class ChallengeServiceTest {
     void calendar_returnsOnlyDaysWithinPeriod() {
         Challenge ch = inProgress(LocalDate.of(2026, 6, 1));
         when(challengeRepository.findById(10L)).thenReturn(Optional.of(ch));
-        when(challengeDayRepository.findByChallenge_IdAndDayDateBetween(
-                10L, LocalDate.of(2026, 6, 1), LocalDate.of(2026, 6, 14)))
-                .thenReturn(List.of(ChallengeDay.of(ch, LocalDate.of(2026, 6, 3), 5000, DayStatus.SUCCESS, ch.getDailyLimit())));
+        when(expenseService.getDailySpending(USER, LocalDate.of(2026, 6, 1), LocalDate.of(2026, 6, 14)))
+                .thenReturn(Map.of(LocalDate.of(2026, 6, 3), 5000));
 
         CalendarResponse res = serviceAt(LocalDate.of(2026, 6, 5)).getCalendar(USER, 10L, 2026, 6);
 
         assertThat(res.days()).hasSize(1);
         assertThat(res.days().getFirst().date()).isEqualTo(LocalDate.of(2026, 6, 3));
+        assertThat(res.days().getFirst().spentAmount()).isEqualTo(5000);
+        assertThat(res.days().getFirst().status()).isEqualTo(DayStatus.SUCCESS);
+    }
+
+    @Test
+    @DisplayName("지출이 없어도 '오늘은 안 썼어요'로 선언된 날짜는 0원 성공으로 캘린더에 실린다 (#101 확장)")
+    void calendar_includesNoSpendDeclaredDateAsZeroSpentSuccess() {
+        Challenge ch = inProgress(LocalDate.of(2026, 6, 1));
+        LocalDate noSpendDate = LocalDate.of(2026, 6, 4);
+        when(challengeRepository.findById(10L)).thenReturn(Optional.of(ch));
+        User user = User.createLocalUser("calendar-nospend@hampouch.test", "encoded", "무지출캘린더");
+        when(noSpendDayRepository.findByUser_IdAndRecordDateBetween(
+                USER, LocalDate.of(2026, 6, 1), LocalDate.of(2026, 6, 14)))
+                .thenReturn(List.of(NoSpendDay.of(user, noSpendDate)));
+
+        CalendarResponse res = serviceAt(LocalDate.of(2026, 6, 5)).getCalendar(USER, 10L, 2026, 6);
+
+        assertThat(res.days()).hasSize(1);
+        assertThat(res.days().getFirst().date()).isEqualTo(noSpendDate);
+        assertThat(res.days().getFirst().spentAmount()).isZero();
+        assertThat(res.days().getFirst().status()).isEqualTo(DayStatus.SUCCESS);
     }
 
     @Test

--- a/src/test/java/Hampouch/server/domain/challenge/service/ChallengeServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/service/ChallengeServiceTest.java
@@ -177,7 +177,6 @@ class ChallengeServiceTest {
     void result_conflictWhileInProgress() {
         Challenge ch = inProgress(LocalDate.of(2026, 6, 1));
         when(challengeRepository.findById(10L)).thenReturn(Optional.of(ch));
-        when(challengeDayRepository.findByChallenge_Id(10L)).thenReturn(List.of());
 
         assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 6, 10)).getResult(USER, 10L))
                 .isInstanceOf(CustomException.class);
@@ -188,9 +187,8 @@ class ChallengeServiceTest {
     void result_finalizesSuccessAfterEnd() {
         Challenge ch = inProgress(LocalDate.of(2026, 6, 1));
         when(challengeRepository.findById(10L)).thenReturn(Optional.of(ch));
-        when(challengeDayRepository.findByChallenge_Id(10L)).thenReturn(List.of(
-                ChallengeDay.of(ch, LocalDate.of(2026, 6, 1), 10000, DayStatus.SUCCESS, ch.getDailyLimit()),
-                ChallengeDay.of(ch, LocalDate.of(2026, 6, 2), 12000, DayStatus.SUCCESS, ch.getDailyLimit())));
+        when(expenseService.getDailySpending(USER, LocalDate.of(2026, 6, 1), ch.getEndDate()))
+                .thenReturn(Map.of(LocalDate.of(2026, 6, 1), 10000, LocalDate.of(2026, 6, 2), 12000));
 
         ResultResponse res = serviceAt(LocalDate.of(2026, 6, 20)).getResult(USER, 10L);
 
@@ -324,7 +322,6 @@ class ChallengeServiceTest {
     void result_autoCancelsWhenNoRecords() {
         Challenge ch = inProgress(LocalDate.of(2026, 6, 1)); // endDate 2026-06-14, dailyLimit 20000
         when(challengeRepository.findById(10L)).thenReturn(Optional.of(ch));
-        when(challengeDayRepository.findByChallenge_Id(10L)).thenReturn(List.of());
         when(expenseService.hasDayRecord(eq(USER), any(LocalDate.class))).thenReturn(false);
 
         ResultResponse res = serviceAt(LocalDate.of(2026, 6, 20)).getResult(USER, 10L);
@@ -346,7 +343,6 @@ class ChallengeServiceTest {
         Challenge ch = inProgressWithId(10L, LocalDate.of(2026, 6, 1));
         ch.cancelForMissingInput(LocalDate.of(2026, 6, 3));
         when(challengeRepository.findById(10L)).thenReturn(Optional.of(ch));
-        when(challengeDayRepository.findByChallenge_Id(10L)).thenReturn(List.of());
 
         ResultResponse res = serviceAt(LocalDate.of(2026, 6, 10)).getResult(USER, 10L);
 
@@ -365,7 +361,6 @@ class ChallengeServiceTest {
                 .budgetTotal(70000).dailyLimit(10000).build();
         ReflectionTestUtils.setField(ch, "id", 10L);
         when(challengeRepository.findById(10L)).thenReturn(Optional.of(ch));
-        when(challengeDayRepository.findByChallenge_Id(10L)).thenReturn(List.of());
 
         ResultResponse res = serviceAt(LocalDate.of(2026, 6, 10)).getResult(USER, 10L);
 
@@ -656,9 +651,6 @@ class ChallengeServiceTest {
         ReflectionTestUtils.setField(ch, "id", 10L);
         ch.applyResult(ChallengeStatus.SUCCESS);
         when(challengeRepository.findById(10L)).thenReturn(Optional.of(ch));
-        when(challengeDayRepository.findByChallenge_Id(10L)).thenReturn(List.of(
-                ChallengeDay.of(ch, LocalDate.of(2026, 6, 4), 0, DayStatus.SUCCESS, 10000),
-                ChallengeDay.of(ch, LocalDate.of(2026, 6, 5), 0, DayStatus.SUCCESS, 12000)));
         when(challengeAdjustmentRepository.findByChallenge_IdOrderByEffectiveDateAscIdAsc(10L))
                 .thenReturn(List.of(ChallengeAdjustment.builder()
                         .challenge(ch).sequenceNumber(1).effectiveDate(LocalDate.of(2026, 6, 5))
@@ -815,10 +807,8 @@ class ChallengeServiceTest {
     void result_finalizesFailAfterEnd() {
         Challenge ch = inProgress(LocalDate.of(2026, 6, 1));
         when(challengeRepository.findById(10L)).thenReturn(Optional.of(ch));
-        when(challengeDayRepository.findByChallenge_Id(10L)).thenReturn(List.of(
-                ChallengeDay.of(ch, LocalDate.of(2026, 6, 1), 10000, DayStatus.SUCCESS, ch.getDailyLimit()),
-                ChallengeDay.of(ch, LocalDate.of(2026, 6, 2), 299999, DayStatus.OVER,
-                        ch.getDailyLimit())));
+        when(expenseService.getDailySpending(USER, LocalDate.of(2026, 6, 1), ch.getEndDate()))
+                .thenReturn(Map.of(LocalDate.of(2026, 6, 1), 10000, LocalDate.of(2026, 6, 2), 299999));
 
         ResultResponse res = serviceAt(LocalDate.of(2026, 6, 20)).getResult(USER, 10L);
 
@@ -1046,8 +1036,8 @@ class ChallengeServiceTest {
         Challenge ch = inProgress(LocalDate.of(2026, 6, 1)); // 06-01~06-14, 목표 280000
         ReflectionTestUtils.setField(ch, "id", 10L);
         when(challengeRepository.findByIdForUpdate(10L)).thenReturn(Optional.of(ch));
-        when(challengeDayRepository.findByChallenge_Id(10L)).thenReturn(List.of(
-                ChallengeDay.of(ch, LocalDate.of(2026, 6, 1), 10000, DayStatus.SUCCESS, ch.getDailyLimit())));
+        when(expenseService.getDailySpending(USER, LocalDate.of(2026, 6, 1), ch.getEndDate()))
+                .thenReturn(Map.of(LocalDate.of(2026, 6, 1), 10000));
 
         CloseResponse res = serviceAt(LocalDate.of(2026, 6, 20)).close(USER, 10L);
 
@@ -1164,7 +1154,6 @@ class ChallengeServiceTest {
         Challenge periodEnded = inProgress(LocalDate.of(2026, 6, 1)); // 06-01~06-14, 종료를 안 누른 상태
         ReflectionTestUtils.setField(periodEnded, "id", 10L);
         when(challengeRepository.findInProgress(USER)).thenReturn(Optional.of(periodEnded));
-        when(challengeDayRepository.findByChallenge_Id(10L)).thenReturn(List.of());
         when(challengeRepository.existsInProgress(USER)).thenReturn(false); // 위에서 확정돼 진행 중이 아님
         when(challengeRepository.save(any(Challenge.class))).thenAnswer(inv -> inv.getArgument(0));
 
@@ -1482,7 +1471,6 @@ class ChallengeServiceTest {
     void result_fillsEmotionBreakdownFromExpenseSpendingQuery() {
         Challenge ch = inProgress(LocalDate.of(2026, 6, 1)); // endDate 2026-06-14
         when(challengeRepository.findById(10L)).thenReturn(Optional.of(ch));
-        when(challengeDayRepository.findByChallenge_Id(10L)).thenReturn(List.of());
         List<EmotionSpending> emotionBreakdown = List.of(new EmotionSpending(ExpenseEmotion.STRESS, 7_000, 100));
         when(expenseSpendingQuery.periodSpending(USER, ch.getStartDate(), ch.getEndDate()))
                 .thenReturn(new PeriodSpending(7_000, emotionBreakdown));

--- a/src/test/java/Hampouch/server/domain/challenge/service/ChallengeServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/service/ChallengeServiceTest.java
@@ -9,6 +9,7 @@ import Hampouch.server.domain.challenge.repository.ChallengeRepository;
 import Hampouch.server.domain.expense.entity.ExpenseEmotion;
 import Hampouch.server.domain.expense.entity.NoSpendDay;
 import Hampouch.server.domain.expense.repository.NoSpendDayRepository;
+import Hampouch.server.domain.expense.service.DaySpending;
 import Hampouch.server.domain.expense.service.EmotionSpending;
 import Hampouch.server.domain.expense.service.ExpenseService;
 import Hampouch.server.domain.expense.service.ExpenseSpendingQuery;
@@ -72,6 +73,9 @@ class ChallengeServiceTest {
     void defaultExpenseInput() {
         lenient().when(expenseService.hasDayRecord(anyLong(), any(LocalDate.class)))
                 .thenReturn(true);
+        // getCurrent()가 항상 호출하므로 기본값을 0원으로 깔아 둔다(#101 확장) — 금액을 보는 테스트만 스텁을 따로 덮어쓴다.
+        lenient().when(expenseService.getDaySpending(anyLong(), any(LocalDate.class)))
+                .thenReturn(new DaySpending(0, true));
         // getResult()가 항상 호출하므로 기본값을 빈 집계로 깔아 둔다(#64) — 실제 배선을 보는 테스트만 스텁을 따로 덮어쓴다.
         lenient().when(expenseSpendingQuery.periodSpending(anyLong(), any(LocalDate.class), any(LocalDate.class)))
                 .thenReturn(new PeriodSpending(0, List.of()));
@@ -294,12 +298,11 @@ class ChallengeServiceTest {
                 .previousDailyLimit(20000)
                 .newDailyLimit(22000)
                 .build();
-        List<ChallengeDay> days = List.of(
-                ChallengeDay.of(challenge, LocalDate.of(2026, 6, 1), 5000, DayStatus.SUCCESS, 20000),
-                ChallengeDay.of(challenge, selectedDate, 15000, DayStatus.SUCCESS, 20000));
         when(challengeRepository.findActiveOnDate(USER, selectedDate))
                 .thenReturn(Optional.of(challenge));
-        when(challengeDayRepository.findByChallenge_Id(10L)).thenReturn(days);
+        when(expenseService.getDailySpending(USER, LocalDate.of(2026, 6, 1), selectedDate))
+                .thenReturn(Map.of(LocalDate.of(2026, 6, 1), 5000, selectedDate, 15000));
+        when(expenseService.getDaySpending(USER, selectedDate)).thenReturn(new DaySpending(15000, true));
         when(challengeAdjustmentRepository.findByChallenge_IdOrderByEffectiveDateAscIdAsc(10L))
                 .thenReturn(List.of(laterAdjustment));
 
@@ -436,12 +439,9 @@ class ChallengeServiceTest {
     void current_consumptionState() {
         Challenge ch = inProgress(LocalDate.of(2026, 6, 1));
         LocalDate today = LocalDate.of(2026, 6, 5);
-        ChallengeDay todayRow = ChallengeDay.of(ch, today, 15000, DayStatus.OVER, ch.getDailyLimit());
         when(challengeRepository.findActiveOnDate(USER, today))
                 .thenReturn(Optional.of(ch));
-        when(challengeDayRepository.findByChallenge_Id(any())).thenReturn(List.of(todayRow));
-        when(challengeDayRepository.findByChallenge_IdAndDayDate(any(), any()))
-                .thenReturn(Optional.of(todayRow));
+        when(expenseService.getDaySpending(USER, today)).thenReturn(new DaySpending(15000, true));
 
         CurrentChallengeResponse res = serviceAt(today).getCurrent(USER);
 
@@ -713,8 +713,6 @@ class ChallengeServiceTest {
         LocalDate today = LocalDate.of(2026, 6, 5); // 6/1~6/4 미기록, 오늘도 기록 없음
         when(challengeRepository.findActiveOnDate(USER, today))
                 .thenReturn(Optional.of(ch));
-        when(challengeDayRepository.findByChallenge_Id(any())).thenReturn(List.of());
-        when(challengeDayRepository.findByChallenge_IdAndDayDate(any(), any())).thenReturn(Optional.empty());
 
         CurrentChallengeResponse res = serviceAt(today).getCurrent(USER);
 
@@ -730,8 +728,6 @@ class ChallengeServiceTest {
         LocalDate today = LocalDate.of(2026, 6, 3);
         Challenge ch = inProgressWithId(10L, LocalDate.of(2026, 6, 1));
         when(challengeRepository.findActiveOnDate(USER, today)).thenReturn(Optional.of(ch));
-        when(challengeDayRepository.findByChallenge_Id(10L)).thenReturn(List.of());
-        when(challengeDayRepository.findByChallenge_IdAndDayDate(10L, today)).thenReturn(Optional.empty());
         when(expenseService.hasDayRecord(USER, LocalDate.of(2026, 6, 2))).thenReturn(false);
         when(expenseService.hasDayRecord(USER, LocalDate.of(2026, 6, 1))).thenReturn(false);
 
@@ -748,8 +744,6 @@ class ChallengeServiceTest {
         LocalDate today = LocalDate.of(2026, 6, 4);
         Challenge ch = inProgressWithId(10L, LocalDate.of(2026, 6, 1));
         when(challengeRepository.findActiveOnDate(USER, today)).thenReturn(Optional.of(ch));
-        when(challengeDayRepository.findByChallenge_Id(10L)).thenReturn(List.of());
-        when(challengeDayRepository.findByChallenge_IdAndDayDate(10L, today)).thenReturn(Optional.empty());
         when(expenseService.hasDayRecord(eq(USER), any(LocalDate.class))).thenReturn(false);
 
         CurrentChallengeResponse res = serviceAt(today).getCurrent(USER);
@@ -789,8 +783,6 @@ class ChallengeServiceTest {
         LocalDate today = LocalDate.of(2026, 6, 5);
         Challenge ch = inProgressWithId(10L, LocalDate.of(2026, 6, 1));
         when(challengeRepository.findActiveOnDate(USER, today)).thenReturn(Optional.of(ch));
-        when(challengeDayRepository.findByChallenge_Id(10L)).thenReturn(List.of());
-        when(challengeDayRepository.findByChallenge_IdAndDayDate(10L, today)).thenReturn(Optional.empty());
         when(expenseService.hasDayRecord(USER, LocalDate.of(2026, 6, 4))).thenReturn(false);
         when(expenseService.hasDayRecord(USER, LocalDate.of(2026, 6, 3))).thenReturn(true);
 
@@ -810,14 +802,12 @@ class ChallengeServiceTest {
                 .budgetTotal(70000).dailyLimit(10000).build();
         ReflectionTestUtils.setField(ch, "id", 10L);
         when(challengeRepository.findActiveOnDate(USER, today)).thenReturn(Optional.of(ch));
-        when(challengeDayRepository.findByChallenge_Id(10L)).thenReturn(List.of());
-        when(challengeDayRepository.findByChallenge_IdAndDayDate(10L, today)).thenReturn(Optional.empty());
 
         CurrentChallengeResponse res = serviceAt(today).getCurrent(USER);
 
         assertThat(res.expenseInputState()).isEqualTo(ExpenseInputState.NORMAL);
         assertThat(ch.getStatus()).isEqualTo(ChallengeStatus.IN_PROGRESS);
-        verifyNoInteractions(expenseService);
+        verify(expenseService, never()).hasDayRecord(any(), any());
     }
 
     @Test

--- a/src/test/java/Hampouch/server/domain/challenge/service/ChallengeServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/service/ChallengeServiceTest.java
@@ -1318,8 +1318,8 @@ class ChallengeServiceTest {
         when(challengeRepository.findFirstByUserIdAndStatusInOrderByCreatedAtDescIdDesc(
                 USER, RECOMMENDATION_STATUSES))
                 .thenReturn(Optional.of(prev));
-        when(challengeDayRepository.findByChallenge_Id(30L)).thenReturn(List.of(
-                ChallengeDay.of(prev, LocalDate.of(2026, 6, 1), 340000, DayStatus.OVER, prev.getDailyLimit())));
+        when(expenseService.getDailySpending(USER, LocalDate.of(2026, 6, 1), prev.getEndDate()))
+                .thenReturn(Map.of(LocalDate.of(2026, 6, 1), 340000));
 
         RecommendationResponse res = serviceAt(LocalDate.of(2026, 7, 10)).getRecommendation(USER);
 
@@ -1335,8 +1335,8 @@ class ChallengeServiceTest {
         when(challengeRepository.findFirstByUserIdAndStatusInOrderByCreatedAtDescIdDesc(
                 USER, RECOMMENDATION_STATUSES))
                 .thenReturn(Optional.of(prev));
-        when(challengeDayRepository.findByChallenge_Id(30L)).thenReturn(List.of(
-                ChallengeDay.of(prev, LocalDate.of(2026, 6, 1), 100, DayStatus.SUCCESS, 100)));
+        when(expenseService.getDailySpending(USER, LocalDate.of(2026, 6, 1), prev.getEndDate()))
+                .thenReturn(Map.of(LocalDate.of(2026, 6, 1), 100));
 
         RecommendationResponse res = serviceAt(LocalDate.of(2026, 7, 10)).getRecommendation(USER);
 
@@ -1363,8 +1363,8 @@ class ChallengeServiceTest {
         when(challengeRepository.findFirstByUserIdAndStatusInOrderByCreatedAtDescIdDesc(
                 USER, RECOMMENDATION_STATUSES))
                 .thenReturn(Optional.of(prev));
-        when(challengeDayRepository.findByChallenge_Id(30L)).thenReturn(List.of(
-                ChallengeDay.of(prev, LocalDate.of(2026, 6, 1), 101, DayStatus.OVER, 100)));
+        when(expenseService.getDailySpending(USER, LocalDate.of(2026, 6, 1), prev.getEndDate()))
+                .thenReturn(Map.of(LocalDate.of(2026, 6, 1), 101));
 
         assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 7, 10)).getRecommendation(USER))
                 .isInstanceOf(IllegalStateException.class)
@@ -1378,7 +1378,6 @@ class ChallengeServiceTest {
         when(challengeRepository.findFirstByUserIdAndStatusInOrderByCreatedAtDescIdDesc(
                 USER, RECOMMENDATION_STATUSES))
                 .thenReturn(Optional.of(prev));
-        when(challengeDayRepository.findByChallenge_Id(30L)).thenReturn(List.of());
 
         RecommendationResponse res = serviceAt(LocalDate.of(2026, 7, 10)).getRecommendation(USER);
 
@@ -1394,8 +1393,8 @@ class ChallengeServiceTest {
         when(challengeRepository.findFirstByUserIdAndStatusInOrderByCreatedAtDescIdDesc(
                 USER, RECOMMENDATION_STATUSES))
                 .thenReturn(Optional.of(prev));
-        when(challengeDayRepository.findByChallenge_Id(30L)).thenReturn(List.of(
-                ChallengeDay.of(prev, LocalDate.of(2026, 6, 1), 300000, DayStatus.OVER, prev.getDailyLimit())));
+        when(expenseService.getDailySpending(USER, LocalDate.of(2026, 6, 1), prev.getEndDate()))
+                .thenReturn(Map.of(LocalDate.of(2026, 6, 1), 300000));
 
         RecommendationResponse res = serviceAt(LocalDate.of(2026, 7, 10)).getRecommendation(USER);
 
@@ -1415,8 +1414,6 @@ class ChallengeServiceTest {
         when(challengeRepository.findFirstByUserIdAndStatusInOrderByCreatedAtDescIdDesc(
                 USER, RECOMMENDATION_STATUSES))
                 .thenReturn(Optional.of(givenUp));
-        when(challengeDayRepository.findByChallenge_Id(31L)).thenReturn(List.of(
-                ChallengeDay.of(givenUp, LocalDate.of(2026, 7, 1), 4000, DayStatus.SUCCESS, 10000)));
 
         RecommendationResponse res = serviceAt(LocalDate.of(2026, 7, 10)).getRecommendation(USER);
 
@@ -1436,8 +1433,6 @@ class ChallengeServiceTest {
         when(challengeRepository.findFirstByUserIdAndStatusInOrderByCreatedAtDescIdDesc(
                 USER, RECOMMENDATION_STATUSES))
                 .thenReturn(Optional.of(voided));
-        when(challengeDayRepository.findByChallenge_Id(32L)).thenReturn(List.of(
-                ChallengeDay.of(voided, LocalDate.of(2026, 7, 1), 4000, DayStatus.SUCCESS, 10000)));
 
         RecommendationResponse res = serviceAt(LocalDate.of(2026, 7, 10)).getRecommendation(USER);
 
@@ -1452,7 +1447,6 @@ class ChallengeServiceTest {
         Challenge expired = inProgress(LocalDate.of(2026, 6, 1));
         ReflectionTestUtils.setField(expired, "id", 20L);
         when(challengeRepository.findInProgress(USER)).thenReturn(Optional.of(expired));
-        when(challengeDayRepository.findByChallenge_Id(20L)).thenReturn(List.of());
         when(challengeRepository.findFirstByUserIdAndStatusInOrderByCreatedAtDescIdDesc(
                 USER, RECOMMENDATION_STATUSES))
                 .thenReturn(Optional.of(expired));

--- a/src/test/java/Hampouch/server/domain/expense/repository/ExpenseRepositoryTest.java
+++ b/src/test/java/Hampouch/server/domain/expense/repository/ExpenseRepositoryTest.java
@@ -168,6 +168,23 @@ class ExpenseRepositoryTest {
     }
 
     @Test
+    @DisplayName("findByUser_IdAndRecordDateBetween은 그 유저의 기간 내 '오늘은 안 썼어요' 기록만 돌려주고 기간 밖·남의 기록은 뺀다 (#101 확장 — 캘린더용)")
+    void noSpendDay_findByUserIdAndRecordDateBetween_filtersRangeAndOwner() {
+        User other = userRepository.save(User.createLocalUser("other@hampouch.com", "encoded", "포치other"));
+        LocalDate inRange = LocalDate.of(2026, 6, 5);
+        LocalDate outOfRange = LocalDate.of(2026, 7, 1);
+        noSpendDayRepository.saveAndFlush(NoSpendDay.of(user, inRange));
+        noSpendDayRepository.saveAndFlush(NoSpendDay.of(user, outOfRange));
+        noSpendDayRepository.saveAndFlush(NoSpendDay.of(other, inRange));
+
+        List<NoSpendDay> result = noSpendDayRepository.findByUser_IdAndRecordDateBetween(
+                user.getId(), LocalDate.of(2026, 6, 1), LocalDate.of(2026, 6, 30));
+
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().getRecordDate()).isEqualTo(inRange);
+    }
+
+    @Test
     @DisplayName("findTopByUser_IdAndStatusAndIdNot...는 삭제 대상(id로 제외)을 뺀 나머지 ACTIVE 지출 중 expenseDate가 가장 최근인 것을 찾는다")
     void findTopByUserAndStatusAndIdNot_findsMostRecentRemainingActiveExpense() {
         Expense older = expenseRepository.save(

--- a/src/test/java/Hampouch/server/domain/expense/service/ExpenseServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/expense/service/ExpenseServiceTest.java
@@ -22,6 +22,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.*;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -1096,6 +1097,35 @@ class ExpenseServiceTest {
         DaySpending result = service().getDaySpending(OWNER, date);
 
         assertThat(result).isEqualTo(new DaySpending(0, true));
+    }
+
+    // ---------- getDailySpending ----------
+
+    @Test
+    @DisplayName("getDailySpending은 리포지토리의 날짜별 합계를 Map<LocalDate,Integer>로 옮겨 담는다 (#101 확장 — Challenge 기간 집계용)")
+    void getDailySpending_buildsMapFromRepository() {
+        LocalDate start = LocalDate.of(2026, 6, 1);
+        LocalDate end = LocalDate.of(2026, 6, 10);
+        when(expenseRepository.sumGroupedByDate(OWNER, ExpenseStatus.ACTIVE, start, end))
+                .thenReturn(List.of(
+                        new ExpenseDailyTotal(LocalDate.of(2026, 6, 3), 8000L),
+                        new ExpenseDailyTotal(LocalDate.of(2026, 6, 7), 15000L)));
+
+        Map<LocalDate, Integer> result = service().getDailySpending(OWNER, start, end);
+
+        assertThat(result).containsExactlyInAnyOrderEntriesOf(Map.of(
+                LocalDate.of(2026, 6, 3), 8000,
+                LocalDate.of(2026, 6, 7), 15000));
+    }
+
+    @Test
+    @DisplayName("지출이 없는 기간은 빈 맵을 반환한다 — 호출부가 getOrDefault(date, 0)으로 읽는 전제")
+    void getDailySpending_returnsEmptyMapWhenNothingLogged() {
+        LocalDate start = LocalDate.of(2026, 6, 1);
+        LocalDate end = LocalDate.of(2026, 6, 10);
+        when(expenseRepository.sumGroupedByDate(OWNER, ExpenseStatus.ACTIVE, start, end)).thenReturn(List.of());
+
+        assertThat(service().getDailySpending(OWNER, start, end)).isEmpty();
     }
 
     // ---------- fixtures ----------


### PR DESCRIPTION
## 📎연관된 이슈

- close: #101

## 📄 작업 내용 요약

`ChallengeDay`는 실제로는 테스트/시드 전용 API(`POST /days`, `upsertDay`)로만 채워져서 운영 환경에서는 사실상 빈 테이블입니다. 그 결과 이 테이블을 읽던 모든 홈/캘린더/결과/히스토리/추천 조회가 실제 지출과 무관한 값을 내놓고 있었습니다. #228 (지출 변경 가능 날짜 3규칙)이 먼저 머지되어 "종료된 챌린지 기간의 지출은 절대 안 바뀐다"는 전제가 보장된 상태에서, 아래 6개 읽기 경로를 실제 `Expense`/`NoSpendDay` 기반으로 옮겼습니다.

- `getCurrent`(양쪽 오버로드) — `buildChallengeResponse`가 `expenseService.getDailySpending`/`getDaySpending`으로 진행도·소비 현황 계산
- `getCalendar` — 지출 있는 날 ∪ '오늘은 안 썼어요' 선언된 날을 배치 조회로 합쳐 상태 계산
- `getResult` / `applyDueFinalization`(정기 확정 경로) — 기간 지출 집계로 성패 확정
- `getHistory`/`summarizeCompletedChallenges` — 챌린지별 배치 조회 대신 전체 챌린지 범위를 아우르는 단일 Expense 쿼리로 전환
- `getRecommendation` — 직전 챌린지 집계를 동일하게 전환

## 👀 중요 변경 사항

- **`challenge_day` 테이블·`ChallengeDay` 엔티티·`ChallengeDayRepository`·`upsertDay()`의 쓰기 동작은 이번에 전혀 건드리지 않았습니다.** 오직 읽기 경로만 이관했습니다. `ChallengeService`에서 `challengeDayRepository`를 쓰는 곳은 `transferSameDayRecord`(포기 후 재시작 시 당일 기록 이관), `upsertDay` 본문, `adjustGoal`의 미래 날짜 재판정 3곳만 남았습니다.
- `ChallengeCalculator`는 기존 `List<ChallengeDay>` 기반 메서드를 전혀 수정하지 않고, `Map<LocalDate, Integer>` 기반 오버로드 2개(`summarizeThrough`, `currentStreakAsOf`)만 추가하는 방식으로 `upsertDay` 쪽 호출부를 안전하게 보존했습니다.
- 락 재검토: `getCurrent`/`getResult`/`close`/`getRecommendation`은 `UserOperationLock.lock()`(사용자 행 `SELECT ... FOR UPDATE`)을 쥔 채로 동작하지만, 이번에 바뀐 조회는 모두 "그 챌린지 자신의 시작~종료일" 범위 그대로라 락 보유 시간에 변화가 없습니다. 유일하게 조회 범위가 넓어진 `getHistory`는 애초에 이 락을 전혀 타지 않는 순수 읽기 경로라 락과는 무관합니다.

## 🔖 Uncompleted Tasks

없음 — 계획했던 8단계(캘린더/현황/결과/히스토리/추천 전환 + 통합 테스트 보강) 모두 완료했고, `./gradlew test`(H2, 898개) + `./gradlew mysqlTest`(실 MySQL) 전체 통과 확인했습니다.

## 📢 To Reviewers

- `ChallengeService.buildChallengeResponse`가 `days`/`selectedDay` 파라미터 대신 `userId`를 받는 시그니처로 바뀌었습니다.
- `ChallengeServiceTest`/`ChallengeFlowIntegrationTest`의 스텁·시딩을 `challengeDayRepository` → `expenseService.getDailySpending`/`getDaySpending` 및 실제 `Expense` row로 교체했습니다 — 리뷰 시 기존 테스트 의도(기대값)가 그대로 유지됐는지 확인해주시면 감사하겠습니다.