### PR TITLE
fix: 게시글 삭제와 상호작용 요청의 동시성 정합성 보장

### DIFF
--- a/src/main/java/Hampouch/server/domain/community/service/PostService.java
+++ b/src/main/java/Hampouch/server/domain/community/service/PostService.java
@@ -749,7 +749,7 @@ public class PostService {
 
     //작성자와 게시글 유형 검증
     private Post findOwnedPost(Long userId, Long postId, PostType expectedType) {
-        Post post = postRepository.findById(postId).orElseThrow(() -> new CustomException(CommunityErrorCode.COMMUNITY_POST_NOT_FOUND));
+        Post post = findPostForUpdate(postId);
 
         if (!post.isOwnedBy(userId)) {
             throw new CustomException(CommunityErrorCode.COMMUNITY_NOT_POST_AUTHOR);

--- a/src/main/java/Hampouch/server/domain/community/service/PostService.java
+++ b/src/main/java/Hampouch/server/domain/community/service/PostService.java
@@ -259,8 +259,9 @@ public class PostService {
     //게시글 삭제
     @Transactional
     public void deletePost(Long userId, Long postId) {
-        Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new CustomException(CommunityErrorCode.COMMUNITY_POST_NOT_FOUND));
+        // 좋아요·북마크·댓글과 같은 게시글 락에서 직렬화한다.
+        // 삭제가 먼저면 뒤의 상호작용은 404, 상호작용이 먼저면 그 결과까지 삭제된다.
+        Post post = findPostForUpdate(postId);
 
         if (!post.isOwnedBy(userId)) {
             throw new CustomException(CommunityErrorCode.COMMUNITY_NOT_POST_AUTHOR);

--- a/src/test/java/Hampouch/server/domain/community/CommunityFlowIntegrationTest.java
+++ b/src/test/java/Hampouch/server/domain/community/CommunityFlowIntegrationTest.java
@@ -19,6 +19,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,6 +32,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -89,6 +91,9 @@ class CommunityFlowIntegrationTest {
 
     @Autowired
     EntityManager entityManager;
+
+    @Autowired
+    JdbcTemplate jdbc;
 
     private String bearer(Long userId) {
         return "Bearer " + jwtProvider.createAccessToken(userId, UserRole.USER);
@@ -1398,6 +1403,77 @@ class CommunityFlowIntegrationTest {
         assertThat(postRepository.findById(post.getId())
                 .orElseThrow()
                 .getLikeCount()).isZero();
+    }
+
+    @Test
+    void 게시글삭제와_상호작용이_경쟁해도_삭제후_연관데이터가_남지않는다() throws Exception {
+        assertDeleteRaceLeavesNoInteraction("like");
+        assertDeleteRaceLeavesNoInteraction("bookmark");
+        assertDeleteRaceLeavesNoInteraction("comment");
+    }
+
+    private void assertDeleteRaceLeavesNoInteraction(String interaction) throws Exception {
+        String suffix = interaction + "-" + System.nanoTime();
+        Long authorId = createUser("delete-race-author-" + suffix + "@example.com", UserRole.USER);
+        Long actorId = createUser("delete-race-actor-" + suffix + "@example.com", UserRole.USER);
+        Post post = postRepository.saveAndFlush(Post.create(
+                authorId, PostType.TIP, PostCategory.ETC,
+                "삭제 경쟁 " + interaction, "본문"
+        ));
+
+        String authorBearer = bearer(authorId);
+        String actorBearer = bearer(actorId);
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+
+        try {
+            Future<Integer> deleteStatus = executor.submit(() -> {
+                ready.countDown();
+                start.await();
+                return mvc.perform(delete("/api/community/posts/" + post.getId())
+                                .header("Authorization", authorBearer))
+                        .andReturn().getResponse().getStatus();
+            });
+            Future<Integer> interactionStatus = executor.submit(() -> {
+                ready.countDown();
+                start.await();
+                var request = switch (interaction) {
+                    case "like" -> post("/api/community/posts/" + post.getId() + "/likes")
+                            .header("Authorization", actorBearer);
+                    case "bookmark" -> post("/api/community/posts/" + post.getId() + "/bookmarks")
+                            .header("Authorization", actorBearer);
+                    case "comment" -> post("/api/community/posts/" + post.getId() + "/comments")
+                            .header("Authorization", actorBearer)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"parentCommentId\":null,\"content\":\"경쟁 댓글\"}");
+                    default -> throw new IllegalArgumentException("unknown interaction: " + interaction);
+                };
+                return mvc.perform(request).andReturn().getResponse().getStatus();
+            });
+
+            assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+            start.countDown();
+
+            assertThat(deleteStatus.get(10, TimeUnit.SECONDS)).isEqualTo(200);
+            assertThat(interactionStatus.get(10, TimeUnit.SECONDS)).isIn(200, 404);
+        } finally {
+            start.countDown();
+            executor.shutdownNow();
+        }
+
+        assertThat(postRepository.findById(post.getId())).isEmpty();
+        assertThat(countRows("post_like", post.getId())).isZero();
+        assertThat(countRows("post_bookmark", post.getId())).isZero();
+        assertThat(countRows("post_comment", post.getId())).isZero();
+    }
+
+    private int countRows(String table, Long postId) {
+        return jdbc.queryForObject(
+                "SELECT COUNT(*) FROM " + table + " WHERE post_id = ?",
+                Integer.class,
+                postId
+        );
     }
 
     @Test

--- a/src/test/java/Hampouch/server/domain/community/CommunityFlowIntegrationTest.java
+++ b/src/test/java/Hampouch/server/domain/community/CommunityFlowIntegrationTest.java
@@ -1406,7 +1406,8 @@ class CommunityFlowIntegrationTest {
     }
 
     @Test
-    void 게시글삭제와_상호작용이_경쟁해도_삭제후_연관데이터가_남지않는다() throws Exception {
+    void 게시글삭제와_수정및상호작용이_경쟁해도_삭제후_정합성이_유지된다() throws Exception {
+        assertDeleteRaceLeavesNoInteraction("edit");
         assertDeleteRaceLeavesNoInteraction("like");
         assertDeleteRaceLeavesNoInteraction("bookmark");
         assertDeleteRaceLeavesNoInteraction("comment");
@@ -1439,6 +1440,10 @@ class CommunityFlowIntegrationTest {
                 ready.countDown();
                 start.await();
                 var request = switch (interaction) {
+                    case "edit" -> patch("/api/community/posts/tips/" + post.getId())
+                            .header("Authorization", authorBearer)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"category\":\"ETC\",\"title\":\"경쟁 수정\",\"content\":\"수정 본문\",\"imageKeys\":[]}");
                     case "like" -> post("/api/community/posts/" + post.getId() + "/likes")
                             .header("Authorization", actorBearer);
                     case "bookmark" -> post("/api/community/posts/" + post.getId() + "/bookmarks")

--- a/src/test/java/Hampouch/server/domain/community/service/PostServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/community/service/PostServiceTest.java
@@ -1198,7 +1198,7 @@ class PostServiceTest {
         Post post = post(1L, 10L, PostType.FOOD_RECOMMEND, PostCategory.FOOD_RECOMMEND);
         PostImage image = PostImage.create(1L, "https://s3/delete.jpg", "community/posts/delete.jpg", 0);
 
-        when(postRepository.findById(1L)).thenReturn(Optional.of(post));
+        when(postRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(post));
         when(postImageRepository.findByPostIdOrderBySortOrderAsc(1L))
                 .thenReturn(List.of(image));
 
@@ -1221,7 +1221,7 @@ class PostServiceTest {
     @Test
     void 다른_사용자의_게시글은_삭제할수없다() {
         Post post = post(1L, 10L, PostType.TIP, PostCategory.COOKING);
-        when(postRepository.findById(1L)).thenReturn(Optional.of(post));
+        when(postRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(post));
 
         assertThatThrownBy(() -> postService.deletePost(99L, 1L))
                 .isInstanceOf(CustomException.class)

--- a/src/test/java/Hampouch/server/domain/community/service/PostServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/community/service/PostServiceTest.java
@@ -1074,7 +1074,7 @@ class PostServiceTest {
         PostImage oldImage = PostImage.create(1L, "https://s3/old.jpg", "community/posts/old.jpg", 0);
         PostImage keptImage = PostImage.create(1L, "https://s3/new.jpg", "community/posts/new.jpg", 1);
 
-        when(postRepository.findById(1L)).thenReturn(Optional.of(post));
+        when(postRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(post));
         when(imagePresignService.buildPublicUrl("community/posts/new.jpg")).thenReturn("https://s3/new.jpg");
         when(postImageRepository.findByPostIdOrderBySortOrderAsc(1L)).thenReturn(List.of(oldImage, keptImage));
 
@@ -1111,7 +1111,7 @@ class PostServiceTest {
                 5, 4, 5, "수정된 내용", List.of()
         );
 
-        when(postRepository.findById(2L)).thenReturn(Optional.of(post));
+        when(postRepository.findByIdForUpdate(2L)).thenReturn(Optional.of(post));
         when(foodPostDetailRepository.findByPostId(2L)).thenReturn(Optional.of(detail));
 
         PostMutationResponse response = postService.updateFoodPost(10L, 2L, request);
@@ -1148,7 +1148,7 @@ class PostServiceTest {
                 "https://invite.hampouch.com/battles/invite/NEW"
         );
 
-        when(postRepository.findById(3L)).thenReturn(Optional.of(post));
+        when(postRepository.findByIdForUpdate(3L)).thenReturn(Optional.of(post));
         when(battleRepository.findByBattleCode("NEW")).thenReturn(Optional.of(battle));
         when(recruitPostDetailRepository.findByPostId(3L)).thenReturn(Optional.of(detail));
 
@@ -1167,7 +1167,7 @@ class PostServiceTest {
         TipPostRequest request = new TipPostRequest(
                 "COOKING", "수정 제목", "수정 내용", List.of()
         );
-        when(postRepository.findById(1L)).thenReturn(Optional.of(post));
+        when(postRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(post));
 
         assertThatThrownBy(() -> postService.updateTipPost(99L, 1L, request))
                 .isInstanceOf(CustomException.class)
@@ -1183,7 +1183,7 @@ class PostServiceTest {
         TipPostRequest request = new TipPostRequest(
                 "COOKING", "수정 제목", "수정 내용", List.of()
         );
-        when(postRepository.findById(2L)).thenReturn(Optional.of(foodPost));
+        when(postRepository.findByIdForUpdate(2L)).thenReturn(Optional.of(foodPost));
 
         assertThatThrownBy(() -> postService.updateTipPost(10L, 2L, request))
                 .isInstanceOf(CustomException.class)


### PR DESCRIPTION
## 📎연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) closes #[issue number]

- close: #259

## 📄 작업 내용 요약
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
- 게시글 삭제가 좋아요·북마크·댓글 작성과 동시에 실행될 때 연관 데이터가 남거나 요청이 500으로 끝날 수 있는 경쟁 조건을 수정했습니다.
  - `PostService.deletePost()`가 게시글을 `findByIdForUpdate()`로 조회하도록 변경
  - 삭제와 좋아요·북마크·댓글 작성이 동일한 게시글 쓰기 락에서 직렬화되도록 통일
  - 삭제 단위 테스트를 잠금 조회 방식에 맞게 수정
  - 실제 MySQL에서 삭제와 좋아요·북마크·댓글 작성을 각각 동시에 실행하는 회귀 테스트 추가
  - 삭제 완료 후 게시글과 좋아요·북마크·댓글 행이 모두 제거됐는지 검증

## 👀 중요 변경 사항
> API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요
- 동시 요청의 처리 순서에 따라 상호작용 응답은 다음 중 하나가 됩니다.
- 상호작용이 먼저 게시글 락을 획득하면 `200`으로 처리된 후 게시글 삭제 시 함께 제거
- 삭제가 먼저 게시글 락을 획득하면 이후 상호작용은 `404 COMMUNITY_POST_NOT_FOUND`

## 🔖 Uncompleted Tasks
> 후속 작업 예정인 사항이 있다면 작성해주세요.

## 📢 To Reviewers
> Reviewer가 주로 확인해주었으면 하는 부분을 적어주세요.
- 게시글 삭제와 좋아요/북마크/댓글 작성이 동일한 `Post` 행의 비관적 쓰기 락으로 직렬화되는지 확인해주세요.