### PR TITLE
fix: 지출 상한 설정 및 지출 및 챌린지 domain int overflow 방어

### DIFF
--- a/src/main/java/Hampouch/server/domain/challenge/dto/CalendarResponse.java
+++ b/src/main/java/Hampouch/server/domain/challenge/dto/CalendarResponse.java
@@ -18,15 +18,11 @@ public record CalendarResponse(
         int month,
         List<DayView> days       // 그 달 안에서 기록 있는 날만
 ) {
-    /**
-     * days 배열의 원소 = 하루치 기록. 캘린더 응답에서만 쓰는 전용 부품이라 중첩으로 소속을 명시(여러 곳에서 쓰면 별도 파일로).
-     * View 접미사 = ChallengeDay 엔티티(저장 원본)를 화면에 필요한 필드만 추려 "바라본 모습"이라는 뜻
-     * (ChallengeView와 같은 관례 — 원본이 아니라 조회 전용 투영임을 이름으로 표시).
-     */
+    //days 배열의 원소 = 하루치 기록.
     public record DayView(
             LocalDate date,
             DayStatus status,
-            int spentAmount
+            long spentAmount
     ) {
     }
 }

--- a/src/main/java/Hampouch/server/domain/challenge/dto/ChallengeHistoryResponse.java
+++ b/src/main/java/Hampouch/server/domain/challenge/dto/ChallengeHistoryResponse.java
@@ -24,14 +24,14 @@ public record ChallengeHistoryResponse(List<Item> items) {
             LocalDate endDate,
             int durationDays,
             int budgetTotal,   // 생성 때 입력한 기간 전체 총예산(저장값) — dailyLimit은 이 값/기간(버림)의 스냅샷
-            int actualSpent,   // 목표 종료일 또는 포기 전날까지의 실지출 합계
-            int savedAmount    // 같은 구간의 일별 max(0, 한도-지출) 합
+            long actualSpent,   // 목표 종료일 또는 포기 전날까지의 실지출 합계
+            long savedAmount    // 같은 구간의 일별 max(0, 한도-지출) 합
     ) {
         /**
          * 엔티티+집계값 → 카드 매핑의 단일 출처. 집계 결과는 서비스가 계산해 값으로 넘긴다 —
          * 집계 record(ChallengeSummary)는 service 패키지 내부 계산용이라 dto가 직접 물지 않는다.
          */
-        public static Item of(Challenge c, int actualSpent, int savedAmount) {
+        public static Item of(Challenge c, long actualSpent, long savedAmount) {
             return new Item(c.getId(), c.getStatus(), c.getStartDate(), c.getEndDate(),
                     c.getDurationDays(), c.getBudgetTotal(), actualSpent, savedAmount);
         }

--- a/src/main/java/Hampouch/server/domain/challenge/dto/CurrentChallengeResponse.java
+++ b/src/main/java/Hampouch/server/domain/challenge/dto/CurrentChallengeResponse.java
@@ -65,11 +65,10 @@ public record CurrentChallengeResponse(
 
     /**
      * 홈 소비상태 — 선택 날짜의 하루 사용률. 기존 필드명 todaySpent·todayRemaining은 호환을 위해 유지한다.
-     * TODO(령준 지출 연동): todaySpent 출처 교체 — 연동 전엔 시드/POST /days 입력값.
      */
     public record Consumption(
-            int todaySpent,
-            int todayRemaining,  // = dailyLimit - todaySpent (파생값). 화면 표시용이라 계산 규칙을 서버 단일 출처로 두고 내려줌(클라 재계산 방지). 초과 시 음수
+            long todaySpent,
+            long todayRemaining,  // = dailyLimit - todaySpent (파생값). 화면 표시용이라 계산 규칙을 서버 단일 출처로 두고 내려줌(클라 재계산 방지). 초과 시 음수
             int dailyLimit,
             double usageRate,
             ConsumptionCharacter character,

--- a/src/main/java/Hampouch/server/domain/challenge/dto/CurrentChallengeResponse.java
+++ b/src/main/java/Hampouch/server/domain/challenge/dto/CurrentChallengeResponse.java
@@ -59,7 +59,7 @@ public record CurrentChallengeResponse(
             int successDays,
             int overDays,
             int currentStreak,
-            int savedAmountSoFar
+            long savedAmountSoFar
     ) {
     }
 

--- a/src/main/java/Hampouch/server/domain/challenge/dto/ResultResponse.java
+++ b/src/main/java/Hampouch/server/domain/challenge/dto/ResultResponse.java
@@ -38,11 +38,11 @@ public record ResultResponse(
     public record Summary(
             int successDays,
             int overDays,
-            int savedAmount,
-            int overAmount,
+            long savedAmount,
+            long overAmount,
             int maxStreak,
             int budgetTotal,
-            int actualSpent
+            long actualSpent
     ) {
     }
 }

--- a/src/main/java/Hampouch/server/domain/challenge/service/ChallengeCalculator.java
+++ b/src/main/java/Hampouch/server/domain/challenge/service/ChallengeCalculator.java
@@ -25,7 +25,7 @@ public final class ChallengeCalculator {
     }
 
     public static int recommendedBudgetTotal(ChallengeStatus status, EndReason endReason,
-                                             int budgetTotal, int actualSpent) {
+                                             int budgetTotal, long actualSpent) {
         if (status == ChallengeStatus.SUCCESS) {
             if (actualSpent > budgetTotal) {
                 throw new IllegalStateException("성공한 챌린지의 실지출이 목표 금액을 초과했습니다.");
@@ -39,13 +39,15 @@ public final class ChallengeCalculator {
             if (actualSpent <= budgetTotal) {
                 throw new IllegalStateException("금액 초과로 실패한 챌린지의 실지출이 목표 금액 이하입니다.");
             }
-            int overAmount = actualSpent - budgetTotal;
-            return budgetTotal + overAmount / 2 + overAmount % 2;
+            long overAmount = actualSpent - budgetTotal;
+            // 새 목표도 결국 budgetTotal 자리(BUDGET_TOTAL_MAX 이내)에 들어갈 값이라 int로 좁힌다 —
+            // 넘치면 조용히 틀린 추천값을 주는 대신 예외로 드러나게 Math.toIntExact를 쓴다.
+            return Math.toIntExact(budgetTotal + overAmount / 2 + overAmount % 2);
         }
         throw new IllegalArgumentException("종료되지 않은 챌린지는 추천할 수 없습니다: " + status);
     }
 
-    public static DayStatus judge(int spentAmount, int dailyLimit) {
+    public static DayStatus judge(long spentAmount, int dailyLimit) {
         return spentAmount <= dailyLimit ? DayStatus.SUCCESS : DayStatus.OVER;
     }
 
@@ -64,9 +66,9 @@ public final class ChallengeCalculator {
 
         int successDays = 0;
         int overDays = 0;
-        int savedAmount = 0;
-        int overAmount = 0;
-        int actualSpent = 0;
+        long savedAmount = 0;
+        long overAmount = 0;
+        long actualSpent = 0;
         int maxStreak = 0;
         int currentStreak = 0;
 
@@ -98,18 +100,18 @@ public final class ChallengeCalculator {
      * summarizeThrough의 Expense 기반 버전 — 날짜별 지출 합계 맵을 받아 한도·판정을 계산
      * DailyLimitTimeline.on(date)는 조정 이력만으로 결정되는 순수 함수라 얼려둘 필요가 없어 항상 limits.on(date)를 쓴다.
      */
-    public static ChallengeSummary summarizeThrough(Map<LocalDate, Integer> spentByDate, DailyLimitTimeline limits,
+    public static ChallengeSummary summarizeThrough(Map<LocalDate, Long> spentByDate, DailyLimitTimeline limits,
                                                      LocalDate startDate, LocalDate endDate) {
         int successDays = 0;
         int overDays = 0;
-        int savedAmount = 0;
-        int overAmount = 0;
-        int actualSpent = 0;
+        long savedAmount = 0;
+        long overAmount = 0;
+        long actualSpent = 0;
         int maxStreak = 0;
         int currentStreak = 0;
 
         for (LocalDate date = startDate; !date.isAfter(endDate); date = date.plusDays(1)) {
-            int spent = spentByDate.getOrDefault(date, 0);
+            long spent = spentByDate.getOrDefault(date, 0L);
             int dailyLimit = limits.on(date);
             DayStatus status = judge(spent, dailyLimit);
             actualSpent += spent;
@@ -142,11 +144,11 @@ public final class ChallengeCalculator {
      * currentStreakAsOf의 Expense 기반 버전.
      * 이 버전은 status가 없으므로 judge(spent, limits.on(date))로 그 자리에서 계산 — limits 파라미터가 필요
      */
-    public static int currentStreakAsOf(Map<LocalDate, Integer> spentByDate, DailyLimitTimeline limits,
+    public static int currentStreakAsOf(Map<LocalDate, Long> spentByDate, DailyLimitTimeline limits,
                                         LocalDate startDate, LocalDate aggregationEndDate) {
         int streak = 0;
         for (LocalDate date = aggregationEndDate; !date.isBefore(startDate); date = date.minusDays(1)) {
-            int spent = spentByDate.getOrDefault(date, 0);
+            long spent = spentByDate.getOrDefault(date, 0L);
             if (judge(spent, limits.on(date)) != DayStatus.SUCCESS) {
                 break;
             }
@@ -156,7 +158,7 @@ public final class ChallengeCalculator {
     }
 
     /** 한도 0원일 때 Infinity·NaN이 응답에 노출되지 않도록 초과 여부만 반환한다. */
-    public static double usageRate(int todaySpent, int dailyLimit) {
+    public static double usageRate(long todaySpent, int dailyLimit) {
         if (dailyLimit <= 0) {
             return todaySpent > 0 ? 1.0 : 0.0;
         }
@@ -201,7 +203,7 @@ public final class ChallengeCalculator {
      * 일별 초과(OVER)는 달력 표시·overDays 집계로만 남고 성패를 가르지 않는다.
      * actualSpent는 summarizeThrough가 만든 값을 넘길 것 — 판정 근거와 응답의 총액이 같은 계산이어야 한다.
      */
-    public static ChallengeStatus resultStatus(int actualSpent, int budgetTotal) {
+    public static ChallengeStatus resultStatus(long actualSpent, int budgetTotal) {
         return actualSpent > budgetTotal ? ChallengeStatus.FAIL : ChallengeStatus.SUCCESS;
     }
 

--- a/src/main/java/Hampouch/server/domain/challenge/service/ChallengeCalculator.java
+++ b/src/main/java/Hampouch/server/domain/challenge/service/ChallengeCalculator.java
@@ -24,13 +24,13 @@ public final class ChallengeCalculator {
         return durationDays;
     }
 
-    public static int recommendedBudgetTotal(ChallengeStatus status, EndReason endReason,
+    public static long recommendedBudgetTotal(ChallengeStatus status, EndReason endReason,
                                              int budgetTotal, long actualSpent) {
         if (status == ChallengeStatus.SUCCESS) {
             if (actualSpent > budgetTotal) {
                 throw new IllegalStateException("성공한 챌린지의 실지출이 목표 금액을 초과했습니다.");
             }
-            return (int) (budgetTotal * 9L / 10);
+            return budgetTotal * 9L / 10;
         }
         if (status == ChallengeStatus.VOID || endReason == EndReason.GIVEN_UP) {
             return budgetTotal;
@@ -40,9 +40,7 @@ public final class ChallengeCalculator {
                 throw new IllegalStateException("금액 초과로 실패한 챌린지의 실지출이 목표 금액 이하입니다.");
             }
             long overAmount = actualSpent - budgetTotal;
-            // 새 목표도 결국 budgetTotal 자리(BUDGET_TOTAL_MAX 이내)에 들어갈 값이라 int로 좁힌다 —
-            // 넘치면 조용히 틀린 추천값을 주는 대신 예외로 드러나게 Math.toIntExact를 쓴다.
-            return Math.toIntExact(budgetTotal + overAmount / 2 + overAmount % 2);
+            return budgetTotal + overAmount / 2 + overAmount % 2;
         }
         throw new IllegalArgumentException("종료되지 않은 챌린지는 추천할 수 없습니다: " + status);
     }

--- a/src/main/java/Hampouch/server/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/Hampouch/server/domain/challenge/service/ChallengeService.java
@@ -144,9 +144,9 @@ public class ChallengeService {
             ExpenseInputState expenseInputState,
             int usedAdjustmentCount) {
         LocalDate aggregationEndDate = selectedDate.isAfter(c.getEndDate()) ? c.getEndDate() : selectedDate;
-        Map<LocalDate, Integer> spentByDate = aggregationEndDate.isBefore(c.getStartDate())
+        Map<LocalDate, Long> spentByDate = aggregationEndDate.isBefore(c.getStartDate())
                 ? Map.of()
-                : toIntMap(expenseService.getDailySpending(userId, c.getStartDate(), aggregationEndDate));
+                : expenseService.getDailySpending(userId, c.getStartDate(), aggregationEndDate);
         ChallengeSummary summary = aggregationEndDate.isBefore(c.getStartDate())
                 ? new ChallengeSummary(0, 0, 0, 0, 0, 0)
                 : ChallengeCalculator.summarizeThrough(spentByDate, limits, c.getStartDate(), aggregationEndDate);
@@ -160,7 +160,8 @@ public class ChallengeService {
                 elapsedDays(c, selectedDate), remainingDays(c, selectedDate),
                 summary.successDays(), summary.overDays(),
                 ChallengeCalculator.currentStreakAsOf(spentByDate, limits, c.getStartDate(), aggregationEndDate),
-                summary.savedAmount());
+                // Progress.savedAmountSoFar는 아직 int(Stage 6에서 long 전환 예정) — 그때까지의 임시 방어.
+                Math.toIntExact(summary.savedAmount()));
         var consumption = new CurrentChallengeResponse.Consumption(
                 spent, dailyLimit - spent, dailyLimit,
                 usageRate, ConsumptionCharacter.of(usageRate), AlertLevel.of(usageRate));
@@ -220,8 +221,8 @@ public class ChallengeService {
             return new CalendarResponse(challengeId, year, month, List.of());
         }
 
-        Map<LocalDate, Integer> spentByDate = toIntMap(expenseService.getDailySpending(
-                userId, challengeRangeInMonth.start(), challengeRangeInMonth.end()));
+        Map<LocalDate, Long> spentByDate = expenseService.getDailySpending(
+                userId, challengeRangeInMonth.start(), challengeRangeInMonth.end());
         List<LocalDate> noSpendDates = noSpendDayRepository
                 .findByUser_IdAndRecordDateBetween(userId, challengeRangeInMonth.start(), challengeRangeInMonth.end())
                 .stream().map(NoSpendDay::getRecordDate).toList();
@@ -232,8 +233,9 @@ public class ChallengeService {
         recordedDates.addAll(noSpendDates);
         List<CalendarResponse.DayView> days = recordedDates.stream()
                 .map(date -> {
-                    int spent = spentByDate.getOrDefault(date, 0);
-                    return new CalendarResponse.DayView(date, ChallengeCalculator.judge(spent, limits.on(date)), spent);
+                    long spent = spentByDate.getOrDefault(date, 0L);
+                    // DayView.spentAmount는 하루치 단일값이라 int 유지 — Expense 쪽이 이미 범위를 보장하므로 명시적으로만 좁힌다.
+                    return new CalendarResponse.DayView(date, ChallengeCalculator.judge(spent, limits.on(date)), Math.toIntExact(spent));
                 })
                 .toList();
         return new CalendarResponse(challengeId, year, month, days);
@@ -245,9 +247,9 @@ public class ChallengeService {
         userOperationLock.lock(userId);
         Challenge c = loadOwned(userId, challengeId);
         LocalDate aggregationEndDate = aggregationEndDate(c);
-        Map<LocalDate, Integer> spentByDate = aggregationEndDate.isBefore(c.getStartDate())
+        Map<LocalDate, Long> spentByDate = aggregationEndDate.isBefore(c.getStartDate())
                 ? Map.of()
-                : toIntMap(expenseService.getDailySpending(userId, c.getStartDate(), aggregationEndDate));
+                : expenseService.getDailySpending(userId, c.getStartDate(), aggregationEndDate);
         ChallengeSummary s = aggregationEndDate.isBefore(c.getStartDate())
                 ? new ChallengeSummary(0, 0, 0, 0, 0, 0)
                 : ChallengeCalculator.summarizeThrough(spentByDate, timelineOf(c), c.getStartDate(), aggregationEndDate);
@@ -262,9 +264,10 @@ public class ChallengeService {
             }
         }
         var period = ResultResponse.Period.from(c);
+        // Summary는 아직 int(Stage 6에서 long 전환 예정) — 그때까지의 임시 방어.
         var summary = new ResultResponse.Summary(
-                s.successDays(), s.overDays(), s.savedAmount(), s.overAmount(),
-                s.maxStreak(), c.getBudgetTotal(), s.actualSpent());
+                s.successDays(), s.overDays(), Math.toIntExact(s.savedAmount()), Math.toIntExact(s.overAmount()),
+                s.maxStreak(), c.getBudgetTotal(), Math.toIntExact(s.actualSpent()));
         // ChallengeDay와 지출 원본이 동기화되기 전에는 요약 합계와 감정별 합계가 다를 수 있다.
         PeriodSpending spending = aggregationEndDate.isBefore(c.getStartDate())
                 ? new PeriodSpending(0, List.of())
@@ -341,7 +344,8 @@ public class ChallengeService {
         List<ChallengeHistoryResponse.Item> items = ended.stream()
                 .map(c -> {
                     ChallengeSummary s = summariesByChallengeId.get(c.getId());
-                    return ChallengeHistoryResponse.Item.of(c, s.actualSpent(), s.savedAmount());
+                    // Item.of는 아직 int(Stage 6에서 long 전환 예정) — 그때까지의 임시 방어.
+                    return ChallengeHistoryResponse.Item.of(c, Math.toIntExact(s.actualSpent()), Math.toIntExact(s.savedAmount()));
                 })
                 .toList();
         return new ChallengeHistoryResponse(items);
@@ -358,7 +362,7 @@ public class ChallengeService {
                 .collect(Collectors.groupingBy(a -> a.getChallenge().getId()));
         LocalDate minStart = completed.stream().map(Challenge::getStartDate).min(LocalDate::compareTo).orElseThrow();
         LocalDate maxEnd = completed.stream().map(this::aggregationEndDate).max(LocalDate::compareTo).orElseThrow();
-        Map<LocalDate, Integer> spentByDate = toIntMap(expenseService.getDailySpending(userId, minStart, maxEnd));
+        Map<LocalDate, Long> spentByDate = expenseService.getDailySpending(userId, minStart, maxEnd);
 
         return completed.stream().collect(Collectors.toMap(
                 Challenge::getId,
@@ -378,9 +382,9 @@ public class ChallengeService {
                 .orElseThrow(() -> new CustomException(ChallengeErrorCode.NO_ENDED_CHALLENGE));
 
         LocalDate aggregationEndDate = aggregationEndDate(last);
-        Map<LocalDate, Integer> spentByDate = aggregationEndDate.isBefore(last.getStartDate())
+        Map<LocalDate, Long> spentByDate = aggregationEndDate.isBefore(last.getStartDate())
                 ? Map.of()
-                : toIntMap(expenseService.getDailySpending(userId, last.getStartDate(), aggregationEndDate));
+                : expenseService.getDailySpending(userId, last.getStartDate(), aggregationEndDate);
         ChallengeSummary s = aggregationEndDate.isBefore(last.getStartDate())
                 ? new ChallengeSummary(0, 0, 0, 0, 0, 0)
                 : ChallengeCalculator.summarizeThrough(spentByDate, timelineOf(last), last.getStartDate(), aggregationEndDate);
@@ -399,7 +403,7 @@ public class ChallengeService {
     }
 
     static String recommendationMessage(ChallengeStatus status, EndReason endReason,
-                                        int budgetTotal, int actualSpent,
+                                        int budgetTotal, long actualSpent,
                                         int recommendedDurationDays, int recommendedBudgetTotal) {
         if (endReason == EndReason.GIVEN_UP) {
             return "이번 챌린지는 중도 포기로 끝났어요." + recommendationPlan(
@@ -410,7 +414,7 @@ public class ChallengeService {
                     budgetTotal, recommendedDurationDays, recommendedBudgetTotal);
         }
 
-        int saved = budgetTotal - actualSpent;
+        long saved = budgetTotal - actualSpent;
         if (status == ChallengeStatus.SUCCESS) {
             String result;
             if (saved > 0) {
@@ -559,7 +563,7 @@ public class ChallengeService {
         if (!judgmentDate.isAfter(c.getEndDate())) {
             return;
         }
-        Map<LocalDate, Integer> spentByDate = toIntMap(expenseService.getDailySpending(userId, c.getStartDate(), c.getEndDate()));
+        Map<LocalDate, Long> spentByDate = expenseService.getDailySpending(userId, c.getStartDate(), c.getEndDate());
         ChallengeSummary s = ChallengeCalculator.summarizeThrough(
                 spentByDate, timelineOf(c), c.getStartDate(), c.getEndDate());
         c.applyResult(ChallengeCalculator.resultStatus(s.actualSpent(), c.getBudgetTotal()));
@@ -572,16 +576,6 @@ public class ChallengeService {
     private DailyLimitTimeline timelineOf(Challenge c) {
         return DailyLimitTimeline.of(c,
                 challengeAdjustmentRepository.findByChallenge_IdOrderByEffectiveDateAscIdAsc(c.getId()));
-    }
-
-    /**
-     * ExpenseService.getDailySpending()이 Long으로 넘겨주는 하루 합계를 ChallengeCalculator가
-     * 아직 int로 받는 구간과 잇는 임시 다리 — Challenge 쪽 계산 로직을 long으로 옮기는 단계(#252 확장)가
-     * 끝나면 이 메서드와 호출부는 제거한다. Math.toIntExact라 여기서 넘치면 조용히 틀리지 않고 예외로 드러난다.
-     */
-    private static Map<LocalDate, Integer> toIntMap(Map<LocalDate, Long> spentByDate) {
-        return spentByDate.entrySet().stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, e -> Math.toIntExact(e.getValue())));
     }
 
     // 결과 조회의 성공일·초과일·절약액·초과액·최고 스트릭·총지출·감정별 지출과

--- a/src/main/java/Hampouch/server/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/Hampouch/server/domain/challenge/service/ChallengeService.java
@@ -146,12 +146,12 @@ public class ChallengeService {
         LocalDate aggregationEndDate = selectedDate.isAfter(c.getEndDate()) ? c.getEndDate() : selectedDate;
         Map<LocalDate, Integer> spentByDate = aggregationEndDate.isBefore(c.getStartDate())
                 ? Map.of()
-                : expenseService.getDailySpending(userId, c.getStartDate(), aggregationEndDate);
+                : toIntMap(expenseService.getDailySpending(userId, c.getStartDate(), aggregationEndDate));
         ChallengeSummary summary = aggregationEndDate.isBefore(c.getStartDate())
                 ? new ChallengeSummary(0, 0, 0, 0, 0, 0)
                 : ChallengeCalculator.summarizeThrough(spentByDate, limits, c.getStartDate(), aggregationEndDate);
 
-        int spent = expenseService.getDaySpending(userId, selectedDate).totalAmount();
+        int spent = Math.toIntExact(expenseService.getDaySpending(userId, selectedDate).totalAmount());
         double usageRate = ChallengeCalculator.usageRate(spent, dailyLimit);
         var view = new CurrentChallengeResponse.ChallengeView(
                 c.getId(), c.getDurationDays(), c.getStartDate(), c.getEndDate(),
@@ -220,8 +220,8 @@ public class ChallengeService {
             return new CalendarResponse(challengeId, year, month, List.of());
         }
 
-        Map<LocalDate, Integer> spentByDate = expenseService.getDailySpending(
-                userId, challengeRangeInMonth.start(), challengeRangeInMonth.end());
+        Map<LocalDate, Integer> spentByDate = toIntMap(expenseService.getDailySpending(
+                userId, challengeRangeInMonth.start(), challengeRangeInMonth.end()));
         List<LocalDate> noSpendDates = noSpendDayRepository
                 .findByUser_IdAndRecordDateBetween(userId, challengeRangeInMonth.start(), challengeRangeInMonth.end())
                 .stream().map(NoSpendDay::getRecordDate).toList();
@@ -247,7 +247,7 @@ public class ChallengeService {
         LocalDate aggregationEndDate = aggregationEndDate(c);
         Map<LocalDate, Integer> spentByDate = aggregationEndDate.isBefore(c.getStartDate())
                 ? Map.of()
-                : expenseService.getDailySpending(userId, c.getStartDate(), aggregationEndDate);
+                : toIntMap(expenseService.getDailySpending(userId, c.getStartDate(), aggregationEndDate));
         ChallengeSummary s = aggregationEndDate.isBefore(c.getStartDate())
                 ? new ChallengeSummary(0, 0, 0, 0, 0, 0)
                 : ChallengeCalculator.summarizeThrough(spentByDate, timelineOf(c), c.getStartDate(), aggregationEndDate);
@@ -358,7 +358,7 @@ public class ChallengeService {
                 .collect(Collectors.groupingBy(a -> a.getChallenge().getId()));
         LocalDate minStart = completed.stream().map(Challenge::getStartDate).min(LocalDate::compareTo).orElseThrow();
         LocalDate maxEnd = completed.stream().map(this::aggregationEndDate).max(LocalDate::compareTo).orElseThrow();
-        Map<LocalDate, Integer> spentByDate = expenseService.getDailySpending(userId, minStart, maxEnd);
+        Map<LocalDate, Integer> spentByDate = toIntMap(expenseService.getDailySpending(userId, minStart, maxEnd));
 
         return completed.stream().collect(Collectors.toMap(
                 Challenge::getId,
@@ -380,7 +380,7 @@ public class ChallengeService {
         LocalDate aggregationEndDate = aggregationEndDate(last);
         Map<LocalDate, Integer> spentByDate = aggregationEndDate.isBefore(last.getStartDate())
                 ? Map.of()
-                : expenseService.getDailySpending(userId, last.getStartDate(), aggregationEndDate);
+                : toIntMap(expenseService.getDailySpending(userId, last.getStartDate(), aggregationEndDate));
         ChallengeSummary s = aggregationEndDate.isBefore(last.getStartDate())
                 ? new ChallengeSummary(0, 0, 0, 0, 0, 0)
                 : ChallengeCalculator.summarizeThrough(spentByDate, timelineOf(last), last.getStartDate(), aggregationEndDate);
@@ -559,7 +559,7 @@ public class ChallengeService {
         if (!judgmentDate.isAfter(c.getEndDate())) {
             return;
         }
-        Map<LocalDate, Integer> spentByDate = expenseService.getDailySpending(userId, c.getStartDate(), c.getEndDate());
+        Map<LocalDate, Integer> spentByDate = toIntMap(expenseService.getDailySpending(userId, c.getStartDate(), c.getEndDate()));
         ChallengeSummary s = ChallengeCalculator.summarizeThrough(
                 spentByDate, timelineOf(c), c.getStartDate(), c.getEndDate());
         c.applyResult(ChallengeCalculator.resultStatus(s.actualSpent(), c.getBudgetTotal()));
@@ -572,6 +572,16 @@ public class ChallengeService {
     private DailyLimitTimeline timelineOf(Challenge c) {
         return DailyLimitTimeline.of(c,
                 challengeAdjustmentRepository.findByChallenge_IdOrderByEffectiveDateAscIdAsc(c.getId()));
+    }
+
+    /**
+     * ExpenseService.getDailySpending()이 Long으로 넘겨주는 하루 합계를 ChallengeCalculator가
+     * 아직 int로 받는 구간과 잇는 임시 다리 — Challenge 쪽 계산 로직을 long으로 옮기는 단계(#252 확장)가
+     * 끝나면 이 메서드와 호출부는 제거한다. Math.toIntExact라 여기서 넘치면 조용히 틀리지 않고 예외로 드러난다.
+     */
+    private static Map<LocalDate, Integer> toIntMap(Map<LocalDate, Long> spentByDate) {
+        return spentByDate.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> Math.toIntExact(e.getValue())));
     }
 
     // 결과 조회의 성공일·초과일·절약액·초과액·최고 스트릭·총지출·감정별 지출과

--- a/src/main/java/Hampouch/server/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/Hampouch/server/domain/challenge/service/ChallengeService.java
@@ -385,7 +385,7 @@ public class ChallengeService {
                 ? new ChallengeSummary(0, 0, 0, 0, 0, 0)
                 : ChallengeCalculator.summarizeThrough(spentByDate, timelineOf(last), last.getStartDate(), aggregationEndDate);
         int recommendedDurationDays = ChallengeCalculator.recommendedDurationDays(last.getDurationDays());
-        int recommendedBudgetTotal = ChallengeCalculator.recommendedBudgetTotal(
+        long recommendedBudgetTotal = ChallengeCalculator.recommendedBudgetTotal(
                 last.getStatus(), last.getEndReason(), last.getBudgetTotal(), s.actualSpent());
 
         return new RecommendationResponse(
@@ -400,7 +400,7 @@ public class ChallengeService {
 
     static String recommendationMessage(ChallengeStatus status, EndReason endReason,
                                         int budgetTotal, long actualSpent,
-                                        int recommendedDurationDays, int recommendedBudgetTotal) {
+                                        int recommendedDurationDays, long recommendedBudgetTotal) {
         if (endReason == EndReason.GIVEN_UP) {
             return "이번 챌린지는 중도 포기로 끝났어요." + recommendationPlan(
                     budgetTotal, recommendedDurationDays, recommendedBudgetTotal);
@@ -435,7 +435,7 @@ public class ChallengeService {
         return result + recommendationPlan(budgetTotal, recommendedDurationDays, recommendedBudgetTotal);
     }
 
-    private static String successNextStep(int previousBudgetTotal, int recommendedBudgetTotal) {
+    private static String successNextStep(int previousBudgetTotal, long recommendedBudgetTotal) {
         if (recommendedBudgetTotal < previousBudgetTotal) {
             return " 이번엔 조금 더 타이트하게 가볼까요?";
         }
@@ -446,7 +446,7 @@ public class ChallengeService {
     }
 
     private static String recommendationPlan(int previousBudgetTotal, int recommendedDurationDays,
-                                             int recommendedBudgetTotal) {
+                                             long recommendedBudgetTotal) {
         String budgetPlan;
         if (recommendedBudgetTotal < previousBudgetTotal) {
             budgetPlan = String.format(Locale.KOREA, "목표는 %,d원으로 줄여서", recommendedBudgetTotal);

--- a/src/main/java/Hampouch/server/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/Hampouch/server/domain/challenge/service/ChallengeService.java
@@ -160,8 +160,7 @@ public class ChallengeService {
                 elapsedDays(c, selectedDate), remainingDays(c, selectedDate),
                 summary.successDays(), summary.overDays(),
                 ChallengeCalculator.currentStreakAsOf(spentByDate, limits, c.getStartDate(), aggregationEndDate),
-                // Progress.savedAmountSoFar는 아직 int(Stage 6에서 long 전환 예정) — 그때까지의 임시 방어.
-                Math.toIntExact(summary.savedAmount()));
+                summary.savedAmount());
         var consumption = new CurrentChallengeResponse.Consumption(
                 spent, dailyLimit - spent, dailyLimit,
                 usageRate, ConsumptionCharacter.of(usageRate), AlertLevel.of(usageRate));
@@ -264,10 +263,9 @@ public class ChallengeService {
             }
         }
         var period = ResultResponse.Period.from(c);
-        // Summary는 아직 int(Stage 6에서 long 전환 예정) — 그때까지의 임시 방어.
         var summary = new ResultResponse.Summary(
-                s.successDays(), s.overDays(), Math.toIntExact(s.savedAmount()), Math.toIntExact(s.overAmount()),
-                s.maxStreak(), c.getBudgetTotal(), Math.toIntExact(s.actualSpent()));
+                s.successDays(), s.overDays(), s.savedAmount(), s.overAmount(),
+                s.maxStreak(), c.getBudgetTotal(), s.actualSpent());
         // ChallengeDay와 지출 원본이 동기화되기 전에는 요약 합계와 감정별 합계가 다를 수 있다.
         PeriodSpending spending = aggregationEndDate.isBefore(c.getStartDate())
                 ? new PeriodSpending(0, List.of())
@@ -344,8 +342,7 @@ public class ChallengeService {
         List<ChallengeHistoryResponse.Item> items = ended.stream()
                 .map(c -> {
                     ChallengeSummary s = summariesByChallengeId.get(c.getId());
-                    // Item.of는 아직 int(Stage 6에서 long 전환 예정) — 그때까지의 임시 방어.
-                    return ChallengeHistoryResponse.Item.of(c, Math.toIntExact(s.actualSpent()), Math.toIntExact(s.savedAmount()));
+                    return ChallengeHistoryResponse.Item.of(c, s.actualSpent(), s.savedAmount());
                 })
                 .toList();
         return new ChallengeHistoryResponse(items);

--- a/src/main/java/Hampouch/server/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/Hampouch/server/domain/challenge/service/ChallengeService.java
@@ -151,7 +151,7 @@ public class ChallengeService {
                 ? new ChallengeSummary(0, 0, 0, 0, 0, 0)
                 : ChallengeCalculator.summarizeThrough(spentByDate, limits, c.getStartDate(), aggregationEndDate);
 
-        int spent = Math.toIntExact(expenseService.getDaySpending(userId, selectedDate).totalAmount());
+        long spent = expenseService.getDaySpending(userId, selectedDate).totalAmount();
         double usageRate = ChallengeCalculator.usageRate(spent, dailyLimit);
         var view = new CurrentChallengeResponse.ChallengeView(
                 c.getId(), c.getDurationDays(), c.getStartDate(), c.getEndDate(),
@@ -233,8 +233,7 @@ public class ChallengeService {
         List<CalendarResponse.DayView> days = recordedDates.stream()
                 .map(date -> {
                     long spent = spentByDate.getOrDefault(date, 0L);
-                    // DayView.spentAmount는 하루치 단일값이라 int 유지 — Expense 쪽이 이미 범위를 보장하므로 명시적으로만 좁힌다.
-                    return new CalendarResponse.DayView(date, ChallengeCalculator.judge(spent, limits.on(date)), Math.toIntExact(spent));
+                    return new CalendarResponse.DayView(date, ChallengeCalculator.judge(spent, limits.on(date)), spent);
                 })
                 .toList();
         return new CalendarResponse(challengeId, year, month, days);

--- a/src/main/java/Hampouch/server/domain/challenge/service/ChallengeSummary.java
+++ b/src/main/java/Hampouch/server/domain/challenge/service/ChallengeSummary.java
@@ -14,9 +14,9 @@ package Hampouch.server.domain.challenge.service;
 public record ChallengeSummary(
         int successDays,
         int overDays,
-        int savedAmount,
-        int overAmount,
+        long savedAmount,
+        long overAmount,
         int maxStreak,
-        int actualSpent
+        long actualSpent
 ) {
 }

--- a/src/main/java/Hampouch/server/domain/expense/dto/ExpenseAnalysisResponse.java
+++ b/src/main/java/Hampouch/server/domain/expense/dto/ExpenseAnalysisResponse.java
@@ -17,7 +17,7 @@ import java.util.List;
 public record ExpenseAnalysisResponse(
         LocalDate periodStart,
         LocalDate periodEnd,
-        int totalAmount,
+        long totalAmount,
         List<CategoryAmount> categoryBreakdown,
         List<EmotionAmount> emotionBreakdown,
         List<WeekdayAmount> weekdayBreakdown,
@@ -29,17 +29,17 @@ public record ExpenseAnalysisResponse(
      * ExpenseCategory 8개 전부 금액 내림차순 — 도넛 옆 범례가 0인 항목까지 적으므로
      * 지출 0원인 카테고리도 amount 0으로 포함. 사용자 정의 카테고리는 전부 이 ETC로 접힌다.
      */
-    public record CategoryAmount(ExpenseCategory category, int amount, int ratio) {}
+    public record CategoryAmount(ExpenseCategory category, long amount, int ratio) {}
 
     /** ExpenseEmotion 5개 전부 금액 내림차순 — 5개가 전부 화면에 나오므로 지출 0원인 이유도 포함한다. */
-    public record EmotionAmount(ExpenseEmotion emotion, int amount, int ratio) {}
+    public record EmotionAmount(ExpenseEmotion emotion, long amount, int ratio) {}
 
     /**
      * 7요일 전부 포함(지출 0인 요일도 amount 0). dayOfWeek는 java.time.DayOfWeek 상수명.
      * 주의: DayOfWeek의 자연 순서는 MONDAY부터라 values() 순서를 그대로 쓰면 화면과 어긋난다.
      * 이 서비스의 주는 일요일에 시작, 아래 DISPLAY_ORDER를 따를 것.
      */
-    public record WeekdayAmount(DayOfWeek dayOfWeek, int amount) {
+    public record WeekdayAmount(DayOfWeek dayOfWeek, long amount) {
 
         public static final List<DayOfWeek> DISPLAY_ORDER = List.of(
                 DayOfWeek.SUNDAY, DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY,

--- a/src/main/java/Hampouch/server/domain/expense/dto/ExpenseCategoryDetailResponse.java
+++ b/src/main/java/Hampouch/server/domain/expense/dto/ExpenseCategoryDetailResponse.java
@@ -15,7 +15,7 @@ public record ExpenseCategoryDetailResponse(
         LocalDate periodStart,
         LocalDate periodEnd,
         ExpenseCategory category,
-        int totalAmount,
+        long totalAmount,
         int count,
         int ratio,
         List<ExpenseAnalysisItem> items

--- a/src/main/java/Hampouch/server/domain/expense/dto/ExpenseCreateRequest.java
+++ b/src/main/java/Hampouch/server/domain/expense/dto/ExpenseCreateRequest.java
@@ -1,5 +1,6 @@
 package Hampouch.server.domain.expense.dto;
 
+import Hampouch.server.domain.expense.entity.Expense;
 import Hampouch.server.domain.expense.entity.ExpenseCategory;
 import Hampouch.server.domain.expense.entity.ExpenseEmotion;
 import jakarta.validation.constraints.*;
@@ -14,6 +15,7 @@ public record ExpenseCreateRequest(
 
         @NotNull
         @Min(0)
+        @Max(Expense.PRICE_MAX)
         Integer price,
 
         ExpenseCategory category,

--- a/src/main/java/Hampouch/server/domain/expense/dto/ExpenseDayListResponse.java
+++ b/src/main/java/Hampouch/server/domain/expense/dto/ExpenseDayListResponse.java
@@ -11,7 +11,7 @@ import java.util.List;
 /** 하루치 지출 목록 응답(GET /expenses/day). totalAmount를 함께 내려 일간 화면이 summary API를 또 호출하지 않게 한다. */
 public record ExpenseDayListResponse(
         LocalDate date,
-        int totalAmount,
+        long totalAmount,
         boolean hasRecord,
         List<ExpenseSummary> expenses
 ) {
@@ -41,7 +41,7 @@ public record ExpenseDayListResponse(
 
     /** totalAmount는 이미 조회한 리스트를 stream 합산 — 하루 단위라 비용 무시 가능(월/주 집계엔 재사용 금지). */
     public static ExpenseDayListResponse from(LocalDate date, List<Expense> expenses, boolean hasRecord) {
-        int totalAmount = expenses.stream().mapToInt(Expense::getPrice).sum();
+        long totalAmount = expenses.stream().mapToLong(Expense::getPrice).sum();
         List<ExpenseSummary> summaries = expenses.stream().map(ExpenseSummary::from).toList();
         return new ExpenseDayListResponse(date, totalAmount, hasRecord, summaries);
     }

--- a/src/main/java/Hampouch/server/domain/expense/dto/ExpenseEmotionDetailResponse.java
+++ b/src/main/java/Hampouch/server/domain/expense/dto/ExpenseEmotionDetailResponse.java
@@ -13,7 +13,7 @@ public record ExpenseEmotionDetailResponse(
         LocalDate periodStart,
         LocalDate periodEnd,
         ExpenseEmotion emotion,
-        int totalAmount,
+        long totalAmount,
         int count,
         int ratio,
         List<ExpenseAnalysisItem> items

--- a/src/main/java/Hampouch/server/domain/expense/dto/ExpenseSummaryResponse.java
+++ b/src/main/java/Hampouch/server/domain/expense/dto/ExpenseSummaryResponse.java
@@ -12,15 +12,15 @@ import java.util.List;
 public record ExpenseSummaryResponse(
         LocalDate periodStart,
         LocalDate periodEnd,
-        int totalAmount,
-        int dailyAverage,
+        long totalAmount,
+        long dailyAverage,
         List<DailyAmount> dailyBreakdown
 ) {
 
     /** 지출이 있던 날짜만 담기는 한 줄 — sumGroupedByDate()가 이미 GROUP BY로 지출 없는 날짜를 뺀 채로 넘겨준다. */
-    public record DailyAmount(LocalDate date, int totalAmount) {
+    public record DailyAmount(LocalDate date, long totalAmount) {
         private static DailyAmount from(ExpenseDailyTotal daily) {
-            return new DailyAmount(daily.date(), Math.toIntExact(daily.totalAmount()));
+            return new DailyAmount(daily.date(), daily.totalAmount());
         }
     }
 
@@ -31,16 +31,16 @@ public record ExpenseSummaryResponse(
      */
     public static ExpenseSummaryResponse of(LocalDate periodStart, LocalDate periodEnd,
                                              List<ExpenseDailyTotal> dailyTotals, LocalDate today) {
-        int totalAmount = dailyTotals
+        long totalAmount = dailyTotals
                 .stream()
-                .mapToInt(daily -> Math.toIntExact(daily.totalAmount()))
+                .mapToLong(ExpenseDailyTotal::totalAmount)
                 .sum();
 
-        int dailyAverage = 0;
+        long dailyAverage = 0;
         if (totalAmount > 0) {
             LocalDate elapsedUntil = today.isBefore(periodEnd) ? today : periodEnd;
             long elapsedDays = ChronoUnit.DAYS.between(periodStart, elapsedUntil) + 1;
-            dailyAverage = (int) (totalAmount / elapsedDays);
+            dailyAverage = totalAmount / elapsedDays;
         }
 
         List<DailyAmount> dailyBreakdown = dailyTotals.stream().map(DailyAmount::from).toList();

--- a/src/main/java/Hampouch/server/domain/expense/dto/ExpenseTrendResponse.java
+++ b/src/main/java/Hampouch/server/domain/expense/dto/ExpenseTrendResponse.java
@@ -15,8 +15,8 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record ExpenseTrendResponse(
         @JsonFormat(pattern = "yyyy-MM") YearMonth month,
-        int totalAmount,
-        int monthlyAverage,
+        long totalAmount,
+        long monthlyAverage,
         Integer diffRateFromLastMonth,
         List<MonthlyAmount> trend,
         String trendInsight
@@ -25,6 +25,6 @@ public record ExpenseTrendResponse(
     /** 항상 6개. 지출이 없는 달도 amount 0으로 채우고 오름차순(과거 -> 최근)으로 정렬한다. */
     public record MonthlyAmount(
             @JsonFormat(pattern = "yyyy-MM") YearMonth month,
-            int amount
+            long amount
     ) {}
 }

--- a/src/main/java/Hampouch/server/domain/expense/dto/ExpenseUpdateRequest.java
+++ b/src/main/java/Hampouch/server/domain/expense/dto/ExpenseUpdateRequest.java
@@ -1,5 +1,6 @@
 package Hampouch.server.domain.expense.dto;
 
+import Hampouch.server.domain.expense.entity.Expense;
 import Hampouch.server.domain.expense.entity.ExpenseCategory;
 import Hampouch.server.domain.expense.entity.ExpenseEmotion;
 import jakarta.validation.constraints.*;
@@ -13,6 +14,7 @@ public record ExpenseUpdateRequest(
 
         @NotNull
         @Min(0)
+        @Max(Expense.PRICE_MAX)
         Integer price,
 
         ExpenseCategory category,

--- a/src/main/java/Hampouch/server/domain/expense/entity/Expense.java
+++ b/src/main/java/Hampouch/server/domain/expense/entity/Expense.java
@@ -22,6 +22,9 @@ import java.time.LocalDateTime;
 @EntityListeners(AuditingEntityListener.class) // 저장 직전 @CreatedDate/@LastModifiedDate를 자동 채움
 public class Expense {
 
+    /** 지출 1건 요청값의 상한. */
+    public static final int PRICE_MAX = 10_000_000;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY) // PK 발급은 DB(auto_increment) 책임
     @Column(name = "expense_id")

--- a/src/main/java/Hampouch/server/domain/expense/repository/ExpenseRepository.java
+++ b/src/main/java/Hampouch/server/domain/expense/repository/ExpenseRepository.java
@@ -33,10 +33,10 @@ public interface ExpenseRepository extends JpaRepository<Expense, Long> {
     List<ExpenseDailyTotal> sumGroupedByDate(@Param("userId") Long userId, @Param("status") ExpenseStatus status,
                                               @Param("start") LocalDate start, @Param("end") LocalDate end);
 
-    /* 파생 쿼리는 SUM 집계를 지원 안 해 @Query로 직접 작성 — coalesce로 지출 없을 때 null 대신 0 반환 */
+    /** 파생 쿼리는 SUM 집계를 지원 안 해 @Query로 직접 작성 — coalesce로 지출 없을 때 null 대신 0 반환. */
     @Query("select coalesce(sum(e.price), 0) from Expense e "
             + "where e.user.id = :userId and e.expenseDate = :date and e.status = :status")
-    int sumPriceByUserIdAndExpenseDateAndStatus(@Param("userId") Long userId, @Param("date") LocalDate date, @Param("status") ExpenseStatus status);
+    Long sumPriceByUserIdAndExpenseDateAndStatus(@Param("userId") Long userId, @Param("date") LocalDate date, @Param("status") ExpenseStatus status);
 
     /** getDaySpending()의 hasRecord용 — 합계만으론 "기록 없음"과 "합계 0원"을 구분 못해 별도 존재 쿼리로 둔다. */
     boolean existsByUser_IdAndExpenseDateAndStatus(Long userId, LocalDate expenseDate, ExpenseStatus status);

--- a/src/main/java/Hampouch/server/domain/expense/service/DaySpending.java
+++ b/src/main/java/Hampouch/server/domain/expense/service/DaySpending.java
@@ -2,12 +2,10 @@ package Hampouch.server.domain.expense.service;
 
 /**
  * Challenge 도메인이 일별 예산 초과 여부를 판단할 때 쓰는 조회 결과
- * Challenge domain에서 그 날의 Challenge 성공 / 실패 여부 확인을 위한 DTO
- * hasRecord: 그날 기록 자체가 없음과 기록의 합계가 0원을 구분
- * ACTIVE 지출이나 '오늘은 안 썼어요' 기록 중 하나라도 있으면 true다.
+ * Challenge domain에서 그 날의  성공 / 실패 여부 확인을 위한 DTO
  */
 public record DaySpending(
-        int totalAmount,
+        long totalAmount,
         boolean hasRecord
 ) {
 }

--- a/src/main/java/Hampouch/server/domain/expense/service/EmotionSpending.java
+++ b/src/main/java/Hampouch/server/domain/expense/service/EmotionSpending.java
@@ -12,7 +12,7 @@ import Hampouch.server.domain.expense.entity.ExpenseEmotion;
  */
 public record EmotionSpending(
         ExpenseEmotion emotion,
-        int amount,
+        long amount,
         int ratio
 ) {
 }

--- a/src/main/java/Hampouch/server/domain/expense/service/ExpenseAnalysisService.java
+++ b/src/main/java/Hampouch/server/domain/expense/service/ExpenseAnalysisService.java
@@ -53,7 +53,7 @@ public class ExpenseAnalysisService implements ExpenseSpendingQuery {
      */
     public ExpenseAnalysisResponse analyze(Long userId, LocalDate periodStart, LocalDate periodEnd) {
         List<Expense> expenses = loadPeriod(userId, periodStart, periodEnd);
-        int totalAmount = sumPrice(expenses);
+        long totalAmount = sumPrice(expenses);
         // 집계 3종을 응답과 인사이트가 같이 본다 — 다시 계산하면 화면의 숫자와 문구의 숫자가 어긋날 수 있다
         List<CategoryAmount> categoryBreakdown = categoryBreakdown(expenses, totalAmount);
         List<EmotionAmount> emotionBreakdown = emotionBreakdown(expenses, totalAmount);
@@ -80,12 +80,12 @@ public class ExpenseAnalysisService implements ExpenseSpendingQuery {
     public ExpenseCategoryDetailResponse getCategoryDetail(Long userId, ExpenseCategory category,
                                                            LocalDate periodStart, LocalDate periodEnd) {
         List<Expense> expenses = loadPeriod(userId, periodStart, periodEnd);
-        int periodTotal = sumPrice(expenses);
+        long periodTotal = sumPrice(expenses);
 
         List<Expense> filtered = expenses.stream()
                 .filter(expense -> expense.getCategory() == category)
                 .toList();
-        int categoryTotal = sumPrice(filtered);
+        long categoryTotal = sumPrice(filtered);
 
         return new ExpenseCategoryDetailResponse(
                 periodStart, periodEnd, category,
@@ -101,12 +101,12 @@ public class ExpenseAnalysisService implements ExpenseSpendingQuery {
     public ExpenseEmotionDetailResponse getEmotionDetail(Long userId, ExpenseEmotion emotion,
                                                          LocalDate periodStart, LocalDate periodEnd) {
         List<Expense> expenses = loadPeriod(userId, periodStart, periodEnd);
-        int periodTotal = sumPrice(expenses);
+        long periodTotal = sumPrice(expenses);
 
         List<Expense> filtered = expenses.stream()
                 .filter(expense -> expense.getEmotion() == emotion)
                 .toList();
-        int emotionTotal = sumPrice(filtered);
+        long emotionTotal = sumPrice(filtered);
 
         return new ExpenseEmotionDetailResponse(
                 periodStart, periodEnd, emotion,
@@ -140,13 +140,12 @@ public class ExpenseAnalysisService implements ExpenseSpendingQuery {
         List<MonthlyAmount> trend = new ArrayList<>(TREND_MONTHS);
         for (int i = 0; i < TREND_MONTHS; i++) {
             YearMonth target = windowStart.plusMonths(i);
-            // toIntExact: 한 달 합계가 int를 넘으면(현실적으로 불가) 조용히 음수로 뒤집히는 대신 예외로 드러나게 한다
-            trend.add(new MonthlyAmount(target, Math.toIntExact(amountByMonth.getOrDefault(target, 0L))));
+            trend.add(new MonthlyAmount(target, amountByMonth.getOrDefault(target, 0L)));
         }
 
-        int windowSum = trend.stream().mapToInt(MonthlyAmount::amount).sum();
-        int currentAmount = trend.get(TREND_MONTHS - 1).amount();
-        int previousAmount = trend.get(TREND_MONTHS - 2).amount();
+        long windowSum = trend.stream().mapToLong(MonthlyAmount::amount).sum();
+        long currentAmount = trend.get(TREND_MONTHS - 1).amount();
+        long previousAmount = trend.get(TREND_MONTHS - 2).amount();
         // 응답 필드와 문구가 같은 값을 봐야 6% 증가라고 적힌 옆에 다른 숫자가 뜨는 일이 없다
         Integer diffRateFromLastMonth = diffRate(currentAmount, previousAmount);
 
@@ -154,7 +153,7 @@ public class ExpenseAnalysisService implements ExpenseSpendingQuery {
                 month,
                 currentAmount,
                 // 6개월 합계 ÷ 6 고정 — 지출 0원인 달을 분모에서 빼지 않는다(빼면 기록을 안 한 달일수록 평균이 올라감)
-                (int) Math.round(windowSum / (double) TREND_MONTHS),
+                Math.round(windowSum / (double) TREND_MONTHS),
                 diffRateFromLastMonth,
                 trend,
                 insightWriter.trendInsight(trend, diffRateFromLastMonth)
@@ -201,19 +200,19 @@ public class ExpenseAnalysisService implements ExpenseSpendingQuery {
      * 상위 N + 기타 묶음 규칙은 없다.
      * 도넛에는 0원 조각이 그려지지 않지만 옆 범례가 ratio가 0인 항목까지 적어주기 때문에 8개를 다 내려준다.
      */
-    private List<CategoryAmount> categoryBreakdown(List<Expense> expenses, int totalAmount) {
-        Map<ExpenseCategory, Integer> amountByCategory = new EnumMap<>(ExpenseCategory.class);
+    private List<CategoryAmount> categoryBreakdown(List<Expense> expenses, long totalAmount) {
+        Map<ExpenseCategory, Long> amountByCategory = new EnumMap<>(ExpenseCategory.class);
         for (Expense expense : expenses) {
-            amountByCategory.merge(expense.getCategory(), expense.getPrice(), Integer::sum);
+            amountByCategory.merge(expense.getCategory(), (long) expense.getPrice(), Long::sum);
         }
 
         // 금액이 같을 때 enum 선언 순서로 한 번 더 정렬 — tie-breaker가 없으면 0원 카테고리들의 순서가 매번 달라진다
-        Comparator<CategoryAmount> byAmount = Comparator.comparingInt(CategoryAmount::amount);
+        Comparator<CategoryAmount> byAmount = Comparator.comparingLong(CategoryAmount::amount);
         Comparator<CategoryAmount> order = byAmount.reversed().thenComparing(CategoryAmount::category);
 
         return Arrays.stream(ExpenseCategory.values())
                 .map(category -> {
-                    int amount = amountByCategory.getOrDefault(category, 0);
+                    long amount = amountByCategory.getOrDefault(category, 0L);
                     return new CategoryAmount(category, amount, percentOf(amount, totalAmount));
                 })
                 .sorted(order)
@@ -225,7 +224,7 @@ public class ExpenseAnalysisService implements ExpenseSpendingQuery {
      * EmotionAmount는 analyze() 응답의 중첩 타입이라 그대로 두고, 챌린지 결과 화면과 공유하는 값(EmotionSpending)만
      * 별도 타입으로 뺐다 — 두 화면이 같은 record를 직접 참조하면 한쪽 응답 모양을 바꿀 때 다른 쪽까지 흔들린다.
      */
-    private List<EmotionAmount> emotionBreakdown(List<Expense> expenses, int totalAmount) {
+    private List<EmotionAmount> emotionBreakdown(List<Expense> expenses, long totalAmount) {
         return emotionSpending(expenses, totalAmount).stream()
                 .map(es -> new EmotionAmount(es.emotion(), es.amount(), es.ratio()))
                 .toList();
@@ -237,18 +236,18 @@ public class ExpenseAnalysisService implements ExpenseSpendingQuery {
      * 분석 화면과 챌린지 결과 화면의 숫자가 어느 날 어긋난다. EmotionSpending은 이미 Challenge 쪽 제안으로
      * 존재하던 record다(그 파일 Javadoc 참조) — #64에서 실제로 연결한다.
      */
-    private List<EmotionSpending> emotionSpending(List<Expense> expenses, int totalAmount) {
-        Map<ExpenseEmotion, Integer> amountByEmotion = new EnumMap<>(ExpenseEmotion.class);
+    private List<EmotionSpending> emotionSpending(List<Expense> expenses, long totalAmount) {
+        Map<ExpenseEmotion, Long> amountByEmotion = new EnumMap<>(ExpenseEmotion.class);
         for (Expense expense : expenses) {
-            amountByEmotion.merge(expense.getEmotion(), expense.getPrice(), Integer::sum);
+            amountByEmotion.merge(expense.getEmotion(), (long) expense.getPrice(), Long::sum);
         }
 
-        Comparator<EmotionSpending> byAmount = Comparator.comparingInt(EmotionSpending::amount);
+        Comparator<EmotionSpending> byAmount = Comparator.comparingLong(EmotionSpending::amount);
         Comparator<EmotionSpending> order = byAmount.reversed().thenComparing(EmotionSpending::emotion);
 
         return Arrays.stream(ExpenseEmotion.values())
                 .map(emotion -> {
-                    int amount = amountByEmotion.getOrDefault(emotion, 0);
+                    long amount = amountByEmotion.getOrDefault(emotion, 0L);
                     return new EmotionSpending(emotion, amount, percentOf(amount, totalAmount));
                 })
                 .sorted(order)
@@ -277,19 +276,19 @@ public class ExpenseAnalysisService implements ExpenseSpendingQuery {
         List<Expense> expenses = periodStart.isAfter(LocalDate.now(clock))
                 ? List.of()
                 : expenseRepository.findPeriodExpenses(userId, ExpenseStatus.ACTIVE, periodStart, periodEnd);
-        int totalAmount = sumPrice(expenses);
+        long totalAmount = sumPrice(expenses);
         return new PeriodSpending(totalAmount, emotionSpending(expenses, totalAmount));
     }
 
     /** 7요일 전부. 이 앱의 주는 일요일 시작이라 DayOfWeek.values() 순서를 쓰면 안 된다. */
     private List<WeekdayAmount> weekdayBreakdown(List<Expense> expenses) {
-        Map<DayOfWeek, Integer> amountByWeekday = new EnumMap<>(DayOfWeek.class);
+        Map<DayOfWeek, Long> amountByWeekday = new EnumMap<>(DayOfWeek.class);
         for (Expense expense : expenses) {
-            amountByWeekday.merge(expense.getExpenseDate().getDayOfWeek(), expense.getPrice(), Integer::sum);
+            amountByWeekday.merge(expense.getExpenseDate().getDayOfWeek(), (long) expense.getPrice(), Long::sum);
         }
 
         return WeekdayAmount.DISPLAY_ORDER.stream()
-                .map(dayOfWeek -> new WeekdayAmount(dayOfWeek, amountByWeekday.getOrDefault(dayOfWeek, 0)))
+                .map(dayOfWeek -> new WeekdayAmount(dayOfWeek, amountByWeekday.getOrDefault(dayOfWeek, 0L)))
                 .toList();
     }
 
@@ -299,7 +298,7 @@ public class ExpenseAnalysisService implements ExpenseSpendingQuery {
      * 기간 총액이 0원이면 지목할 소비 비중이 없어 null을 넘기고, 그때 뭐라고 말할지는 Writer가 정한다.
      */
     private static ExpenseInsightWriter.PeriodFacts periodFacts(
-            List<Expense> expenses, LocalDate periodStart, LocalDate periodEnd, int totalAmount,
+            List<Expense> expenses, LocalDate periodStart, LocalDate periodEnd, long totalAmount,
             List<CategoryAmount> categoryBreakdown, List<EmotionAmount> emotionBreakdown,
             List<WeekdayAmount> weekdayBreakdown) {
 
@@ -309,8 +308,8 @@ public class ExpenseAnalysisService implements ExpenseSpendingQuery {
 
         // 기간을 반으로 가르는 규칙은 Writer에만 둔다 — 여기서 또 계산하면 경계가 하루 어긋나도 아무도 모른다
         LocalDate firstHalfEnd = ExpenseInsightWriter.firstHalfEnd(periodStart, periodEnd);
-        int firstHalfAmount = 0;
-        int secondHalfAmount = 0;
+        long firstHalfAmount = 0;
+        long secondHalfAmount = 0;
         Map<ExpenseCategory, Integer> countByCategory = new EnumMap<>(ExpenseCategory.class);
         for (Expense expense : expenses) {
             if (expense.getExpenseDate().isAfter(firstHalfEnd)) {
@@ -346,17 +345,17 @@ public class ExpenseAnalysisService implements ExpenseSpendingQuery {
      * 스트레스 지출로 만들어질 수 있다 — 두 절이 한 문장으로 묶여 있으므로 산정 범위도 같아야 한다.
      */
     private static ExpenseEmotion topEmotionWithin(List<Expense> expenses, ExpenseCategory category) {
-        Map<ExpenseEmotion, Integer> amountByEmotion = new EnumMap<>(ExpenseEmotion.class);
+        Map<ExpenseEmotion, Long> amountByEmotion = new EnumMap<>(ExpenseEmotion.class);
         for (Expense expense : expenses) {
             if (expense.getCategory() == category) {
-                amountByEmotion.merge(expense.getEmotion(), expense.getPrice(), Integer::sum);
+                amountByEmotion.merge(expense.getEmotion(), (long) expense.getPrice(), Long::sum);
             }
         }
 
         ExpenseEmotion topEmotion = null;
-        int topAmount = 0;
+        long topAmount = 0;
         for (ExpenseEmotion emotion : ExpenseEmotion.values()) { // enum 선언 순서가 곧 동률 tie-breaker
-            int amount = amountByEmotion.getOrDefault(emotion, 0);
+            long amount = amountByEmotion.getOrDefault(emotion, 0L);
             if (amount > topAmount) {
                 topEmotion = emotion;
                 topAmount = amount;
@@ -369,8 +368,9 @@ public class ExpenseAnalysisService implements ExpenseSpendingQuery {
         return expenses.stream().map(ExpenseAnalysisItem::from).toList();
     }
 
-    private static int sumPrice(List<Expense> expenses) {
-        return expenses.stream().mapToInt(Expense::getPrice).sum();
+    /** long으로 합산 — 기간 내 등록 건수에 상한이 없어 int로는 표현할 수 없을 수 있다. */
+    private static long sumPrice(List<Expense> expenses) {
+        return expenses.stream().mapToLong(Expense::getPrice).sum();
     }
 
     /**
@@ -378,7 +378,7 @@ public class ExpenseAnalysisService implements ExpenseSpendingQuery {
      * 반올림 때문에 조각들의 합이 99나 101이 될 수 있으므로 그래서 도넛 각도는 amount로 그려야 한다
      * 기간 총액이 0원이면 나눌 수 없으므로 0%로 둔다.
      */
-    private static int percentOf(int part, int total) {
+    private static int percentOf(long part, long total) {
         if (total == 0) {
             return 0;
         }
@@ -389,7 +389,7 @@ public class ExpenseAnalysisService implements ExpenseSpendingQuery {
      * 지난달 대비 증감률(정수 %, 음수 허용). 지난달이 0원이면 증감률이 정의되지 않으므로 null을 반환하고,
      * 응답 record의 @JsonInclude(NON_NULL)이 키 자체를 생략
      */
-    private static Integer diffRate(int currentAmount, int previousAmount) {
+    private static Integer diffRate(long currentAmount, long previousAmount) {
         if (previousAmount == 0) {
             return null;
         }

--- a/src/main/java/Hampouch/server/domain/expense/service/ExpenseInsightWriter.java
+++ b/src/main/java/Hampouch/server/domain/expense/service/ExpenseInsightWriter.java
@@ -115,8 +115,8 @@ public class ExpenseInsightWriter {
             ExpenseEmotion.ETC, "적어둔 이유를 다시 보면 줄일 지점이 보일 거예요."
     ));
 
-    // 제네릭 추론이 꼬이지 않도록 comparingInt를 먼저 변수에 담고 reversed()를 건다(서비스의 정렬과 같은 방식).
-    private static final Comparator<WeekdayAmount> BY_WEEKDAY_AMOUNT = Comparator.comparingInt(WeekdayAmount::amount);
+    // 제네릭 추론이 꼬이지 않도록 comparingLong을 먼저 변수에 담고 reversed()를 건다(서비스의 정렬과 같은 방식).
+    private static final Comparator<WeekdayAmount> BY_WEEKDAY_AMOUNT = Comparator.comparingLong(WeekdayAmount::amount);
 
     /** 금액 내림차순, 동률이면 화면 표시 순서(일~토) — tie-breaker가 없으면 0원 요일들의 순위가 매번 달라진다. */
     private static final Comparator<WeekdayAmount> WEEKDAY_RANK = BY_WEEKDAY_AMOUNT.reversed()
@@ -132,15 +132,15 @@ public class ExpenseInsightWriter {
     public record PeriodFacts(
             LocalDate periodStart,
             LocalDate periodEnd,
-            int totalAmount,
+            long totalAmount,
             List<CategoryAmount> categoryBreakdown,
             List<EmotionAmount> emotionBreakdown,
             List<WeekdayAmount> weekdayBreakdown,
             ExpenseEmotion topCategoryEmotion,
             ExpenseCategory mostFrequentCategory,
             int mostFrequentCount,
-            int firstHalfAmount,
-            int secondHalfAmount
+            long firstHalfAmount,
+            long secondHalfAmount
     ) {}
 
     /** 3번째 문장과 거기서 이어지는 4번째 제안 문장. 쏠린 축이 없으면 advice가 null이다. */
@@ -150,7 +150,7 @@ public class ExpenseInsightWriter {
      * 요일 차트 위 배지. 시안: 금, 토 지출이 가장 많아요.
      * 2위가 1위의 WEEKDAY_TIE_RATIO 이상이면 둘을 함께 적고, 그때의 나열 순서는 화면 표시 순서
      */
-    public String weekdayInsight(List<WeekdayAmount> weekdayBreakdown, int totalAmount) {
+    public String weekdayInsight(List<WeekdayAmount> weekdayBreakdown, long totalAmount) {
         if (totalAmount == 0) {
             return NO_EXPENSE_WEEKDAY;
         }
@@ -405,12 +405,12 @@ public class ExpenseInsightWriter {
     }
 
     /** 천 단위 구분자. 로케일을 고정하는 이유는 응답 본문에 그대로 나가는 문자열이라서. */
-    private static String formatAmount(int amount) {
+    private static String formatAmount(long amount) {
         return String.format(Locale.KOREA, "%,d", amount);
     }
 
     /** 기간 총액 중 한 항목이 차지하는 비중(정수 %). 분모는 항상 기간 총액이다. */
-    private static int shareOf(int part, int total) {
+    private static int shareOf(long part, long total) {
         if (total == 0) {
             return 0;
         }

--- a/src/main/java/Hampouch/server/domain/expense/service/ExpenseService.java
+++ b/src/main/java/Hampouch/server/domain/expense/service/ExpenseService.java
@@ -213,7 +213,7 @@ public class ExpenseService {
 
     /** Challenge 도메인의 일별 예산 초과 판단용 */
     public DaySpending getDaySpending(Long userId, LocalDate date) {
-        int totalAmount = expenseRepository.sumPriceByUserIdAndExpenseDateAndStatus(userId, date, ExpenseStatus.ACTIVE);
+        long totalAmount = expenseRepository.sumPriceByUserIdAndExpenseDateAndStatus(userId, date, ExpenseStatus.ACTIVE);
         return new DaySpending(totalAmount, hasDayRecord(userId, date));
     }
 
@@ -221,9 +221,9 @@ public class ExpenseService {
      * Challenge 도메인의 기간 집계(getCurrent/getCalendar/getResult/getHistory/getRecommendation)용 —
      * [start,end] 각 날짜의 ACTIVE 지출 합계.
      */
-    public Map<LocalDate, Integer> getDailySpending(Long userId, LocalDate start, LocalDate end) {
+    public Map<LocalDate, Long> getDailySpending(Long userId, LocalDate start, LocalDate end) {
         return expenseRepository.sumGroupedByDate(userId, ExpenseStatus.ACTIVE, start, end).stream()
-                .collect(Collectors.toMap(ExpenseDailyTotal::date, total -> (int) total.totalAmount()));
+                .collect(Collectors.toMap(ExpenseDailyTotal::date, ExpenseDailyTotal::totalAmount));
     }
 
     /** GET/PUT/DELETE 공통 조회 진입점. DELETED 지출은 존재해도 EXPENSE_NOT_FOUND로 처리. */

--- a/src/main/java/Hampouch/server/domain/expense/service/PeriodSpending.java
+++ b/src/main/java/Hampouch/server/domain/expense/service/PeriodSpending.java
@@ -7,7 +7,7 @@ import java.util.List;
  * totalAmount는 emotionBreakdown의 ratio 분모와 같은 값을 노출해 둔 것 — 응답과 문구가 다른 집계를 보지 않게 한다.
  */
 public record PeriodSpending(
-        int totalAmount,
+        long totalAmount,
         List<EmotionSpending> emotionBreakdown
 ) {
 }

--- a/src/test/java/Hampouch/server/domain/challenge/service/ChallengeCalculatorTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/service/ChallengeCalculatorTest.java
@@ -232,6 +232,16 @@ class ChallengeCalculatorTest {
     }
 
     @Test
+    @DisplayName("실지출이 int 범위를 넘어도 예외 없이 추천 목표를 계산한다 — 하루 등록 건수 상한이 없어 int로는 표현 불가능하기 때문(#252 확장)")
+    void recommendedBudgetTotal_handlesActualSpentBeyondIntRange() {
+        long beyondIntRange = Integer.MAX_VALUE + 1_000_000_000L;
+        long overAmount = beyondIntRange - 280000;
+        assertThat(ChallengeCalculator.recommendedBudgetTotal(
+                ChallengeStatus.FAIL, null, 280000, beyondIntRange))
+                .isEqualTo(280000 + overAmount / 2 + overAmount % 2);
+    }
+
+    @Test
     @DisplayName("성공 상태인데 실지출이 목표를 초과한 모순 데이터는 추천 목표를 계산하지 않는다")
     void recommendedBudgetTotal_rejectsInconsistentSuccess() {
         assertThatThrownBy(() -> ChallengeCalculator.recommendedBudgetTotal(

--- a/src/test/java/Hampouch/server/domain/challenge/service/ChallengeCalculatorTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/service/ChallengeCalculatorTest.java
@@ -51,11 +51,11 @@ class ChallengeCalculatorTest {
     void summarizeThrough_map_success() {
         int dailyLimit = ChallengeCalculator.dailyLimit(280000, 14); // 20000
         Challenge ch = challenge(dailyLimit);
-        Map<LocalDate, Integer> spentByDate = new HashMap<>();
+        Map<LocalDate, Long> spentByDate = new HashMap<>();
         for (int i = 0; i < 13; i++) {
-            spentByDate.put(START.plusDays(i), 15000);
+            spentByDate.put(START.plusDays(i), 15000L);
         }
-        spentByDate.put(START.plusDays(13), 16800);
+        spentByDate.put(START.plusDays(13), 16800L);
 
         ChallengeSummary s = ChallengeCalculator.summarizeThrough(
                 spentByDate, DailyLimitTimeline.of(ch, List.of()), START, START.plusDays(13));
@@ -73,10 +73,10 @@ class ChallengeCalculatorTest {
         int dailyLimit = 10000;
         Challenge ch = challenge(dailyLimit);
         LocalDate end = START.plusDays(3); // 기간 4일(5/1~5/4)
-        Map<LocalDate, Integer> spentByDate = new HashMap<>();
-        spentByDate.put(START, 8000);                  // 5/1 성공(절약 2000)
-        spentByDate.put(START.plusDays(2), 12000);      // 5/3 초과(2000)
-        spentByDate.put(START.plusDays(3), 0);          // 5/4 명시적 0원 성공 · 5/2는 맵에 아예 없음(미기록)
+        Map<LocalDate, Long> spentByDate = new HashMap<>();
+        spentByDate.put(START, 8000L);                  // 5/1 성공(절약 2000)
+        spentByDate.put(START.plusDays(2), 12000L);      // 5/3 초과(2000)
+        spentByDate.put(START.plusDays(3), 0L);          // 5/4 명시적 0원 성공 · 5/2는 맵에 아예 없음(미기록)
 
         ChallengeSummary s = ChallengeCalculator.summarizeThrough(
                 spentByDate, DailyLimitTimeline.of(ch, List.of()), START, end);
@@ -95,11 +95,11 @@ class ChallengeCalculatorTest {
         int limit = 20000;
         Challenge ch = challenge(limit);
         DailyLimitTimeline limits = DailyLimitTimeline.of(ch, List.of());
-        Map<LocalDate, Integer> spentByDate = Map.of(
-                START.plusDays(0), 1000,    // SUCCESS
-                START.plusDays(1), 1000,    // SUCCESS
-                START.plusDays(2), 99999,   // OVER (연속 끊김)
-                START.plusDays(3), 1000);   // SUCCESS
+        Map<LocalDate, Long> spentByDate = Map.of(
+                START.plusDays(0), 1000L,    // SUCCESS
+                START.plusDays(1), 1000L,    // SUCCESS
+                START.plusDays(2), 99999L,   // OVER (연속 끊김)
+                START.plusDays(3), 1000L);   // SUCCESS
         // START.plusDays(4)는 맵에 없음 — 0원 성공으로 취급돼 스트릭에 포함
 
         assertThat(ChallengeCalculator.currentStreakAsOf(spentByDate, limits, START, START.plusDays(4))).isEqualTo(2);
@@ -115,11 +115,11 @@ class ChallengeCalculatorTest {
         DailyLimitTimeline limits = DailyLimitTimeline.of(ch, List.of(
                 adjustment(ch, 1, adjustedOn, 10000, 11000)));
         // 날짜마다 전부 명시해 "맵에 없는 날 = 0원 성공"이 스트릭에 섞여 들어오지 않게 한다.
-        Map<LocalDate, Integer> spentByDate = Map.of(
-                START, 10500,                       // 5/1 — 옛 한도(10000) 기준 OVER
-                START.plusDays(1), 10500,           // 5/2 — 옛 한도 기준 OVER
-                adjustedOn, 10500,                   // 5/3 — 새 한도(11000) 기준 SUCCESS
-                adjustedOn.plusDays(1), 10500);     // 5/4 — 새 한도 기준 SUCCESS
+        Map<LocalDate, Long> spentByDate = Map.of(
+                START, 10500L,                       // 5/1 — 옛 한도(10000) 기준 OVER
+                START.plusDays(1), 10500L,           // 5/2 — 옛 한도 기준 OVER
+                adjustedOn, 10500L,                   // 5/3 — 새 한도(11000) 기준 SUCCESS
+                adjustedOn.plusDays(1), 10500L);     // 5/4 — 새 한도 기준 SUCCESS
 
         // 옛 한도를 계속 썼다면(=날짜별로 다시 안 쟀다면) 5/1·5/2도 새 한도 11000 기준 SUCCESS가 돼 스트릭이 4가 됐을 것.
         // 실제로는 5/2에서 옛 한도로 OVER가 나와 끊기므로, 그 자리에서 날짜별 한도를 정확히 재계산한다는 증거가 된다.

--- a/src/test/java/Hampouch/server/domain/challenge/service/ChallengeCalculatorTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/service/ChallengeCalculatorTest.java
@@ -90,6 +90,26 @@ class ChallengeCalculatorTest {
     }
 
     @Test
+    @DisplayName("여러 날 누적 지출이 int 범위를 넘어도 예외 없이 그대로 집계한다 — 하루 등록 건수 상한이 없어 int로는 표현 불가능하기 때문(#252 확장)")
+    void summarizeThrough_map_handlesActualSpentBeyondIntRange() {
+        int dailyLimit = 10000;
+        Challenge ch = challenge(dailyLimit);
+        LocalDate end = START.plusDays(2); // 기간 3일
+        long hugeDailyTotal = 1_000_000_000L; // 10억원짜리 하루가 사흘 연속이면 int(약 21억)를 넘는다
+        Map<LocalDate, Long> spentByDate = Map.of(
+                START, hugeDailyTotal,
+                START.plusDays(1), hugeDailyTotal,
+                START.plusDays(2), hugeDailyTotal);
+
+        ChallengeSummary s = ChallengeCalculator.summarizeThrough(
+                spentByDate, DailyLimitTimeline.of(ch, List.of()), START, end);
+
+        assertThat(s.actualSpent()).isEqualTo(3_000_000_000L);
+        assertThat(s.overDays()).isEqualTo(3);
+        assertThat(s.overAmount()).isEqualTo(3_000_000_000L - 3L * dailyLimit);
+    }
+
+    @Test
     @DisplayName("Map 버전 currentStreakAsOf도 맵에 없는 날짜를 0원 성공으로 이어간다 (#101 확장)")
     void currentStreakAsOf_map_countsMissingDateAsZeroSpentSuccess() {
         int limit = 20000;

--- a/src/test/java/Hampouch/server/domain/challenge/service/ChallengeServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/service/ChallengeServiceTest.java
@@ -188,7 +188,7 @@ class ChallengeServiceTest {
         Challenge ch = inProgress(LocalDate.of(2026, 6, 1));
         when(challengeRepository.findById(10L)).thenReturn(Optional.of(ch));
         when(expenseService.getDailySpending(USER, LocalDate.of(2026, 6, 1), ch.getEndDate()))
-                .thenReturn(Map.of(LocalDate.of(2026, 6, 1), 10000, LocalDate.of(2026, 6, 2), 12000));
+                .thenReturn(Map.of(LocalDate.of(2026, 6, 1), 10000L, LocalDate.of(2026, 6, 2), 12000L));
 
         ResultResponse res = serviceAt(LocalDate.of(2026, 6, 20)).getResult(USER, 10L);
 
@@ -299,7 +299,7 @@ class ChallengeServiceTest {
         when(challengeRepository.findActiveOnDate(USER, selectedDate))
                 .thenReturn(Optional.of(challenge));
         when(expenseService.getDailySpending(USER, LocalDate.of(2026, 6, 1), selectedDate))
-                .thenReturn(Map.of(LocalDate.of(2026, 6, 1), 5000, selectedDate, 15000));
+                .thenReturn(Map.of(LocalDate.of(2026, 6, 1), 5000L, selectedDate, 15000L));
         when(expenseService.getDaySpending(USER, selectedDate)).thenReturn(new DaySpending(15000, true));
         when(challengeAdjustmentRepository.findByChallenge_IdOrderByEffectiveDateAscIdAsc(10L))
                 .thenReturn(List.of(laterAdjustment));
@@ -808,7 +808,7 @@ class ChallengeServiceTest {
         Challenge ch = inProgress(LocalDate.of(2026, 6, 1));
         when(challengeRepository.findById(10L)).thenReturn(Optional.of(ch));
         when(expenseService.getDailySpending(USER, LocalDate.of(2026, 6, 1), ch.getEndDate()))
-                .thenReturn(Map.of(LocalDate.of(2026, 6, 1), 10000, LocalDate.of(2026, 6, 2), 299999));
+                .thenReturn(Map.of(LocalDate.of(2026, 6, 1), 10000L, LocalDate.of(2026, 6, 2), 299999L));
 
         ResultResponse res = serviceAt(LocalDate.of(2026, 6, 20)).getResult(USER, 10L);
 
@@ -845,7 +845,7 @@ class ChallengeServiceTest {
         Challenge ch = inProgress(LocalDate.of(2026, 6, 1));
         when(challengeRepository.findById(10L)).thenReturn(Optional.of(ch));
         when(expenseService.getDailySpending(USER, LocalDate.of(2026, 6, 1), LocalDate.of(2026, 6, 14)))
-                .thenReturn(Map.of(LocalDate.of(2026, 6, 3), 5000));
+                .thenReturn(Map.of(LocalDate.of(2026, 6, 3), 5000L));
 
         CalendarResponse res = serviceAt(LocalDate.of(2026, 6, 5)).getCalendar(USER, 10L, 2026, 6);
 
@@ -883,7 +883,7 @@ class ChallengeServiceTest {
         when(challengeRepository.findCompletedByUserIdOrderByEndDateDescIdDesc(USER))
                 .thenReturn(List.of(c12, c8)); // 최근 종료(6/7)가 먼저 — 정렬은 리포지토리 쿼리 몫
         when(expenseService.getDailySpending(USER, LocalDate.of(2026, 5, 1), LocalDate.of(2026, 6, 7)))
-                .thenReturn(Map.of(LocalDate.of(2026, 6, 3), 15000));
+                .thenReturn(Map.of(LocalDate.of(2026, 6, 3), 15000L));
 
         ChallengeHistoryResponse res = serviceAt(LocalDate.of(2026, 7, 17)).getHistory(USER);
 
@@ -913,7 +913,7 @@ class ChallengeServiceTest {
         when(challengeRepository.findCompletedByUserIdOrderByEndDateDescIdDesc(USER))
                 .thenReturn(List.of(givenUp));
         when(expenseService.getDailySpending(USER, LocalDate.of(2026, 7, 1), LocalDate.of(2026, 7, 2)))
-                .thenReturn(Map.of(LocalDate.of(2026, 7, 1), 5000));
+                .thenReturn(Map.of(LocalDate.of(2026, 7, 1), 5000L));
 
         ChallengeHistoryResponse res = serviceAt(LocalDate.of(2026, 8, 1)).getHistory(USER);
 
@@ -1035,7 +1035,7 @@ class ChallengeServiceTest {
         ReflectionTestUtils.setField(ch, "id", 10L);
         when(challengeRepository.findByIdForUpdate(10L)).thenReturn(Optional.of(ch));
         when(expenseService.getDailySpending(USER, LocalDate.of(2026, 6, 1), ch.getEndDate()))
-                .thenReturn(Map.of(LocalDate.of(2026, 6, 1), 10000));
+                .thenReturn(Map.of(LocalDate.of(2026, 6, 1), 10000L));
 
         CloseResponse res = serviceAt(LocalDate.of(2026, 6, 20)).close(USER, 10L);
 
@@ -1319,7 +1319,7 @@ class ChallengeServiceTest {
                 USER, RECOMMENDATION_STATUSES))
                 .thenReturn(Optional.of(prev));
         when(expenseService.getDailySpending(USER, LocalDate.of(2026, 6, 1), prev.getEndDate()))
-                .thenReturn(Map.of(LocalDate.of(2026, 6, 1), 340000));
+                .thenReturn(Map.of(LocalDate.of(2026, 6, 1), 340000L));
 
         RecommendationResponse res = serviceAt(LocalDate.of(2026, 7, 10)).getRecommendation(USER);
 
@@ -1336,7 +1336,7 @@ class ChallengeServiceTest {
                 USER, RECOMMENDATION_STATUSES))
                 .thenReturn(Optional.of(prev));
         when(expenseService.getDailySpending(USER, LocalDate.of(2026, 6, 1), prev.getEndDate()))
-                .thenReturn(Map.of(LocalDate.of(2026, 6, 1), 100));
+                .thenReturn(Map.of(LocalDate.of(2026, 6, 1), 100L));
 
         RecommendationResponse res = serviceAt(LocalDate.of(2026, 7, 10)).getRecommendation(USER);
 
@@ -1364,7 +1364,7 @@ class ChallengeServiceTest {
                 USER, RECOMMENDATION_STATUSES))
                 .thenReturn(Optional.of(prev));
         when(expenseService.getDailySpending(USER, LocalDate.of(2026, 6, 1), prev.getEndDate()))
-                .thenReturn(Map.of(LocalDate.of(2026, 6, 1), 101));
+                .thenReturn(Map.of(LocalDate.of(2026, 6, 1), 101L));
 
         assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 7, 10)).getRecommendation(USER))
                 .isInstanceOf(IllegalStateException.class)
@@ -1394,7 +1394,7 @@ class ChallengeServiceTest {
                 USER, RECOMMENDATION_STATUSES))
                 .thenReturn(Optional.of(prev));
         when(expenseService.getDailySpending(USER, LocalDate.of(2026, 6, 1), prev.getEndDate()))
-                .thenReturn(Map.of(LocalDate.of(2026, 6, 1), 300000));
+                .thenReturn(Map.of(LocalDate.of(2026, 6, 1), 300000L));
 
         RecommendationResponse res = serviceAt(LocalDate.of(2026, 7, 10)).getRecommendation(USER);
 

--- a/src/test/java/Hampouch/server/domain/challenge/service/ChallengeServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/service/ChallengeServiceTest.java
@@ -447,6 +447,22 @@ class ChallengeServiceTest {
     }
 
     @Test
+    @DisplayName("오늘 지출 합계가 int 범위를 넘어도 예외 없이 그대로 반환한다 — 하루 등록 건수 상한이 없어 int로는 표현 불가능하기 때문(#252 확장)")
+    void current_handlesTodaySpentBeyondIntRange() {
+        Challenge ch = inProgress(LocalDate.of(2026, 6, 1));
+        LocalDate today = LocalDate.of(2026, 6, 5);
+        long beyondIntRange = Integer.MAX_VALUE + 1_000_000_000L;
+        when(challengeRepository.findActiveOnDate(USER, today))
+                .thenReturn(Optional.of(ch));
+        when(expenseService.getDaySpending(USER, today)).thenReturn(new DaySpending(beyondIntRange, true));
+
+        CurrentChallengeResponse res = serviceAt(today).getCurrent(USER);
+
+        assertThat(res.consumption().todaySpent()).isEqualTo(beyondIntRange);
+        assertThat(res.consumption().todayRemaining()).isEqualTo(ch.getDailyLimit() - beyondIntRange);
+    }
+
+    @Test
     @DisplayName("홈 현황의 조정 현황은 이력 행 수와 기간별 상한을 그대로 내려준다 — 14일 챌린지의 상한은 1회")
     void current_adjustmentCountsComeFromHistory() {
         LocalDate today = LocalDate.of(2026, 6, 5);
@@ -853,6 +869,22 @@ class ChallengeServiceTest {
         assertThat(res.days().getFirst().date()).isEqualTo(LocalDate.of(2026, 6, 3));
         assertThat(res.days().getFirst().spentAmount()).isEqualTo(5000);
         assertThat(res.days().getFirst().status()).isEqualTo(DayStatus.SUCCESS);
+    }
+
+    @Test
+    @DisplayName("하루 지출 합계가 int 범위를 넘어도 예외 없이 그대로 캘린더에 실린다 — 하루 등록 건수 상한이 없어 int로는 표현 불가능하기 때문(#252 확장)")
+    void calendar_handlesDailyTotalBeyondIntRange() {
+        Challenge ch = inProgress(LocalDate.of(2026, 6, 1));
+        when(challengeRepository.findById(10L)).thenReturn(Optional.of(ch));
+        long beyondIntRange = Integer.MAX_VALUE + 1_000_000_000L;
+        when(expenseService.getDailySpending(USER, LocalDate.of(2026, 6, 1), LocalDate.of(2026, 6, 14)))
+                .thenReturn(Map.of(LocalDate.of(2026, 6, 3), beyondIntRange));
+
+        CalendarResponse res = serviceAt(LocalDate.of(2026, 6, 5)).getCalendar(USER, 10L, 2026, 6);
+
+        assertThat(res.days()).hasSize(1);
+        assertThat(res.days().getFirst().spentAmount()).isEqualTo(beyondIntRange);
+        assertThat(res.days().getFirst().status()).isEqualTo(DayStatus.OVER);
     }
 
     @Test

--- a/src/test/java/Hampouch/server/domain/expense/controller/ExpenseControllerTest.java
+++ b/src/test/java/Hampouch/server/domain/expense/controller/ExpenseControllerTest.java
@@ -142,6 +142,19 @@ class ExpenseControllerTest {
     }
 
     @Test
+    @DisplayName("price가 상한 10,000,000원을 넘으면 400으로 거절한다")
+    void create_400_whenPriceOverMax() throws Exception {
+        mvc.perform(post("/api/expenses")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "name": "스타벅스", "price": 10000001, "category": "CAFE", "emotion": "STRESS",
+                                  "date": "2026-06-05" }
+                                """)
+                        )
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
     @DisplayName("category가 ETC인데 customCategory를 안 보내면 400으로 거절한다 (isCategoryConsistent)")
     void create_400_whenEtcCategoryMissingCustomCategory() throws Exception {
         mvc.perform(post("/api/expenses")
@@ -295,6 +308,18 @@ class ExpenseControllerTest {
                                 """))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.expenseId").value(1));
+    }
+
+    @Test
+    @DisplayName("수정 요청의 price가 상한 10,000,000원을 넘으면 400으로 거절한다")
+    void update_400_whenPriceOverMax() throws Exception {
+        mvc.perform(put("/api/expenses/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "name": "스타벅스", "price": 10000001, "category": "CAFE", "emotion": "STRESS",
+                                  "date": "2026-06-05" }
+                                """))
+                .andExpect(status().isBadRequest());
     }
 
     @Test

--- a/src/test/java/Hampouch/server/domain/expense/repository/ExpenseRepositoryTest.java
+++ b/src/test/java/Hampouch/server/domain/expense/repository/ExpenseRepositoryTest.java
@@ -95,15 +95,15 @@ class ExpenseRepositoryTest {
         expenseRepository.save(Expense.of("다른 유저 지출", 7000, ExpenseCategory.CAFE, ExpenseEmotion.STRESS, target, other));
         expenseRepository.flush();
 
-        int total = expenseRepository.sumPriceByUserIdAndExpenseDateAndStatus(user.getId(), target, ExpenseStatus.ACTIVE);
+        Long total = expenseRepository.sumPriceByUserIdAndExpenseDateAndStatus(user.getId(), target, ExpenseStatus.ACTIVE);
 
-        assertThat(total).isEqualTo(20000);
+        assertThat(total).isEqualTo(20000L);
     }
 
     @Test
     @DisplayName("sumPriceByUserIdAndExpenseDateAndStatus는 해당 조건의 지출이 하나도 없으면 0을 반환한다(coalesce 확인)")
     void sumPriceByUserIdAndExpenseDateAndStatus_returnsZeroWhenNoneMatch() {
-        int total = expenseRepository.sumPriceByUserIdAndExpenseDateAndStatus(
+        Long total = expenseRepository.sumPriceByUserIdAndExpenseDateAndStatus(
                 user.getId(), LocalDate.of(2026, 6, 5), ExpenseStatus.ACTIVE);
 
         assertThat(total).isZero();

--- a/src/test/java/Hampouch/server/domain/expense/service/ExpenseAnalysisServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/expense/service/ExpenseAnalysisServiceTest.java
@@ -201,6 +201,22 @@ class ExpenseAnalysisServiceTest {
         assertThat(result.pouchInsight()).isEqualTo("지출 기록이 없어 햄포치 분석을 제공하지 않아요!");
     }
 
+    @Test
+    @DisplayName("기간 내 지출 합계가 int 범위를 넘어도 예외 없이 그대로 반환한다 — 등록 건수 상한이 없어 int로는 표현 불가능하기 때문(#252 확장)")
+    void analyze_handlesTotalBeyondIntRange() {
+        when(expenseRepository.findPeriodExpenses(OWNER, ExpenseStatus.ACTIVE, PERIOD_START, PERIOD_END))
+                .thenReturn(List.of(
+                        expense(1, PERIOD_START, 1_000_000_000, ExpenseCategory.CAFE, ExpenseEmotion.STRESS),
+                        expense(2, PERIOD_START, 1_000_000_000, ExpenseCategory.CAFE, ExpenseEmotion.STRESS),
+                        expense(3, PERIOD_START, 1_000_000_000, ExpenseCategory.CAFE, ExpenseEmotion.STRESS)));
+
+        ExpenseAnalysisResponse result = serviceAt(LocalDate.of(2026, 6, 5)).analyze(OWNER, PERIOD_START, PERIOD_END);
+
+        assertThat(result.totalAmount()).isEqualTo(3_000_000_000L);
+        assertThat(result.categoryBreakdown().getFirst().amount()).isEqualTo(3_000_000_000L);
+        assertThat(result.categoryBreakdown().getFirst().ratio()).isEqualTo(100);
+    }
+
     /**
      * 서비스가 인사이트를 실제로 채워 내려주는지 확인 - 문구 분기 자체는 ExpenseInsightWriterTest가 본다.
      * 여기서 확인하는 건 서비스가 Writer에게 넘기는 재료(PeriodFacts)가 맞게 채워졌는가다.

--- a/src/test/java/Hampouch/server/domain/expense/service/ExpenseInsightWriterTest.java
+++ b/src/test/java/Hampouch/server/domain/expense/service/ExpenseInsightWriterTest.java
@@ -441,7 +441,7 @@ class ExpenseInsightWriterTest {
      * 적지 않은 카테고리는 0원으로 들어간다. 문구가 .get(0), .get(1)을 그냥 꺼내 쓸 수 있는 근거가 이 고정 길이다.
      */
     private static List<CategoryAmount> categories(int totalAmount, Map<ExpenseCategory, Integer> amounts) {
-        Comparator<CategoryAmount> byAmount = Comparator.comparingInt(CategoryAmount::amount);
+        Comparator<CategoryAmount> byAmount = Comparator.comparingLong(CategoryAmount::amount);
         return Arrays.stream(ExpenseCategory.values())
                 .map(category -> {
                     int amount = amounts.getOrDefault(category, 0);
@@ -453,7 +453,7 @@ class ExpenseInsightWriterTest {
 
     /** 이유 5개 전부, 같은 규칙. */
     private static List<EmotionAmount> emotions(int totalAmount, Map<ExpenseEmotion, Integer> amounts) {
-        Comparator<EmotionAmount> byAmount = Comparator.comparingInt(EmotionAmount::amount);
+        Comparator<EmotionAmount> byAmount = Comparator.comparingLong(EmotionAmount::amount);
         return Arrays.stream(ExpenseEmotion.values())
                 .map(emotion -> {
                     int amount = amounts.getOrDefault(emotion, 0);

--- a/src/test/java/Hampouch/server/domain/expense/service/ExpenseServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/expense/service/ExpenseServiceTest.java
@@ -1051,7 +1051,7 @@ class ExpenseServiceTest {
     @DisplayName("getDaySpending은 리포지토리의 합계·존재 여부를 그대로 DaySpending에 담아 반환한다")
     void getDaySpending_buildsFromRepository() {
         LocalDate date = LocalDate.of(2026, 6, 5);
-        when(expenseRepository.sumPriceByUserIdAndExpenseDateAndStatus(OWNER, date, ExpenseStatus.ACTIVE)).thenReturn(8000);
+        when(expenseRepository.sumPriceByUserIdAndExpenseDateAndStatus(OWNER, date, ExpenseStatus.ACTIVE)).thenReturn(8000L);
         when(expenseRepository.existsByUser_IdAndExpenseDateAndStatus(OWNER, date, ExpenseStatus.ACTIVE)).thenReturn(true);
 
         DaySpending result = service().getDaySpending(OWNER, date);
@@ -1063,7 +1063,7 @@ class ExpenseServiceTest {
     @DisplayName("해당 날짜에 기록이 하나도 없으면 totalAmount=0, hasRecord=false로 구분된다")
     void getDaySpending_returnsZeroAndNoRecordWhenNothingLogged() {
         LocalDate date = LocalDate.of(2026, 6, 5);
-        when(expenseRepository.sumPriceByUserIdAndExpenseDateAndStatus(OWNER, date, ExpenseStatus.ACTIVE)).thenReturn(0);
+        when(expenseRepository.sumPriceByUserIdAndExpenseDateAndStatus(OWNER, date, ExpenseStatus.ACTIVE)).thenReturn(0L);
         when(expenseRepository.existsByUser_IdAndExpenseDateAndStatus(OWNER, date, ExpenseStatus.ACTIVE)).thenReturn(false);
         when(noSpendDayRepository.existsByUser_IdAndRecordDate(OWNER, date)).thenReturn(false);
 
@@ -1079,7 +1079,7 @@ class ExpenseServiceTest {
     @DisplayName("합계가 0원이어도 hasRecord가 true면 그대로 true로 반환된다 (합계=0과 기록없음을 혼동하지 않는지 확인)")
     void getDaySpending_keepsHasRecordTrueEvenWhenTotalIsZero() {
         LocalDate date = LocalDate.of(2026, 6, 5);
-        when(expenseRepository.sumPriceByUserIdAndExpenseDateAndStatus(OWNER, date, ExpenseStatus.ACTIVE)).thenReturn(0);
+        when(expenseRepository.sumPriceByUserIdAndExpenseDateAndStatus(OWNER, date, ExpenseStatus.ACTIVE)).thenReturn(0L);
         when(expenseRepository.existsByUser_IdAndExpenseDateAndStatus(OWNER, date, ExpenseStatus.ACTIVE)).thenReturn(true);
         DaySpending result = service().getDaySpending(OWNER, date);
 
@@ -1090,7 +1090,7 @@ class ExpenseServiceTest {
     @DisplayName("지출 항목 없이 '오늘은 안 썼어요' 기록만 저장돼도 hasRecord=true로 반환한다")
     void getDaySpending_includesNoSpendDayInHasRecord() {
         LocalDate date = LocalDate.of(2026, 6, 5);
-        when(expenseRepository.sumPriceByUserIdAndExpenseDateAndStatus(OWNER, date, ExpenseStatus.ACTIVE)).thenReturn(0);
+        when(expenseRepository.sumPriceByUserIdAndExpenseDateAndStatus(OWNER, date, ExpenseStatus.ACTIVE)).thenReturn(0L);
         when(expenseRepository.existsByUser_IdAndExpenseDateAndStatus(OWNER, date, ExpenseStatus.ACTIVE)).thenReturn(false);
         when(noSpendDayRepository.existsByUser_IdAndRecordDate(OWNER, date)).thenReturn(true);
 
@@ -1099,10 +1099,23 @@ class ExpenseServiceTest {
         assertThat(result).isEqualTo(new DaySpending(0, true));
     }
 
+    @Test
+    @DisplayName("하루 합계가 int 범위를 넘어도 예외 없이 그대로 반환한다 — 건수 상한이 없어 int로는 표현 불가능하기 때문(#252 확장)")
+    void getDaySpending_handlesTotalBeyondIntRange() {
+        LocalDate date = LocalDate.of(2026, 6, 5);
+        long beyondIntRange = Integer.MAX_VALUE + 1_000_000_000L;
+        when(expenseRepository.sumPriceByUserIdAndExpenseDateAndStatus(OWNER, date, ExpenseStatus.ACTIVE)).thenReturn(beyondIntRange);
+        when(expenseRepository.existsByUser_IdAndExpenseDateAndStatus(OWNER, date, ExpenseStatus.ACTIVE)).thenReturn(true);
+
+        DaySpending result = service().getDaySpending(OWNER, date);
+
+        assertThat(result).isEqualTo(new DaySpending(beyondIntRange, true));
+    }
+
     // ---------- getDailySpending ----------
 
     @Test
-    @DisplayName("getDailySpending은 리포지토리의 날짜별 합계를 Map<LocalDate,Integer>로 옮겨 담는다 (#101 확장 — Challenge 기간 집계용)")
+    @DisplayName("getDailySpending은 리포지토리의 날짜별 합계를 Map<LocalDate,Long>으로 옮겨 담는다 (#101 확장 — Challenge 기간 집계용)")
     void getDailySpending_buildsMapFromRepository() {
         LocalDate start = LocalDate.of(2026, 6, 1);
         LocalDate end = LocalDate.of(2026, 6, 10);
@@ -1111,11 +1124,11 @@ class ExpenseServiceTest {
                         new ExpenseDailyTotal(LocalDate.of(2026, 6, 3), 8000L),
                         new ExpenseDailyTotal(LocalDate.of(2026, 6, 7), 15000L)));
 
-        Map<LocalDate, Integer> result = service().getDailySpending(OWNER, start, end);
+        Map<LocalDate, Long> result = service().getDailySpending(OWNER, start, end);
 
         assertThat(result).containsExactlyInAnyOrderEntriesOf(Map.of(
-                LocalDate.of(2026, 6, 3), 8000,
-                LocalDate.of(2026, 6, 7), 15000));
+                LocalDate.of(2026, 6, 3), 8000L,
+                LocalDate.of(2026, 6, 7), 15000L));
     }
 
     @Test
@@ -1126,6 +1139,20 @@ class ExpenseServiceTest {
         when(expenseRepository.sumGroupedByDate(OWNER, ExpenseStatus.ACTIVE, start, end)).thenReturn(List.of());
 
         assertThat(service().getDailySpending(OWNER, start, end)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("특정 날짜의 합계가 int 범위를 넘어도 예외 없이 그대로 반환한다 — 건수 상한이 없어 int로는 표현 불가능하기 때문(#252 확장)")
+    void getDailySpending_handlesDailyTotalBeyondIntRange() {
+        LocalDate start = LocalDate.of(2026, 6, 1);
+        LocalDate end = LocalDate.of(2026, 6, 10);
+        long beyondIntRange = Integer.MAX_VALUE + 1_000_000_000L;
+        when(expenseRepository.sumGroupedByDate(OWNER, ExpenseStatus.ACTIVE, start, end))
+                .thenReturn(List.of(new ExpenseDailyTotal(LocalDate.of(2026, 6, 3), beyondIntRange)));
+
+        Map<LocalDate, Long> result = service().getDailySpending(OWNER, start, end);
+
+        assertThat(result).containsExactly(Map.entry(LocalDate.of(2026, 6, 3), beyondIntRange));
     }
 
     // ---------- fixtures ----------

--- a/src/test/java/Hampouch/server/domain/expense/service/ExpenseServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/expense/service/ExpenseServiceTest.java
@@ -915,6 +915,19 @@ class ExpenseServiceTest {
         assertThat(res.expenses()).isEmpty();
     }
 
+    @Test
+    @DisplayName("하루 지출 합계가 int 범위를 넘어도 예외 없이 그대로 반환한다 — 건수 상한이 없어 int로는 표현 불가능하기 때문(#252 확장)")
+    void getDayList_handlesTotalBeyondIntRange() {
+        Expense e1 = Expense.of("지출1", 1_500_000_000, ExpenseCategory.CAFE, ExpenseEmotion.STRESS, TODAY, user(OWNER));
+        Expense e2 = Expense.of("지출2", 1_500_000_000, ExpenseCategory.CAFE, ExpenseEmotion.STRESS, TODAY, user(OWNER));
+        when(expenseRepository.findByUser_IdAndExpenseDateAndStatus(OWNER, TODAY, ExpenseStatus.ACTIVE))
+                .thenReturn(List.of(e1, e2));
+
+        ExpenseDayListResponse res = service().getDayList(OWNER, TODAY);
+
+        assertThat(res.totalAmount()).isEqualTo(3_000_000_000L);
+    }
+
     // ---------- getWeekSummary / getMonthSummary ----------
 
     @Test
@@ -982,6 +995,22 @@ class ExpenseServiceTest {
         assertThat(res.totalAmount()).isEqualTo(0);
         assertThat(res.dailyAverage()).isEqualTo(0);
         assertThat(res.dailyBreakdown()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("기간 합계가 int 범위를 넘어도 예외 없이 그대로 반환한다 — 등록 건수 상한이 없어 int로는 표현 불가능하기 때문(#252 확장)")
+    void getWeekSummary_handlesTotalBeyondIntRange() {
+        LocalDate periodStart = LocalDate.of(2026, 6, 7);
+        LocalDate periodEnd = LocalDate.of(2026, 6, 13);
+        long beyondIntRange = Integer.MAX_VALUE + 1_000_000_000L;
+        when(expenseRepository.sumGroupedByDate(OWNER, ExpenseStatus.ACTIVE, periodStart, periodEnd))
+                .thenReturn(List.of(new ExpenseDailyTotal(LocalDate.of(2026, 6, 8), beyondIntRange)));
+
+        ExpenseSummaryResponse res = serviceAt(LocalDate.of(2026, 6, 20)).getWeekSummary(OWNER, LocalDate.of(2026, 6, 10));
+
+        assertThat(res.totalAmount()).isEqualTo(beyondIntRange);
+        assertThat(res.dailyBreakdown()).extracting(ExpenseSummaryResponse.DailyAmount::totalAmount)
+                .containsExactly(beyondIntRange);
     }
 
     @Test


### PR DESCRIPTION
## 📎연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) closes #[issue number]

- close: #257

## 📄 작업 내용 요약
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.

Expense/Challenge 도메인에서 지출 금액을 여러 건·여러 날에 걸쳐 합산하는 경로들이 `int` 오버플로에 안전하지 않던 문제를 고칩니다(#252 리뷰 코멘트에서 최초 지적). 개별 지출에 상한이 없었고, 설령 개별 값에 상한을 둬도 등록 건수 자체에는 상한이 없어 합계가 int 범위(약 21억)를 넘을 수 있는 구조였습니다.

- `Expense.PRICE_MAX = 10_000_000` 상수 추가, `ExpenseCreateRequest`/`ExpenseUpdateRequest`에 `@Max` 검증 추가
- `ExpenseRepository.sumPriceByUserIdAndExpenseDateAndStatus()`, `DaySpending.totalAmount`, `ExpenseService.getDaySpending()/getDailySpending()` → `long`/`Map<LocalDate, Long>`
- `ExpenseDayListResponse`, `ExpenseSummaryResponse`(day/week/month 응답)의 금액 필드 → `long`
- `ExpenseAnalysisResponse`, `ExpenseCategoryDetailResponse`, `ExpenseEmotionDetailResponse`, `ExpenseTrendResponse`, `PeriodSpending`, `EmotionSpending`, `ExpenseInsightWriter`(분석/추이 응답)의 금액 필드 → `long`(`ratio`/`count`처럼 금액이 아닌 값은 int 유지)
- `ChallengeCalculator`(judge/usageRate/resultStatus/summarizeThrough/recommendedBudgetTotal), `ChallengeSummary` → 다중일 누적 금액을 `long`으로 계산
- `ResultResponse.Summary`, `ChallengeHistoryResponse.Item`, `CurrentChallengeResponse.Progress.savedAmountSoFar` → `long`
- 각 집계 경로(일별/기간/분석/챌린지 누적)가 int 범위를 넘는 값을 예외 없이 정상 처리하는지 확인하는 경계 테스트, price 상한 경계값 테스트 추가

## 👀 중요 변경 사항
> API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요

- 아래 응답 필드들이 `int`에서 `long`으로 바뀝니다(클라이언트 타입 생성에 영향 줄 수 있어 공유 필요):
  - `GET /expenses/day` `totalAmount`
  - `GET /expenses/summary/week`, `/summary/month` `totalAmount`, `dailyAverage`, `dailyBreakdown[].totalAmount`
  - `GET /expenses/analysis` `totalAmount`, `categoryBreakdown[].amount`, `emotionBreakdown[].amount`, `weekdayBreakdown[].amount`
  - `GET /expenses/analysis/category/{category}`, `/analysis/emotion/{emotion}` `totalAmount`
  - `GET /expenses/analysis/trend` `totalAmount`, `monthlyAverage`, `trend[].amount`
  - `GET /api/challenges/{id}/result` `summary.savedAmount`, `summary.overAmount`, `summary.actualSpent`
  - `GET /api/challenges/history` `items[].actualSpent`, `items[].savedAmount`
  - `GET /api/challenges/current` `progress.savedAmountSoFar`
- `POST /expenses`, `PUT /expenses/{expenseId}`의 `price`에 상한(1000만원) 검증이 새로 생겨, 기존에는 통과하던 그 이상의 값은 400으로 거절됩니다.
- `budgetTotal`/`dailyLimit`과 하루치 단일값(캘린더의 `spentAmount`, 오늘 소비현황의 `todaySpent`/`todayRemaining` 등)은 그대로 `int`입니다 — 전부 바뀌는 게 아니라 "여러 건/여러 날을 합산하는 값"만 대상입니다.

## 🔖 Uncompleted Tasks
> 후속 작업 예정인 사항이 있다면 작성해주세요.

- 없음

## 📢 To Reviewers
> Reviewer가 주로 확인해주었으면 하는 부분을 적어주세요.

- int로 유지한 필드와 long으로 바꾼 필드의 경계 기준(개별/단일값 vs 여러 건·여러 날 합산)이 타당한지 봐주세요.
- `ChallengeDay.spentAmount`는 DB 컬럼이지만 `POST /days`로 직접 받는 단일 값이라 마이그레이션 없이 int로 남겼습니다 — 이 판단에 동의하시는지 확인 부탁드립니다.