### PR TITLE
feat: 배포 검증에 앱 컨테이너 uptime 활용 및 불필요한 재시작 검증 제외

### DIFF
--- a/scripts/deployment/README.md
+++ b/scripts/deployment/README.md
@@ -26,7 +26,7 @@
 Datadog 서비스가 있는 배포에서는 `datadog_verification.py deployment`가 추가로 실행된다.
 
 1. 앱과 MySQL의 컨테이너 표준 출력에 이번 SHA를 포함한 배포 표식을 남긴다.
-2. 배포 시작 시각 이후에 호스트 메모리, 앱 컨테이너 메모리, 컨테이너 재시작 횟수, JVM 메모리, MySQL 연결 지표가 도착했는지 Datadog Metrics API로 확인한다.
+2. 배포 시작 시각 이후에 호스트 메모리, 앱 컨테이너 메모리, 앱 컨테이너 uptime, JVM 메모리, MySQL 연결 지표가 도착했는지 Datadog Metrics API로 확인한다.
 3. 같은 시각 이후 앱과 MySQL의 배포 표식이 Datadog Logs API에서 조회되는지 확인한다.
 4. `datadog-verification.json`에 기록된 여섯 모니터의 이름, 종류, 쿼리, 임계치, 필수 옵션과 태그가 실제 설정과 같은지 확인한다.
 5. 각 모니터가 `published` 상태이고 활성 downtime이 없으며, 승인된 알림 수신처가 메시지에 포함됐는지 확인한다.
@@ -39,6 +39,10 @@ Datadog 서비스가 있는 배포에서는 `datadog_verification.py deployment`
 - `DD_APP_KEY`는 `timeseries_query`, `logs_read_data`, `monitors_read`, `monitors_downtime` 권한만 가진 Application Key를 사용한다.
 - `DD_MONITOR_CONTAINER_MEMORY_ID`, `DD_MONITOR_CONTAINER_OOM_ID`, `DD_MONITOR_CONTAINER_RESTART_ID`, `DD_MONITOR_APP_READINESS_ID`, `DD_MONITOR_MYSQL_CONNECTIONS_ID`, `DD_ALERT_TEST_MONITOR_ID`에는 실제 모니터 ID를 넣는다.
 - `DD_REQUIRED_NOTIFICATION_HANDLES`에는 담당자가 승인한 Datadog 알림 수신처를 쉼표로 구분해 넣는다.
+
+배포 데이터 도착성 검증은 실행 중인 앱 컨테이너에서 지속적으로 수집되는
+`container.uptime`을 사용한다. `container.restarts`는 배포 성공 조건이 아니라
+실제 컨테이너 재시작을 감지하는 모니터에만 사용한다.
 
 모니터 쿼리와 임계치는 `datadog-verification.json`이 정본이다. 컨테이너 재시작 모니터는 `container.restarts`가 끊겨도 침묵하지 않고 No Data를 알리도록 `on_missing_data=show_and_notify_no_data`를 사용한다. 변경하려면 실제 Datadog 설정과 이 파일을 함께 변경하고 자원 임계치와 알림 수신처는 담당자 승인을 먼저 받는다.
 

--- a/scripts/deployment/datadog-verification.json
+++ b/scripts/deployment/datadog-verification.json
@@ -9,8 +9,8 @@
       "query": "max:container.memory.working_set{env:prod,container_name:hampouch-server}"
     },
     {
-      "name": "container-restarts",
-      "query": "max:container.restarts{env:prod}"
+      "name": "app-container-uptime",
+      "query": "max:container.uptime{env:prod,container_name:hampouch-server}"
     },
     {
       "name": "jvm-memory",

--- a/scripts/deployment/test_datadog_monitoring_contract.py
+++ b/scripts/deployment/test_datadog_monitoring_contract.py
@@ -10,9 +10,9 @@ ROOT = Path(__file__).resolve().parents[2]
 
 class DatadogMonitoringContractTest(unittest.TestCase):
     def test_github_workflow_runs_at_ten_kst_and_uses_only_deployed_files(self):
-        workflow = (ROOT / ".github/workflows/datadog-alert-path.yml").read_text(
-            encoding="utf-8"
-        )
+        workflow = (
+            ROOT / ".github/workflows/datadog-alert-path.yml"
+        ).read_text(encoding="utf-8")
 
         self.assertIn("workflow_dispatch:", workflow)
         self.assertIn("schedule:", workflow)
@@ -21,38 +21,80 @@ class DatadogMonitoringContractTest(unittest.TestCase):
         self.assertNotIn("scp ", workflow)
         self.assertIn("datadog_verification.py alert-path", workflow)
 
-    def test_restart_monitor_requires_fresh_metric_and_notifies_on_missing_data(self):
+    def test_deployment_uses_container_uptime_and_keeps_restart_monitor_contract(
+        self,
+    ):
         config = json.loads(
             (
                 ROOT / "scripts/deployment/datadog-verification.json"
             ).read_text(encoding="utf-8")
         )
-        metric_queries = {metric["query"] for metric in config["metrics"]}
+
+        metrics_by_name = {
+            metric["name"]: metric["query"]
+            for metric in config["metrics"]
+        }
+
         restart_monitor = next(
             monitor
             for monitor in config["monitors"]
             if monitor["id_env"] == "DD_MONITOR_CONTAINER_RESTART_ID"
         )
 
-        self.assertIn("max:container.restarts{env:prod}", metric_queries)
+        self.assertEqual(
+            "max:container.uptime{env:prod,container_name:hampouch-server}",
+            metrics_by_name["app-container-uptime"],
+        )
+
+        self.assertNotIn(
+            "container-restarts",
+            metrics_by_name,
+        )
+
+        self.assertEqual(
+            "change(avg(last_5m),last_5m):"
+            "max:container.restarts{env:prod} "
+            "by {container_name} > 0",
+            restart_monitor["query"],
+        )
+
         self.assertEqual(
             "show_and_notify_no_data",
             restart_monitor["options"]["on_missing_data"],
         )
-        self.assertNotIn("notify_no_data", restart_monitor["options"])
+
+        self.assertNotIn(
+            "notify_no_data",
+            restart_monitor["options"],
+        )
 
     def test_deployment_refreshes_an_agent_that_supports_restart_metrics(self):
-        compose = (ROOT / "docker-compose.prod.yml").read_text(encoding="utf-8")
+        compose = (
+            ROOT / "docker-compose.prod.yml"
+        ).read_text(encoding="utf-8")
+
         deployment = (
             ROOT / "scripts/deployment/deploy-and-verify.sh"
         ).read_text(encoding="utf-8")
+
         verification = (
             ROOT / "scripts/observability/verify-datadog.sh"
         ).read_text(encoding="utf-8")
 
-        self.assertIn("registry.datadoghq.com/agent:7.82.1", compose)
-        self.assertIn('"${compose[@]}" pull datadog', deployment)
-        self.assertIn("MIN_DATADOG_AGENT_VERSION:-7.82.1", verification)
+        self.assertIn(
+            "registry.datadoghq.com/agent:7.82.1",
+            compose,
+        )
+
+        self.assertIn(
+            '"${compose[@]}" pull datadog',
+            deployment,
+        )
+
+        self.assertIn(
+            "MIN_DATADOG_AGENT_VERSION:-7.82.1",
+            verification,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- 배포 데이터 도착성 검증에 `container.uptime` 지표를 사용하도록 수정.
- 불필요한 재시작 지표(`container.restarts`)는 제외하고 모니터로만 사용.
- 관련 스크립트, Datadog 설정 파일 및 테스트 케이스 수정.

## 📎연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) closes #[issue number]

- close: #250 

## 📄 작업 내용 요약
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.

-

## 👀 중요 변경 사항
> API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요


## 🔖 Uncompleted Tasks
> 후속 작업 예정인 사항이 있다면 작성해주세요.

## 📢 To Reviewers
> Reviewer가 주로 확인해주었으면 하는 부분을 적어주세요.