### PR TITLE
fix: 비밀번호 재설정 인증 재사용 및 기존 세션 유지 문제 수정

### DIFF
--- a/src/main/java/Hampouch/server/domain/auth/entity/EmailVerification.java
+++ b/src/main/java/Hampouch/server/domain/auth/entity/EmailVerification.java
@@ -92,6 +92,12 @@ public class EmailVerification {
         this.verifiedAt = now;
     }
 
+    /** 비밀번호 재설정에 사용한 인증은 다시 사용할 수 없도록 즉시 소비한다. */
+    public void consume() {
+        this.verified = false;
+        this.verifiedAt = null;
+    }
+
     public boolean isVerificationExpired(LocalDateTime now) {
         return verifiedAt == null || verifiedAt.plusHours(1).isBefore(now);
     }

--- a/src/main/java/Hampouch/server/domain/auth/entity/EmailVerification.java
+++ b/src/main/java/Hampouch/server/domain/auth/entity/EmailVerification.java
@@ -92,10 +92,11 @@ public class EmailVerification {
         this.verifiedAt = now;
     }
 
-    /** 비밀번호 재설정에 사용한 인증은 다시 사용할 수 없도록 즉시 소비한다. */
-    public void consume() {
+    /** 비밀번호 재설정에 사용한 인증은 기존 코드로 다시 인증할 수 없도록 즉시 소비한다. */
+    public void consume(LocalDateTime now) {
         this.verified = false;
         this.verifiedAt = null;
+        this.expiredAt = now.minusSeconds(1);
     }
 
     public boolean isVerificationExpired(LocalDateTime now) {

--- a/src/main/java/Hampouch/server/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/Hampouch/server/domain/auth/repository/RefreshTokenRepository.java
@@ -20,7 +20,7 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
     @Query("SELECT r FROM RefreshToken r WHERE r.tokenHash = :tokenHash")
     Optional<RefreshToken> findByTokenHashForUpdate(@Param("tokenHash") String tokenHash);
 
-    @Modifying(clearAutomatically = true)
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("UPDATE RefreshToken r SET r.revoked = true WHERE r.userId = :userId AND r.revoked = false")
     void revokeAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/Hampouch/server/domain/auth/service/AuthService.java
+++ b/src/main/java/Hampouch/server/domain/auth/service/AuthService.java
@@ -20,10 +20,13 @@ import Hampouch.server.global.common.exception.domain.AuthErrorCode;
 import Hampouch.server.global.common.exception.domain.UserErrorCode;
 import Hampouch.server.global.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.dao.CannotAcquireLockException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.nio.charset.StandardCharsets;
@@ -55,6 +58,10 @@ public class AuthService {
     private final Clock clock;
     private final EmailSender emailSender;
     private final List<SocialTokenVerifier> socialTokenVerifiers;
+
+    @Lazy
+    @Autowired
+    private AuthService self;
 
     //이메일 인증번호 발송
     @Transactional
@@ -435,24 +442,29 @@ public class AuthService {
     }
 
     //비밀번호 재설정
-    @Transactional
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public void resetPassword(PasswordResetRequest request) {
         String email = request.email();
         LocalDateTime now = LocalDateTime.now(clock);
 
         EmailVerification verification = emailVerificationRepository
+                .findByEmailAndPurpose(email, VerificationPurpose.PASSWORD_RESET)
+                .orElseThrow(() -> new CustomException(AuthErrorCode.AUTH_EMAIL_NOT_VERIFIED));
+        validatePasswordResetVerification(verification, now);
+
+        // bcrypt는 인증 행 잠금 전에 끝내 동일 이메일의 다른 요청이 불필요하게 기다리지 않게 한다.
+        String encodedPassword = passwordEncoder.encode(request.newPassword());
+
+        self.resetPasswordLocked(email, encodedPassword);
+    }
+
+    @Transactional
+    public void resetPasswordLocked(String email, String encodedPassword) {
+        EmailVerification verification = emailVerificationRepository
                 .findByEmailAndPurposeForUpdate(email, VerificationPurpose.PASSWORD_RESET)
                 .orElseThrow(() -> new CustomException(AuthErrorCode.AUTH_EMAIL_NOT_VERIFIED));
-
-        if (!verification.isVerified()) {
-            throw new CustomException(AuthErrorCode.AUTH_EMAIL_NOT_VERIFIED);
-        }
-        if (verification.isVerificationExpired(now)) {
-            throw new CustomException(AuthErrorCode.AUTH_EMAIL_NOT_VERIFIED);
-        }
-
-        // 비밀번호 인코딩(bcrypt, 무거운 연산)은 조회와 무관한 순수 계산이라 먼저 계산해둔다.
-        String encodedPassword = passwordEncoder.encode(request.newPassword());
+        LocalDateTime lockedAt = LocalDateTime.now(clock);
+        validatePasswordResetVerification(verification, lockedAt);
 
         // login()과 같은 이유로 조회 자체를 잠금 조회로 만든다.
         User user = userRepository.findByEmailForUpdate(email)
@@ -467,8 +479,14 @@ public class AuthService {
         }
 
         user.resetPassword(encodedPassword);
-        verification.consume(now);
+        verification.consume(lockedAt);
         refreshTokenRepository.revokeAllByUserId(user.getId());
+    }
+
+    private void validatePasswordResetVerification(EmailVerification verification, LocalDateTime now) {
+        if (!verification.isVerified() || verification.isVerificationExpired(now)) {
+            throw new CustomException(AuthErrorCode.AUTH_EMAIL_NOT_VERIFIED);
+        }
     }
 
     // 회원 탈퇴

--- a/src/main/java/Hampouch/server/domain/auth/service/AuthService.java
+++ b/src/main/java/Hampouch/server/domain/auth/service/AuthService.java
@@ -440,7 +440,7 @@ public class AuthService {
         String email = request.email();
 
         EmailVerification verification = emailVerificationRepository
-                .findByEmailAndPurpose(email, VerificationPurpose.PASSWORD_RESET)
+                .findByEmailAndPurposeForUpdate(email, VerificationPurpose.PASSWORD_RESET)
                 .orElseThrow(() -> new CustomException(AuthErrorCode.AUTH_EMAIL_NOT_VERIFIED));
 
         if (!verification.isVerified()) {
@@ -466,6 +466,8 @@ public class AuthService {
         }
 
         user.resetPassword(encodedPassword);
+        verification.consume();
+        refreshTokenRepository.revokeAllByUserId(user.getId());
     }
 
     // 회원 탈퇴

--- a/src/main/java/Hampouch/server/domain/auth/service/AuthService.java
+++ b/src/main/java/Hampouch/server/domain/auth/service/AuthService.java
@@ -438,6 +438,7 @@ public class AuthService {
     @Transactional
     public void resetPassword(PasswordResetRequest request) {
         String email = request.email();
+        LocalDateTime now = LocalDateTime.now(clock);
 
         EmailVerification verification = emailVerificationRepository
                 .findByEmailAndPurposeForUpdate(email, VerificationPurpose.PASSWORD_RESET)
@@ -446,7 +447,7 @@ public class AuthService {
         if (!verification.isVerified()) {
             throw new CustomException(AuthErrorCode.AUTH_EMAIL_NOT_VERIFIED);
         }
-        if (verification.isVerificationExpired(LocalDateTime.now(clock))) {
+        if (verification.isVerificationExpired(now)) {
             throw new CustomException(AuthErrorCode.AUTH_EMAIL_NOT_VERIFIED);
         }
 
@@ -466,7 +467,7 @@ public class AuthService {
         }
 
         user.resetPassword(encodedPassword);
-        verification.consume();
+        verification.consume(now);
         refreshTokenRepository.revokeAllByUserId(user.getId());
     }
 

--- a/src/test/java/Hampouch/server/domain/auth/AuthFlowIntegrationTest.java
+++ b/src/test/java/Hampouch/server/domain/auth/AuthFlowIntegrationTest.java
@@ -17,6 +17,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -67,6 +68,9 @@ class AuthFlowIntegrationTest {
 
     @Autowired
     RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    PasswordEncoder passwordEncoder;
 
     @Autowired
     JdbcTemplate jdbc;
@@ -265,6 +269,61 @@ class AuthFlowIntegrationTest {
         } catch (NoSuchAlgorithmException e) {
             throw new IllegalStateException(e);
         }
+    }
+
+    @Test
+    void 비밀번호재설정에_사용한_인증은_소비되고_기존_refresh_token은_폐기된다() throws Exception {
+        String email = "password-reset-flow@example.com";
+        User user = userRepository.saveAndFlush(
+                User.createLocalUser(email, passwordEncoder.encode("oldPassword1"), "재설정플로우")
+        );
+
+        LocalDateTime now = LocalDateTime.now();
+        EmailVerification verification = EmailVerification.create(
+                email, "123456", VerificationPurpose.PASSWORD_RESET, now.plusMinutes(10)
+        );
+        verification.verify(now);
+        emailVerificationRepository.saveAndFlush(verification);
+
+        MvcResult loginResult = mvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"" + email + "\",\"password\":\"oldPassword1\"}"))
+                .andExpect(status().isOk())
+                .andReturn();
+        String oldRefreshToken = objectMapper.readTree(loginResult.getResponse().getContentAsString())
+                .path("data").path("refreshToken").asText();
+        RefreshToken refreshToken = refreshTokenRepository
+                .findByTokenHash(hashToken(oldRefreshToken))
+                .orElseThrow();
+
+        mvc.perform(patch("/api/auth/password/reset")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"" + email + "\",\"newPassword\":\"newPassword1\"}"))
+                .andExpect(status().isOk());
+
+        entityManager.flush();
+        entityManager.clear();
+
+        EmailVerification consumed = emailVerificationRepository
+                .findByEmailAndPurpose(email, VerificationPurpose.PASSWORD_RESET)
+                .orElseThrow();
+        RefreshToken revoked = refreshTokenRepository.findById(refreshToken.getId()).orElseThrow();
+
+        assertThat(consumed.isVerified()).isFalse();
+        assertThat(consumed.getVerifiedAt()).isNull();
+        assertThat(revoked.isRevoked()).isTrue();
+
+        mvc.perform(post("/api/auth/refresh")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"refreshToken\":\"" + oldRefreshToken + "\"}"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTH_REFRESH_TOKEN_REVOKED"));
+
+        mvc.perform(patch("/api/auth/password/reset")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"" + email + "\",\"newPassword\":\"anotherPassword1\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("AUTH_EMAIL_NOT_VERIFIED"));
     }
 
     @Test

--- a/src/test/java/Hampouch/server/domain/auth/AuthFlowIntegrationTest.java
+++ b/src/test/java/Hampouch/server/domain/auth/AuthFlowIntegrationTest.java
@@ -21,6 +21,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
@@ -272,6 +273,7 @@ class AuthFlowIntegrationTest {
     }
 
     @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     void 비밀번호재설정에_사용한_인증은_소비되고_기존_refresh_token은_폐기된다() throws Exception {
         String email = "password-reset-flow@example.com";
         User user = userRepository.saveAndFlush(
@@ -300,9 +302,6 @@ class AuthFlowIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"email\":\"" + email + "\",\"newPassword\":\"newPassword1\"}"))
                 .andExpect(status().isOk());
-
-        entityManager.flush();
-        entityManager.clear();
 
         EmailVerification consumed = emailVerificationRepository
                 .findByEmailAndPurpose(email, VerificationPurpose.PASSWORD_RESET)
@@ -397,7 +396,10 @@ class AuthFlowIntegrationTest {
                 .orElseThrow();
 
         assertThat(reissued.getId()).isEqualTo(verificationId);
-        assertThat(emailVerificationRepository.count()).isEqualTo(1);
+        assertThat(jdbc.queryForObject(
+                "SELECT COUNT(*) FROM email_verifications WHERE email = ? AND purpose = 'SIGNUP'",
+                Long.class, email
+        )).isEqualTo(1L);
         verify(emailSender, times(2))
                 .send(eq(email), anyString(), eq(VerificationPurpose.SIGNUP));
     }

--- a/src/test/java/Hampouch/server/domain/auth/AuthFlowIntegrationTest.java
+++ b/src/test/java/Hampouch/server/domain/auth/AuthFlowIntegrationTest.java
@@ -313,6 +313,13 @@ class AuthFlowIntegrationTest {
         assertThat(consumed.getVerifiedAt()).isNull();
         assertThat(revoked.isRevoked()).isTrue();
 
+        mvc.perform(post("/api/auth/email/verify")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"" + email
+                                + "\",\"code\":\"123456\",\"purpose\":\"PASSWORD_RESET\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("AUTH_EMAIL_CODE_EXPIRED"));
+
         mvc.perform(post("/api/auth/refresh")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"refreshToken\":\"" + oldRefreshToken + "\"}"))

--- a/src/test/java/Hampouch/server/domain/auth/AuthVerificationConcurrencyTest.java
+++ b/src/test/java/Hampouch/server/domain/auth/AuthVerificationConcurrencyTest.java
@@ -4,6 +4,8 @@ import Hampouch.server.domain.auth.entity.EmailVerification;
 import Hampouch.server.domain.auth.entity.VerificationPurpose;
 import Hampouch.server.domain.auth.repository.EmailVerificationRepository;
 import Hampouch.server.domain.auth.util.EmailSender;
+import Hampouch.server.domain.user.entity.User;
+import Hampouch.server.domain.user.repository.UserRepository;
 import Hampouch.server.global.mysql.MySqlContainerTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,6 +45,9 @@ class AuthVerificationConcurrencyTest {
 
     @Autowired
     EmailVerificationRepository emailVerificationRepository;
+
+    @Autowired
+    UserRepository userRepository;
 
     @MockitoBean
     EmailSender emailSender;
@@ -137,6 +142,49 @@ class AuthVerificationConcurrencyTest {
         }
     }
 
+    @Test
+    void 동일_인증으로_비밀번호재설정이_경쟁하면_한번만_성공한다() throws Exception {
+        String email = "reset-race-" + System.currentTimeMillis() + "@example.com";
+        userRepository.saveAndFlush(User.createLocalUser(email, "old-encoded", "재설정경쟁"));
+
+        LocalDateTime now = LocalDateTime.now();
+        EmailVerification verification = EmailVerification.create(
+                email, "123456", VerificationPurpose.PASSWORD_RESET, now.plusMinutes(10)
+        );
+        verification.verify(now);
+        emailVerificationRepository.saveAndFlush(verification);
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<HttpResult> firstCall = executor.submit(
+                    () -> callPasswordReset(email, "firstPassword1")
+            );
+            Future<HttpResult> secondCall = executor.submit(
+                    () -> callPasswordReset(email, "secondPassword1")
+            );
+
+            HttpResult first = firstCall.get(10, TimeUnit.SECONDS);
+            HttpResult second = secondCall.get(10, TimeUnit.SECONDS);
+
+            assertThat(Stream.of(first, second).filter(result -> result.status() == 200).count())
+                    .as("동일 인증은 한 요청만 소비할 수 있어야 한다")
+                    .isEqualTo(1);
+            assertThat(Stream.of(first, second).filter(result -> result.status() == 400).count())
+                    .isEqualTo(1);
+
+            HttpResult failed = first.status() == 400 ? first : second;
+            assertThat(failed.body()).contains("AUTH_EMAIL_NOT_VERIFIED");
+
+            EmailVerification consumed = emailVerificationRepository
+                    .findByEmailAndPurpose(email, VerificationPurpose.PASSWORD_RESET)
+                    .orElseThrow();
+            assertThat(consumed.isVerified()).isFalse();
+            assertThat(consumed.getVerifiedAt()).isNull();
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
     private HttpResult callSend(String email) {
         try {
             MvcResult result = mvc.perform(post("/api/auth/email/send")
@@ -169,6 +217,28 @@ class AuthVerificationConcurrencyTest {
                                       "purpose": "SIGNUP"
                                     }
                                     """.formatted(email, code)))
+                    .andReturn();
+
+            return new HttpResult(
+                    result.getResponse().getStatus(),
+                    result.getResponse().getContentAsString()
+            );
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private HttpResult callPasswordReset(String email, String newPassword) {
+        try {
+            MvcResult result = mvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                            .patch("/api/auth/password/reset")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {
+                                      "email": "%s",
+                                      "newPassword": "%s"
+                                    }
+                                    """.formatted(email, newPassword)))
                     .andReturn();
 
             return new HttpResult(

--- a/src/test/java/Hampouch/server/domain/auth/entity/EmailVerificationTest.java
+++ b/src/test/java/Hampouch/server/domain/auth/entity/EmailVerificationTest.java
@@ -63,14 +63,15 @@ class EmailVerificationTest {
     }
 
     @Test
-    void 인증을_소비하면_더이상_인증완료상태가_아니다() {
+    void 인증을_소비하면_인증완료상태가_해제되고_기존코드가_만료된다() {
         EmailVerification verification = create(now.plusMinutes(10));
         verification.verify(now);
 
-        verification.consume();
+        verification.consume(now);
 
         assertThat(verification.isVerified()).isFalse();
         assertThat(verification.getVerifiedAt()).isNull();
+        assertThat(verification.isExpired(now)).isTrue();
         assertThat(verification.isVerificationExpired(now)).isTrue();
     }
 

--- a/src/test/java/Hampouch/server/domain/auth/entity/EmailVerificationTest.java
+++ b/src/test/java/Hampouch/server/domain/auth/entity/EmailVerificationTest.java
@@ -63,6 +63,18 @@ class EmailVerificationTest {
     }
 
     @Test
+    void 인증을_소비하면_더이상_인증완료상태가_아니다() {
+        EmailVerification verification = create(now.plusMinutes(10));
+        verification.verify(now);
+
+        verification.consume();
+
+        assertThat(verification.isVerified()).isFalse();
+        assertThat(verification.getVerifiedAt()).isNull();
+        assertThat(verification.isVerificationExpired(now)).isTrue();
+    }
+
+    @Test
     void 인증후_1시간_지나면_만료다() {
         EmailVerification v = create(now.plusMinutes(10));
         v.verify(now);

--- a/src/test/java/Hampouch/server/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/auth/service/AuthServiceTest.java
@@ -813,7 +813,7 @@ class AuthServiceTest {
 
     @Test
     void 비밀번호재설정_인증기록이_없으면_예외() {
-        when(emailVerificationRepository.findByEmailAndPurpose(
+        when(emailVerificationRepository.findByEmailAndPurposeForUpdate(
                 "test@example.com", VerificationPurpose.PASSWORD_RESET
         )).thenReturn(Optional.empty());
 
@@ -830,7 +830,7 @@ class AuthServiceTest {
     @Test
     void 비밀번호재설정_가입안된_이메일이면_예외() {
         EmailVerification verification = verifiedPasswordResetVerification();
-        when(emailVerificationRepository.findByEmailAndPurpose(
+        when(emailVerificationRepository.findByEmailAndPurposeForUpdate(
                 "test@example.com", VerificationPurpose.PASSWORD_RESET
         )).thenReturn(Optional.of(verification));
         when(userRepository.findByEmailForUpdate("test@example.com"))
@@ -849,7 +849,7 @@ class AuthServiceTest {
     @Test
     void 비밀번호재설정_소셜계정이면_예외() {
         EmailVerification verification = verifiedPasswordResetVerification();
-        when(emailVerificationRepository.findByEmailAndPurpose(
+        when(emailVerificationRepository.findByEmailAndPurposeForUpdate(
                 "test@example.com", VerificationPurpose.PASSWORD_RESET
         )).thenReturn(Optional.of(verification));
 
@@ -870,7 +870,7 @@ class AuthServiceTest {
     @Test
     void 비밀번호재설정_탈퇴한_회원이면_예외() {
         EmailVerification verification = verifiedPasswordResetVerification();
-        when(emailVerificationRepository.findByEmailAndPurpose(
+        when(emailVerificationRepository.findByEmailAndPurposeForUpdate(
                 "test@example.com", VerificationPurpose.PASSWORD_RESET
         )).thenReturn(Optional.of(verification));
 
@@ -891,7 +891,7 @@ class AuthServiceTest {
     @Test
     void 비밀번호재설정_정상요청이면_비밀번호가_변경된다() {
         EmailVerification verification = verifiedPasswordResetVerification();
-        when(emailVerificationRepository.findByEmailAndPurpose(
+        when(emailVerificationRepository.findByEmailAndPurposeForUpdate(
                 "test@example.com", VerificationPurpose.PASSWORD_RESET
         )).thenReturn(Optional.of(verification));
 
@@ -906,6 +906,9 @@ class AuthServiceTest {
         authService.resetPassword(request);
 
         assertThat(user.getPassword()).isEqualTo("new-encoded");
+        assertThat(verification.isVerified()).isFalse();
+        assertThat(verification.getVerifiedAt()).isNull();
+        verify(refreshTokenRepository).revokeAllByUserId(user.getId());
     }
 
     // ========== 10. deleteMe ==========

--- a/src/test/java/Hampouch/server/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/auth/service/AuthServiceTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.InOrder;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
@@ -80,6 +81,7 @@ class AuthServiceTest {
                 emailSender,
                 List.of(socialTokenVerifier)
         );
+        setField(authService, "self", authService);
     }
 
     private User localUser(String email, String encodedPassword, boolean deleted) {
@@ -813,7 +815,7 @@ class AuthServiceTest {
 
     @Test
     void 비밀번호재설정_인증기록이_없으면_예외() {
-        when(emailVerificationRepository.findByEmailAndPurposeForUpdate(
+        when(emailVerificationRepository.findByEmailAndPurpose(
                 "test@example.com", VerificationPurpose.PASSWORD_RESET
         )).thenReturn(Optional.empty());
 
@@ -830,6 +832,9 @@ class AuthServiceTest {
     @Test
     void 비밀번호재설정_가입안된_이메일이면_예외() {
         EmailVerification verification = verifiedPasswordResetVerification();
+        when(emailVerificationRepository.findByEmailAndPurpose(
+                "test@example.com", VerificationPurpose.PASSWORD_RESET
+        )).thenReturn(Optional.of(verification));
         when(emailVerificationRepository.findByEmailAndPurposeForUpdate(
                 "test@example.com", VerificationPurpose.PASSWORD_RESET
         )).thenReturn(Optional.of(verification));
@@ -849,6 +854,9 @@ class AuthServiceTest {
     @Test
     void 비밀번호재설정_소셜계정이면_예외() {
         EmailVerification verification = verifiedPasswordResetVerification();
+        when(emailVerificationRepository.findByEmailAndPurpose(
+                "test@example.com", VerificationPurpose.PASSWORD_RESET
+        )).thenReturn(Optional.of(verification));
         when(emailVerificationRepository.findByEmailAndPurposeForUpdate(
                 "test@example.com", VerificationPurpose.PASSWORD_RESET
         )).thenReturn(Optional.of(verification));
@@ -870,6 +878,9 @@ class AuthServiceTest {
     @Test
     void 비밀번호재설정_탈퇴한_회원이면_예외() {
         EmailVerification verification = verifiedPasswordResetVerification();
+        when(emailVerificationRepository.findByEmailAndPurpose(
+                "test@example.com", VerificationPurpose.PASSWORD_RESET
+        )).thenReturn(Optional.of(verification));
         when(emailVerificationRepository.findByEmailAndPurposeForUpdate(
                 "test@example.com", VerificationPurpose.PASSWORD_RESET
         )).thenReturn(Optional.of(verification));
@@ -891,6 +902,9 @@ class AuthServiceTest {
     @Test
     void 비밀번호재설정_정상요청이면_비밀번호가_변경된다() {
         EmailVerification verification = verifiedPasswordResetVerification();
+        when(emailVerificationRepository.findByEmailAndPurpose(
+                "test@example.com", VerificationPurpose.PASSWORD_RESET
+        )).thenReturn(Optional.of(verification));
         when(emailVerificationRepository.findByEmailAndPurposeForUpdate(
                 "test@example.com", VerificationPurpose.PASSWORD_RESET
         )).thenReturn(Optional.of(verification));
@@ -905,6 +919,12 @@ class AuthServiceTest {
         );
         authService.resetPassword(request);
 
+        InOrder order = inOrder(emailVerificationRepository, passwordEncoder);
+        order.verify(emailVerificationRepository).findByEmailAndPurpose(
+                "test@example.com", VerificationPurpose.PASSWORD_RESET);
+        order.verify(passwordEncoder).encode("newPassword1!");
+        order.verify(emailVerificationRepository).findByEmailAndPurposeForUpdate(
+                "test@example.com", VerificationPurpose.PASSWORD_RESET);
         assertThat(user.getPassword()).isEqualTo("new-encoded");
         assertThat(verification.isVerified()).isFalse();
         assertThat(verification.getVerifiedAt()).isNull();


### PR DESCRIPTION
## 📎연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) closes #[issue number]

- close: #258

## 📄 작업 내용 요약
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
- 비밀번호 재설정 성공 시 사용한 이메일 인증을 즉시 소비하도록 수정했습니다.
  - `verified = false`
  - `verifiedAt = null`
- 비밀번호 재설정 인증 행을 비관적 락으로 조회해 동일 인증을 사용한 동시 요청이 한 번만 성공하도록 함
- 비밀번호 재설정 성공 시 해당 사용자의 기존 refresh token을 모두 폐기하도록 수정
- refresh token 벌크 폐기 전에 영속성 컨텍스트의 변경 내용을 flush하도록 보완
  - 인증 소비와 비밀번호 변경 내용이 `clearAutomatically`로 유실되는 문제 방지
- 엔티티/서비스 단위 테스트와 실제 DB 통합 테스트, MySQL 동시성 테스트 추가

## 👀 중요 변경 사항
> API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요
- 비밀번호 재설정에 성공하면 기존에 로그인된 모든 세션의 refresh token이 폐기됩니다.
- 폐기된 refresh token으로 재발급을 요청하면 기존 계약대로 `401 AUTH_REFRESH_TOKEN_REVOKED`가 반환됩니다.
- 한 번 사용한 비밀번호 재설정 인증으로 다시 재설정을 요청하면 `400 AUTH_EMAIL_NOT_VERIFIED`가 반환됩니다.
- 동일 인증으로 비밀번호 재설정 요청이 동시에 들어와도 인증 행 잠금으로 한 요청만 성공합니다.


## 🔖 Uncompleted Tasks
> 후속 작업 예정인 사항이 있다면 작성해주세요.

## 📢 To Reviewers
> Reviewer가 주로 확인해주었으면 하는 부분을 적어주세요.
- 비밀번호 재설정 성공 시 인증 소비와 기존 refresh token 전체 폐기를 같은 트랜잭션에서 처리하는 흐름을 확인해 주세요.
- `revokeAllByUserId()`의 `flushAutomatically = true`가 벌크 업데이트 전 비밀번호·인증 상태 변경을 보존하는지 확인해 주세요.
- 동일 인증을 사용한 동시 재설정 요청이 한 번만 성공하도록 한 잠금 범위를 확인해 주세요.