### PR TITLE
fix: 배틀 참여 제약의 원인 구분

### DIFF
--- a/src/main/java/Hampouch/server/domain/battle/entity/BattleParticipant.java
+++ b/src/main/java/Hampouch/server/domain/battle/entity/BattleParticipant.java
@@ -19,9 +19,11 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "battle_participant",
-        uniqueConstraints = @UniqueConstraint(name = "uq_battle_participant", columnNames = {"battle_id", "user_id"}))
+        uniqueConstraints = @UniqueConstraint(name = BattleParticipant.PARTICIPANT_UNIQUE, columnNames = {"battle_id", "user_id"}))
 @EntityListeners(AuditingEntityListener.class)
 public class BattleParticipant {
+
+    public static final String PARTICIPANT_UNIQUE = "uq_battle_participant";
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/Hampouch/server/domain/battle/service/BattleService.java
+++ b/src/main/java/Hampouch/server/domain/battle/service/BattleService.java
@@ -17,6 +17,7 @@ import Hampouch.server.global.common.exception.CustomException;
 import Hampouch.server.global.common.exception.domain.BattleErrorCode;
 import Hampouch.server.global.common.exception.domain.CommonErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -104,7 +105,7 @@ public class BattleService {
         try {
             battleParticipantRepository.save(BattleParticipant.of(user, battle));
         } catch (DataIntegrityViolationException e) {
-            throw new CustomException(BattleErrorCode.ALREADY_JOINED);
+            throw alreadyJoinedOr(e);
         }
         return JoinBattleResponse.from(battle);
     }
@@ -142,6 +143,18 @@ public class BattleService {
         if (!startDate.isAfter(LocalDate.now(clock))) {
             throw new CustomException(BattleErrorCode.INVALID_START_DATE);
         }
+    }
+
+    /**
+     * 저장 실패가 uq_battle_participant 위반이면 409로 바꾸고, 그 외 제약 위반은 원래 예외를 그대로 돌려준다.
+     * FK 위반까지 이미 참가함으로 뭉개면 서버 결함이 정상 사용자 오류로 감춰진다.
+     */
+    private static RuntimeException alreadyJoinedOr(DataIntegrityViolationException e) {
+        boolean alreadyJoined = e.getCause() instanceof ConstraintViolationException cause
+                && cause.getConstraintName() != null
+                && cause.getConstraintName().toUpperCase(Locale.ROOT)
+                        .contains(BattleParticipant.PARTICIPANT_UNIQUE.toUpperCase(Locale.ROOT));
+        return alreadyJoined ? new CustomException(BattleErrorCode.ALREADY_JOINED) : e;
     }
 
     /**

--- a/src/test/java/Hampouch/server/domain/battle/BattleConcurrencyMySqlTest.java
+++ b/src/test/java/Hampouch/server/domain/battle/BattleConcurrencyMySqlTest.java
@@ -12,6 +12,7 @@ import Hampouch.server.global.common.exception.BaseErrorCode;
 import Hampouch.server.global.common.exception.CustomException;
 import Hampouch.server.global.common.exception.domain.BattleErrorCode;
 import Hampouch.server.global.mysql.MySqlContainerTest;
+import org.hibernate.exception.ConstraintViolationException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -100,7 +101,9 @@ class BattleConcurrencyMySqlTest {
      * 이 제약을 지우면(마이그레이션 롤백 등) 이 테스트가 실패한다.
      */
     @Test
-    @DisplayName("uq_battle_participant 제약이 동일 배틀·동일 유저의 중복 참가 저장을 막는다")
+    @DisplayName("uq_battle_participant 제약이 동일 배틀·동일 유저의 중복 참가 저장을 막고, " +
+            "실제 MySQL이 돌려주는 제약 이름도 PARTICIPANT_UNIQUE와 일치한다 — " +
+            "BattleService.alreadyJoinedOr()의 이름 비교가 실제 DB에서도 통하는지 확인")
         void uniqueConstraintRejectsDuplicateParticipantRow() {
         User creator = newUser("unique-constraint-creator");
         Battle battle = newBattle(creator, 4);
@@ -109,7 +112,10 @@ class BattleConcurrencyMySqlTest {
 
         assertThatThrownBy(() ->
                 battleParticipantRepository.saveAndFlush(BattleParticipant.of(challenger, battle)))
-                .isInstanceOf(DataIntegrityViolationException.class);
+                .isInstanceOf(DataIntegrityViolationException.class)
+                .cause().isInstanceOf(ConstraintViolationException.class)
+                .extracting(e -> ((ConstraintViolationException) e).getConstraintName())
+                .satisfies(name -> assertThat((String) name).containsIgnoringCase(BattleParticipant.PARTICIPANT_UNIQUE));
     }
 
     /**

--- a/src/test/java/Hampouch/server/domain/battle/service/BattleServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/battle/service/BattleServiceTest.java
@@ -16,6 +16,7 @@ import Hampouch.server.domain.user.repository.UserRepository;
 import Hampouch.server.global.common.exception.CustomException;
 import Hampouch.server.global.common.exception.domain.BattleErrorCode;
 import Hampouch.server.global.common.exception.domain.CommonErrorCode;
+import org.hibernate.exception.ConstraintViolationException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,6 +26,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.sql.SQLException;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -71,6 +73,12 @@ class BattleServiceTest {
 
     private static CreateBattleRequest request(int capacity, int durationDays, LocalDate startDate) {
         return new CreateBattleRequest("짠테크 배틀", capacity, durationDays, startDate, "치킨 사주기");
+    }
+
+    /** 스프링이 하이버네이트 제약 위반을 감싸 올려보내는 실제 모양 — 이름 없는 예외로는 검증이 안 된다. */
+    private static DataIntegrityViolationException violationOf(String constraintName) {
+        return new DataIntegrityViolationException("could not execute statement",
+                new ConstraintViolationException("constraint violation", new SQLException(), constraintName));
     }
 
     /** 참가 링크 조회/참가 테스트 공용 — status별 Battle을 만들어 BATTLE_ID를 부여한다. */
@@ -427,11 +435,27 @@ class BattleServiceTest {
         when(battleParticipantRepository.countByBattle_Id(BATTLE_ID)).thenReturn(2);
         when(userRepository.getReferenceById(OWNER)).thenReturn(user(OWNER));
         when(battleParticipantRepository.save(any(BattleParticipant.class)))
-                .thenThrow(new DataIntegrityViolationException("uq_battle_participant"));
+                .thenThrow(violationOf(BattleParticipant.PARTICIPANT_UNIQUE));
 
         assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 7, 1)).join(OWNER, "ABCD1234"))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", BattleErrorCode.ALREADY_JOINED);
+    }
+
+    @Test
+    @DisplayName("uq_battle_participant가 아닌 다른 무결성 위반(예: user_id FK)은 ALREADY_JOINED로 바꾸지 않고 " +
+            "원래 예외를 그대로 던진다 — 서버 결함을 정상 사용자 오류로 감추지 않기 위함")
+    void join_rethrowsNonUniqueConstraintViolation() {
+        Battle battle = battleWithStatus(BattleStatus.READY, 4);
+        when(battleRepository.findByBattleCodeForUpdate("ABCD1234")).thenReturn(Optional.of(battle));
+        when(battleParticipantRepository.existsByBattle_IdAndUser_Id(BATTLE_ID, OWNER)).thenReturn(false);
+        when(battleParticipantRepository.countByBattle_Id(BATTLE_ID)).thenReturn(2);
+        when(userRepository.getReferenceById(OWNER)).thenReturn(user(OWNER));
+        when(battleParticipantRepository.save(any(BattleParticipant.class)))
+                .thenThrow(violationOf("fk_battle_participant_user"));
+
+        assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 7, 1)).join(OWNER, "ABCD1234"))
+                .isInstanceOf(DataIntegrityViolationException.class);
     }
 
     // ---------- getBattleDetail ----------


### PR DESCRIPTION
## 📎연관된 이슈
- close: #245

## 📄 작업 내용 요약
- `BattleService.join()`이 참가자 저장 실패 시 원인을 가리지 않고 전부 `ALREADY_JOINED`(409)로 바꾸던 문제를 수정했습니다.
  - `battle_participant`에는 `uq_battle_participant` 유니크 외에 `user_id`·`battle_id` FK(둘 다 `nullable = false`)도 있어, FK 위반까지 같은 409로 감춰지고 있었습니다.
  - `UserRestService.alreadyRestingOr`와 동일한 패턴으로, `ConstraintViolationException.getConstraintName()`이 `uq_battle_participant`를 포함할 때만 `ALREADY_JOINED`로 변환하고, 그 외 무결성 위반은 원래 예외를 그대로 던지도록 변경했습니다.
- `BattleParticipant`의 제약 이름 리터럴(`"uq_battle_participant"`)을 `PARTICIPANT_UNIQUE` 상수로 추출해 엔티티 선언과 서비스의 예외 판별이 같은 상수를 참조하도록 했습니다.
- 기존 유니크 위반 테스트를 실제 하이버네이트가 감싸는 예외 모양(`violationOf()` 헬퍼)으로 고치고, FK 등 다른 무결성 위반은 원래 예외 그대로 올라오는지 확인하는 테스트를 추가했습니다.

## 👀 중요 변경 사항
- `POST /battles/{battleCode}/join`에서 `uq_battle_participant` 위반이 아닌 다른 무결성 위반(예: 참가 대상 유저가 검증 후 삭제되는 경쟁 상황의 FK 위반)은 더 이상 409 `ALREADY_JOINED`가 아니라 원래 예외 그대로 500으로 드러납니다.
- 같은 문제가 챌린지 도메인에도 있지만, 생성·날짜 고정 시작 경로는 #137 에서, 목표 조정 경로는 #244 로 분리되어 이번 PR 범위에는 포함하지 않았습니다.

## 🔖 Uncompleted Tasks
(없음)

## 📢 To Reviewers
- `alreadyJoinedOr()`의 제약 이름 비교(대소문자 무시 `contains`)가 `UserRestService.alreadyRestingOr`와 같은 방식인지, H2/MySQL 양쪽에서 문제없는지 확인해 주세요.