### PR TITLE
fix(challenge): 날짜 고정 최초 주기 예산 배분과 초안 일치성 정리

### DIFF
--- a/src/main/java/Hampouch/server/domain/challenge/dto/StartFixedDateChallengeRequest.java
+++ b/src/main/java/Hampouch/server/domain/challenge/dto/StartFixedDateChallengeRequest.java
@@ -3,12 +3,21 @@ package Hampouch.server.domain.challenge.dto;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
+import java.time.LocalDate;
+
 /**
  * 고정 날짜 챌린지 시작을 위한 DTO, 기간·고정일·목표는 모두 직전 챌린지와 오늘로부터 서버가 계산.
  */
 public record StartFixedDateChallengeRequest(
         @NotNull
         @Positive
-        Long sourceChallengeId
+        Long sourceChallengeId,
+
+        /**
+         * 클라이언트가 초안에서 받은 주기 시작일. 계산에는 쓰지 않고 초안이 아직 유효한지 확인만 한다.
+         * 늦게 입장하면 주기 시작일이 과거이므로 @FutureOrPresent를 붙이면 안 된다.
+         */
+        @NotNull
+        LocalDate startDate
 ) {
 }

--- a/src/main/java/Hampouch/server/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/Hampouch/server/domain/challenge/service/ChallengeService.java
@@ -56,22 +56,24 @@ public class ChallengeService {
         LocalDate today = LocalDate.now(clock);
         LocalDate startDate = req.startDate();
         int durationDays;
+        int budgetTotal = req.budgetTotal();
         if (req.fixedDay() != null) {
             // 날짜 고정의 최초 챌린지는 설정 당일 즉시 시작한다 — 미래 시작일은 계약 밖이다.
             if (startDate.isAfter(today)) {
                 throw new CustomException(CommonErrorCode.BAD_REQUEST);
             }
             durationDays = FixedDateChallengeCycle.startingOn(startDate, req.fixedDay()).durationDays();
+            budgetTotal = firstCycleBudget(budgetTotal, startDate, req.fixedDay(), durationDays);
         } else {
             durationDays = req.durationDays();
         }
         userRestRepository.findActiveOn(userId, today).ifPresent(rest -> rest.resume(today));
-        int dailyLimit = ChallengeCalculator.dailyLimit(req.budgetTotal(), durationDays);
+        int dailyLimit = ChallengeCalculator.dailyLimit(budgetTotal, durationDays);
         Challenge challenge = Challenge.builder()
                 .userId(userId)
                 .durationDays(durationDays)
                 .startDate(startDate)
-                .budgetTotal(req.budgetTotal())
+                .budgetTotal(budgetTotal)
                 .dailyLimit(dailyLimit)
                 .fixedDay(req.fixedDay())
                 .build();
@@ -97,6 +99,33 @@ public class ChallengeService {
                 && cause.getConstraintName().toUpperCase(Locale.ROOT)
                         .contains(Challenge.ACTIVE_USER_UNIQUE.toUpperCase(Locale.ROOT));
         return alreadyInProgress ? new CustomException(ChallengeErrorCode.CHALLENGE_ALREADY_IN_PROGRESS) : e;
+    }
+
+    /**
+     * 최초 설정이 고정일 경계에서 시작하지 않으면 한 달 목표를 주기 길이에 비례해 배분한다.
+     * 배분하지 않으면 고정일 전날 설정한 사람의 하루 한도가 한 달 목표 전액이 된다.
+     */
+    private static int firstCycleBudget(int monthlyBudgetTotal, LocalDate startDate,
+                                        int fixedDay, int durationDays) {
+        if (FixedDateChallengeCycle.isCycleStart(startDate, fixedDay)) {
+            return monthlyBudgetTotal;
+        }
+        return Math.toIntExact(
+                (long) monthlyBudgetTotal * durationDays / FixedDateChallengeCycle.STANDARD_CYCLE_DAYS);
+    }
+
+    /**
+     * 다음 주기가 이어받을 한 달 목표.
+     * budgetTotal이 목표를 담는 유일한 자리라, 부분 주기용으로 배분해 저장한 값을 그대로 물려주면
+     * 월 목표가 주기마다 깎인다(300,000 → 250,000 → …). 부분 주기면 배분을 되돌려 복원한다.
+     * 정수 나눗셈 손실은 한 번뿐이고, 두 번째 주기부터는 온전 주기라 그대로 상속돼 누적되지 않는다.
+     */
+    private static int monthlyBudgetOf(Challenge latest) {
+        if (FixedDateChallengeCycle.isCycleStart(latest.getStartDate(), latest.getFixedDay())) {
+            return latest.getBudgetTotal();
+        }
+        return Math.toIntExact((long) latest.getBudgetTotal()
+                * FixedDateChallengeCycle.STANDARD_CYCLE_DAYS / latest.getDurationDays());
     }
 
     private void transferSameDayRecord(Long userId, Challenge challenge) {
@@ -126,9 +155,10 @@ public class ChallengeService {
         }
         // 늦게 열어도 주기는 고정일에 정렬된다 — 초안의 시작일은 오늘이 아니라 이번 주기의 고정일이다.
         FixedDateChallengeCycle.Plan plan = FixedDateChallengeCycle.containing(today, latest.getFixedDay());
-        int dailyLimit = ChallengeCalculator.dailyLimit(latest.getBudgetTotal(), plan.durationDays());
+        int budgetTotal = monthlyBudgetOf(latest);
+        int dailyLimit = ChallengeCalculator.dailyLimit(budgetTotal, plan.durationDays());
         return new NextFixedDateChallengeResponse(latest.getId(), latest.getFixedDay(),
-                plan.startDate(), plan.endDate(), plan.durationDays(), latest.getBudgetTotal(), dailyLimit);
+                plan.startDate(), plan.endDate(), plan.durationDays(), budgetTotal, dailyLimit);
     }
 
     /**
@@ -164,13 +194,14 @@ public class ChallengeService {
         }
         userRestRepository.findActiveOn(userId, today).ifPresent(rest -> rest.resume(today));
         FixedDateChallengeCycle.Plan plan = FixedDateChallengeCycle.containing(today, latest.getFixedDay());
-        int dailyLimit = ChallengeCalculator.dailyLimit(latest.getBudgetTotal(), plan.durationDays());
+        int budgetTotal = monthlyBudgetOf(latest);
+        int dailyLimit = ChallengeCalculator.dailyLimit(budgetTotal, plan.durationDays());
         Challenge challenge = Challenge.builder()
                 .userId(userId)
                 .durationDays(plan.durationDays())
                 .startDate(plan.startDate())
                 .activatedDate(today) // 주기 시작일과 실제 입장일이 다를 수 있다.
-                .budgetTotal(latest.getBudgetTotal())
+                .budgetTotal(budgetTotal)
                 .dailyLimit(dailyLimit)
                 .fixedDay(latest.getFixedDay())
                 .build();

--- a/src/main/java/Hampouch/server/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/Hampouch/server/domain/challenge/service/ChallengeService.java
@@ -192,8 +192,13 @@ public class ChallengeService {
         if (!today.isAfter(latest.getEndDate())) {
             throw new CustomException(ChallengeErrorCode.FIXED_DATE_NOT_DUE);
         }
-        userRestRepository.findActiveOn(userId, today).ifPresent(rest -> rest.resume(today));
         FixedDateChallengeCycle.Plan plan = FixedDateChallengeCycle.containing(today, latest.getFixedDay());
+        // 초안을 조회한 뒤 자정을 넘겨 입장하면 서버가 계산하는 주기가 달라진다. sourceChallengeId는
+        // 그대로라 위 검사를 통과하므로, 클라이언트가 본 주기와 다르면 초안을 다시 조회하게 돌려보낸다.
+        if (!plan.startDate().equals(req.startDate())) {
+            throw new CustomException(ChallengeErrorCode.FIXED_DATE_SOURCE_STALE);
+        }
+        userRestRepository.findActiveOn(userId, today).ifPresent(rest -> rest.resume(today));
         int budgetTotal = monthlyBudgetOf(latest);
         int dailyLimit = ChallengeCalculator.dailyLimit(budgetTotal, plan.durationDays());
         Challenge challenge = Challenge.builder()

--- a/src/main/java/Hampouch/server/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/Hampouch/server/domain/challenge/service/ChallengeService.java
@@ -175,6 +175,7 @@ public class ChallengeService {
         if (active.isPresent()) {
             Challenge current = active.get();
             if (isStartedForCycleOf(userId, current, today, req)) {
+                requireSameCycleAsDraft(current.getStartDate(), req);
                 return CreateChallengeResponse.from(current);
             }
             throw new CustomException(ChallengeErrorCode.CHALLENGE_ALREADY_IN_PROGRESS);
@@ -184,6 +185,7 @@ public class ChallengeService {
                 .orElseThrow(() -> new CustomException(ChallengeErrorCode.FIXED_DATE_SETTING_NOT_FOUND));
         // 생성 직후 자동 취소된 챌린지는 진행 중으로 남지 않으므로 최신 챌린지 쪽에서도 멱등을 판정한다.
         if (isStartedForCycleOf(userId, latest, today, req)) {
+            requireSameCycleAsDraft(latest.getStartDate(), req);
             return CreateChallengeResponse.from(latest);
         }
         if (!latest.getId().equals(req.sourceChallengeId())) {
@@ -193,11 +195,7 @@ public class ChallengeService {
             throw new CustomException(ChallengeErrorCode.FIXED_DATE_NOT_DUE);
         }
         FixedDateChallengeCycle.Plan plan = FixedDateChallengeCycle.containing(today, latest.getFixedDay());
-        // 초안을 조회한 뒤 자정을 넘겨 입장하면 서버가 계산하는 주기가 달라진다. sourceChallengeId는
-        // 그대로라 위 검사를 통과하므로, 클라이언트가 본 주기와 다르면 초안을 다시 조회하게 돌려보낸다.
-        if (!plan.startDate().equals(req.startDate())) {
-            throw new CustomException(ChallengeErrorCode.FIXED_DATE_SOURCE_STALE);
-        }
+        requireSameCycleAsDraft(plan.startDate(), req);
         userRestRepository.findActiveOn(userId, today).ifPresent(rest -> rest.resume(today));
         int budgetTotal = monthlyBudgetOf(latest);
         int dailyLimit = ChallengeCalculator.dailyLimit(budgetTotal, plan.durationDays());
@@ -219,6 +217,20 @@ public class ChallengeService {
         // 이미 3일이 지나 입장했다면 생성과 동시에 자동 취소된다 — 조회를 기다리지 않고 여기서 확정한다.
         evaluateExpenseInputState(userId, challenge, today);
         return CreateChallengeResponse.from(challenge);
+    }
+
+    /**
+     * 요청이 들고 온 초안의 주기가 이번 주기와 같은지 확인한다.
+     * 초안 조회와 입장 사이에 자정이 지나면 서버가 계산하는 주기가 달라지는데 sourceChallengeId는
+     * 그대로라 다른 검사를 전부 통과한다. 다르면 초안을 다시 조회하도록 409로 돌려보낸다.
+     * 새로 만드는 경로와 이미 만든 챌린지를 돌려주는 멱등 경로가 같은 규칙을 쓴다 —
+     * 한쪽만 검사하면 낡은 초안으로 요청해도 200이 나가 "시작일이 다르면 409" 계약이 깨진다.
+     */
+    private static void requireSameCycleAsDraft(LocalDate cycleStartDate,
+                                                StartFixedDateChallengeRequest req) {
+        if (!cycleStartDate.equals(req.startDate())) {
+            throw new CustomException(ChallengeErrorCode.FIXED_DATE_SOURCE_STALE);
+        }
     }
 
     /**

--- a/src/main/java/Hampouch/server/domain/challenge/service/FixedDateChallengeCycle.java
+++ b/src/main/java/Hampouch/server/domain/challenge/service/FixedDateChallengeCycle.java
@@ -6,7 +6,22 @@ import java.time.temporal.ChronoUnit;
 
 final class FixedDateChallengeCycle {
 
+    /**
+     * 부분 주기의 목표를 배분할 때 기준으로 삼는 한 달 길이.
+     * 실제 주기 길이(28~31일)로 나누면 같은 목표라도 설정한 달에 따라 첫 주기 예산이 갈린다.
+     */
+    static final int STANDARD_CYCLE_DAYS = 30;
+
     private FixedDateChallengeCycle() {
+    }
+
+    /**
+     * 그 날짜가 고정일 주기의 시작 경계인지 — 아니면 설정 당일부터 시작한 부분 주기다.
+     * 부분 주기는 최초 설정(create)에서만 생긴다. 도래 후 입장은 언제나 containing이 잡아준
+     * 경계에서 시작하므로 항상 온전한 주기다.
+     */
+    static boolean isCycleStart(LocalDate date, int fixedDay) {
+        return date.equals(containing(date, fixedDay).startDate());
     }
 
     static Plan startingOn(LocalDate startDate, int fixedDay) {

--- a/src/test/java/Hampouch/server/domain/challenge/ChallengeConcurrencyMySqlTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/ChallengeConcurrencyMySqlTest.java
@@ -180,7 +180,7 @@ class ChallengeConcurrencyMySqlTest {
         User user = newUser("fixed-date-start");
         LocalDate today = today();
         Challenge source = endedFixedDateSource(user.getId(), today);
-        var request = new StartFixedDateChallengeRequest(source.getId());
+        var request = new StartFixedDateChallengeRequest(source.getId(), today);
 
         OrderedRace<CreateChallengeResponse, CreateChallengeResponse> outcomes = orderedRace(
                 () -> challengeService.startFixedDate(user.getId(), request),
@@ -205,7 +205,7 @@ class ChallengeConcurrencyMySqlTest {
         User user = newUser("fixed-date-rest");
         LocalDate today = today();
         Challenge source = endedFixedDateSource(user.getId(), today);
-        var request = new StartFixedDateChallengeRequest(source.getId());
+        var request = new StartFixedDateChallengeRequest(source.getId(), today);
 
         OrderedRace<CreateChallengeResponse, RestStartResponse> outcomes = orderedRace(
                 () -> challengeService.startFixedDate(user.getId(), request),

--- a/src/test/java/Hampouch/server/domain/challenge/controller/ChallengeControllerTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/controller/ChallengeControllerTest.java
@@ -264,6 +264,18 @@ class ChallengeControllerTest {
     }
 
     @Test
+    @DisplayName("날짜 고정 챌린지 시작 요청에 초안의 시작일이 없으면 400을 반환한다")
+    void startFixedDate_400_whenStartDateIsMissing() throws Exception {
+        mvc.perform(post("/api/challenges/fixed-date/start")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                { "sourceChallengeId": 10 }
+                                """))
+                .andExpect(status().isBadRequest());
+        verify(service, never()).startFixedDate(anyLong(), any());
+    }
+
+    @Test
     @DisplayName("이미 진행 중인 챌린지가 있으면 409와 팀 공통 에러 본문을 돌려준다 (S6)")
     void create_409() throws Exception {
         when(service.create(anyLong(), any())).thenThrow(new CustomException(ChallengeErrorCode.CHALLENGE_ALREADY_IN_PROGRESS));

--- a/src/test/java/Hampouch/server/domain/challenge/controller/ChallengeControllerTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/controller/ChallengeControllerTest.java
@@ -244,7 +244,7 @@ class ChallengeControllerTest {
         mvc.perform(post("/api/challenges/fixed-date/start")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                                { "sourceChallengeId": 10 }
+                                { "sourceChallengeId": 10, "startDate": "2026-12-01" }
                                 """))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.challengeId").value(11))
@@ -257,7 +257,7 @@ class ChallengeControllerTest {
         mvc.perform(post("/api/challenges/fixed-date/start")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                                { "sourceChallengeId": 0 }
+                                { "sourceChallengeId": 0, "startDate": "2026-12-01" }
                                 """))
                 .andExpect(status().isBadRequest());
         verify(service, never()).startFixedDate(anyLong(), any());

--- a/src/test/java/Hampouch/server/domain/challenge/service/ChallengeServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/service/ChallengeServiceTest.java
@@ -208,6 +208,36 @@ class ChallengeServiceTest {
     }
 
     @Test
+    @DisplayName("고정일 당일에 설정하면 온전한 주기라 목표를 배분하지 않고 그대로 쓴다")
+    void create_fixedDateKeepsWholeBudgetWhenStartingOnCycleBoundary() {
+        when(challengeRepository.save(any(Challenge.class))).thenAnswer(inv -> inv.getArgument(0));
+        var req = new CreateChallengeRequest(null, 300000, LocalDate.of(2026, 8, 1), 1);
+
+        CreateChallengeResponse res = serviceAt(LocalDate.of(2026, 8, 1)).create(USER, req);
+
+        assertThat(res.startDate()).isEqualTo(LocalDate.of(2026, 8, 1));
+        assertThat(res.endDate()).isEqualTo(LocalDate.of(2026, 8, 31));
+        assertThat(res.durationDays()).isEqualTo(31);
+        assertThat(res.budgetTotal()).isEqualTo(300000);
+        assertThat(res.dailyLimit()).isEqualTo(9677); // 300,000 / 31
+    }
+
+    @Test
+    @DisplayName("고정일 전날에 설정해 첫 주기가 하루뿐이어도 하루 한도는 한 달 목표가 아니라 하루치다")
+    void create_fixedDateProratesSingleDayFirstCycle() {
+        when(challengeRepository.save(any(Challenge.class))).thenAnswer(inv -> inv.getArgument(0));
+        var req = new CreateChallengeRequest(null, 300000, LocalDate.of(2026, 8, 14), 15);
+
+        CreateChallengeResponse res = serviceAt(LocalDate.of(2026, 8, 14)).create(USER, req);
+
+        assertThat(res.durationDays()).isEqualTo(1);
+        assertThat(res.endDate()).isEqualTo(LocalDate.of(2026, 8, 14));
+        // 배분하지 않으면 300,000원이 하루 한도가 된다
+        assertThat(res.budgetTotal()).isEqualTo(10000);
+        assertThat(res.dailyLimit()).isEqualTo(10000);
+    }
+
+    @Test
     @DisplayName("날짜 고정 챌린지를 처음 만들 때 시작일을 미래로 지정하면 요청을 거절한다")
     void create_fixedDateRejectsFutureInitialStart() {
         LocalDate today = LocalDate.of(2026, 8, 7);
@@ -447,6 +477,108 @@ class ChallengeServiceTest {
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ChallengeErrorCode.FIXED_DATE_NOT_DUE);
         verify(challengeRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("직전이 배분된 부분 주기면 한 달 목표를 역산해 상속하고 축소된 값을 물려주지 않는다")
+    void startFixedDate_restoresMonthlyBudgetFromPartialFirstCycle() {
+        LocalDate today = LocalDate.of(2026, 9, 1);
+        // 300,000원을 25일에 배분해 250,000원으로 저장된 최초 부분 주기
+        Challenge source = fixedChallengeWithId(
+                10L, LocalDate.of(2026, 8, 7), 25, 250000, 10000, 1, ChallengeStatus.SUCCESS);
+        when(challengeRepository.findFirstByUserIdOrderByCreatedAtDescIdDesc(USER))
+                .thenReturn(Optional.of(source));
+        when(challengeRepository.save(any(Challenge.class))).thenAnswer(inv -> {
+            Challenge challenge = inv.getArgument(0);
+            ReflectionTestUtils.setField(challenge, "id", 11L);
+            return challenge;
+        });
+        var req = new StartFixedDateChallengeRequest(10L, today);
+
+        CreateChallengeResponse res = serviceAt(today).startFixedDate(USER, req);
+
+        // 250,000 × 30 / 25 = 300,000으로 복원된다
+        assertThat(res.budgetTotal()).isEqualTo(300000);
+        assertThat(res.dailyLimit()).isEqualTo(10000);
+        ArgumentCaptor<Challenge> saved = ArgumentCaptor.forClass(Challenge.class);
+        verify(challengeRepository).save(saved.capture());
+        assertThat(saved.getValue().getBudgetTotal()).isEqualTo(300000);
+    }
+
+    @Test
+    @DisplayName("직전이 온전한 주기면 역산하지 않고 목표를 그대로 상속한다")
+    void startFixedDate_keepsBudgetWhenPreviousCycleIsWhole() {
+        LocalDate today = LocalDate.of(2026, 9, 1);
+        Challenge source = fixedChallengeWithId(
+                10L, LocalDate.of(2026, 8, 1), 31, 300000, 9677, 1, ChallengeStatus.SUCCESS);
+        when(challengeRepository.findFirstByUserIdOrderByCreatedAtDescIdDesc(USER))
+                .thenReturn(Optional.of(source));
+        when(challengeRepository.save(any(Challenge.class))).thenAnswer(inv -> {
+            Challenge challenge = inv.getArgument(0);
+            ReflectionTestUtils.setField(challenge, "id", 11L);
+            return challenge;
+        });
+        var req = new StartFixedDateChallengeRequest(10L, today);
+
+        CreateChallengeResponse res = serviceAt(today).startFixedDate(USER, req);
+
+        assertThat(res.budgetTotal()).isEqualTo(300000);
+        assertThat(res.dailyLimit()).isEqualTo(10000); // 30일 주기라 하루 한도만 달라진다
+    }
+
+    @Test
+    @DisplayName("부분 주기에서 목표를 조정했으면 조정된 값을 기준으로 한 달 목표를 역산한다")
+    void startFixedDate_restoresAdjustedMonthlyBudgetFromPartialCycle() {
+        LocalDate today = LocalDate.of(2026, 9, 1);
+        Challenge source = fixedChallengeWithId(
+                10L, LocalDate.of(2026, 8, 7), 25, 250000, 10000, 1, ChallengeStatus.IN_PROGRESS);
+        source.adjustGoal(200000, 8000);
+        source.applyResult(ChallengeStatus.SUCCESS);
+        when(challengeRepository.findFirstByUserIdOrderByCreatedAtDescIdDesc(USER))
+                .thenReturn(Optional.of(source));
+        when(challengeRepository.save(any(Challenge.class))).thenAnswer(inv -> {
+            Challenge challenge = inv.getArgument(0);
+            ReflectionTestUtils.setField(challenge, "id", 11L);
+            return challenge;
+        });
+        var req = new StartFixedDateChallengeRequest(10L, today);
+
+        CreateChallengeResponse res = serviceAt(today).startFixedDate(USER, req);
+
+        // 200,000 × 30 / 25 = 240,000
+        assertThat(res.budgetTotal()).isEqualTo(240000);
+        assertThat(res.dailyLimit()).isEqualTo(8000);
+    }
+
+    @Test
+    @DisplayName("초안을 조회한 뒤 자정을 넘겨 입장하면 초안의 주기가 낡았으므로 거절한다")
+    void startFixedDate_rejectsStaleDraftCycle() {
+        Challenge source = fixedChallengeWithId(
+                10L, LocalDate.of(2026, 8, 1), 31, 300000, 9677, 1, ChallengeStatus.SUCCESS);
+        when(challengeRepository.findFirstByUserIdOrderByCreatedAtDescIdDesc(USER))
+                .thenReturn(Optional.of(source));
+        // 9/30에 조회한 초안(9/1~9/30)을 들고 10/1에 입장 — sourceChallengeId는 그대로라 통과한다
+        var req = new StartFixedDateChallengeRequest(10L, LocalDate.of(2026, 9, 1));
+
+        assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 10, 1)).startFixedDate(USER, req))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ChallengeErrorCode.FIXED_DATE_SOURCE_STALE);
+        verify(challengeRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("초안 조회도 직전 부분 주기의 한 달 목표를 역산해 보여준다")
+    void nextFixedDateChallenge_restoresMonthlyBudgetFromPartialFirstCycle() {
+        Challenge source = fixedChallengeWithId(
+                10L, LocalDate.of(2026, 8, 7), 25, 250000, 10000, 1, ChallengeStatus.SUCCESS);
+        when(challengeRepository.findFirstByUserIdOrderByCreatedAtDescIdDesc(USER))
+                .thenReturn(Optional.of(source));
+
+        NextFixedDateChallengeResponse res = serviceAt(LocalDate.of(2026, 9, 1))
+                .getNextFixedDateChallenge(USER);
+
+        assertThat(res.budgetTotal()).isEqualTo(300000);
+        assertThat(res.dailyLimit()).isEqualTo(10000);
     }
 
     @Test

--- a/src/test/java/Hampouch/server/domain/challenge/service/ChallengeServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/service/ChallengeServiceTest.java
@@ -189,14 +189,16 @@ class ChallengeServiceTest {
     }
 
     @Test
-    @DisplayName("날짜 고정 챌린지를 처음 만들면 오늘부터 첫 고정일 전날까지의 기간과 하루 한도를 계산한다")
+    @DisplayName("날짜 고정 챌린지를 처음 만들면 첫 고정일 전날까지를 주기로 잡고 목표를 기간에 비례해 배분한다")
     void create_fixedDateComputesFirstCycle() {
         when(challengeRepository.save(any(Challenge.class))).thenAnswer(inv -> inv.getArgument(0));
-        var req = new CreateChallengeRequest(null, 250000, LocalDate.of(2026, 8, 7), 1);
+        var req = new CreateChallengeRequest(null, 300000, LocalDate.of(2026, 8, 7), 1);
 
         CreateChallengeResponse res = serviceAt(LocalDate.of(2026, 8, 7)).create(USER, req);
 
         assertThat(res.endDate()).isEqualTo(LocalDate.of(2026, 8, 31));
+        // 25일짜리 부분 주기 → 300,000 × 25 / 30 = 250,000, 하루 한도는 온전 주기와 같은 10,000원
+        assertThat(res.budgetTotal()).isEqualTo(250000);
         assertThat(res.dailyLimit()).isEqualTo(10000);
         ArgumentCaptor<Challenge> saved = ArgumentCaptor.forClass(Challenge.class);
         verify(challengeRepository).save(saved.capture());
@@ -237,7 +239,7 @@ class ChallengeServiceTest {
     @DisplayName("고정일보다 늦게 조회해도 현재 주기의 원래 고정일부터 다음 고정일 전날까지 계산한다")
     void nextFixedDateChallenge_keepsOriginalCycleWhenOpenedLate() {
         Challenge source = fixedChallengeWithId(
-                10L, LocalDate.of(2026, 8, 7), 25, 270000, 10800, 1, ChallengeStatus.SUCCESS);
+                10L, LocalDate.of(2026, 8, 1), 31, 270000, 8709, 1, ChallengeStatus.SUCCESS);
         when(challengeRepository.findFirstByUserIdOrderByCreatedAtDescIdDesc(USER))
                 .thenReturn(Optional.of(source));
 
@@ -277,7 +279,7 @@ class ChallengeServiceTest {
         LocalDate today = LocalDate.of(2026, 9, 3);
         LocalDate cycleStart = LocalDate.of(2026, 9, 1);
         Challenge source = fixedChallengeWithId(
-                10L, LocalDate.of(2026, 8, 7), 25, 350000, 14000, 1, ChallengeStatus.SUCCESS);
+                10L, LocalDate.of(2026, 8, 1), 31, 350000, 11290, 1, ChallengeStatus.SUCCESS);
         UserRest rest = UserRest.start(USER, LocalDate.of(2026, 9, 1), 7);
         when(challengeRepository.findFirstByUserIdOrderByCreatedAtDescIdDesc(USER))
                 .thenReturn(Optional.of(source));

--- a/src/test/java/Hampouch/server/domain/challenge/service/ChallengeServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/service/ChallengeServiceTest.java
@@ -291,7 +291,7 @@ class ChallengeServiceTest {
         });
         when(expenseService.hasDayRecord(USER, LocalDate.of(2026, 9, 2))).thenReturn(false);
         when(expenseService.hasDayRecord(USER, LocalDate.of(2026, 9, 1))).thenReturn(false);
-        var req = new StartFixedDateChallengeRequest(10L);
+        var req = new StartFixedDateChallengeRequest(10L, LocalDate.of(2026, 9, 1));
 
         CreateChallengeResponse res = serviceAt(today).startFixedDate(USER, req);
 
@@ -320,7 +320,7 @@ class ChallengeServiceTest {
         when(challengeRepository.findInProgress(USER)).thenReturn(Optional.of(active));
         when(challengeRepository.findFirstByUserIdAndIdNotOrderByCreatedAtDescIdDesc(USER, 11L))
                 .thenReturn(Optional.of(source));
-        var req = new StartFixedDateChallengeRequest(10L);
+        var req = new StartFixedDateChallengeRequest(10L, LocalDate.of(2026, 9, 1));
 
         CreateChallengeResponse res = serviceAt(today).startFixedDate(USER, req);
 
@@ -351,7 +351,7 @@ class ChallengeServiceTest {
                 .thenReturn(Optional.of(cancelled));
         when(challengeRepository.findFirstByUserIdAndIdNotOrderByCreatedAtDescIdDesc(USER, 11L))
                 .thenReturn(Optional.of(source));
-        var req = new StartFixedDateChallengeRequest(10L);
+        var req = new StartFixedDateChallengeRequest(10L, LocalDate.of(2026, 9, 1));
 
         CreateChallengeResponse res = serviceAt(today).startFixedDate(USER, req);
 
@@ -367,7 +367,7 @@ class ChallengeServiceTest {
                 12L, LocalDate.of(2026, 8, 7), 25, 300000, 12000, 1, ChallengeStatus.SUCCESS);
         when(challengeRepository.findFirstByUserIdOrderByCreatedAtDescIdDesc(USER))
                 .thenReturn(Optional.of(latest));
-        var req = new StartFixedDateChallengeRequest(10L);
+        var req = new StartFixedDateChallengeRequest(10L, LocalDate.of(2026, 9, 1));
 
         assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 9, 1)).startFixedDate(USER, req))
                 .isInstanceOf(CustomException.class)
@@ -391,7 +391,7 @@ class ChallengeServiceTest {
         when(expenseService.hasDayRecord(USER, LocalDate.of(2026, 9, 3))).thenReturn(false);
         when(expenseService.hasDayRecord(USER, LocalDate.of(2026, 9, 2))).thenReturn(false);
         when(expenseService.hasDayRecord(USER, LocalDate.of(2026, 9, 1))).thenReturn(false);
-        var req = new StartFixedDateChallengeRequest(10L);
+        var req = new StartFixedDateChallengeRequest(10L, LocalDate.of(2026, 9, 1));
 
         CreateChallengeResponse res = serviceAt(today).startFixedDate(USER, req);
 
@@ -421,7 +421,7 @@ class ChallengeServiceTest {
         when(expenseService.hasDayRecord(USER, LocalDate.of(2026, 9, 23))).thenReturn(false);
         when(expenseService.hasDayRecord(USER, LocalDate.of(2026, 9, 22))).thenReturn(false);
         when(expenseService.hasDayRecord(USER, LocalDate.of(2026, 9, 21))).thenReturn(false);
-        var req = new StartFixedDateChallengeRequest(10L);
+        var req = new StartFixedDateChallengeRequest(10L, LocalDate.of(2026, 9, 1));
 
         CreateChallengeResponse res = serviceAt(today).startFixedDate(USER, req);
 
@@ -441,7 +441,7 @@ class ChallengeServiceTest {
                 10L, LocalDate.of(2026, 8, 7), 25, 300000, 12000, 1, ChallengeStatus.FAIL);
         when(challengeRepository.findFirstByUserIdOrderByCreatedAtDescIdDesc(USER))
                 .thenReturn(Optional.of(source));
-        var req = new StartFixedDateChallengeRequest(10L);
+        var req = new StartFixedDateChallengeRequest(10L, LocalDate.of(2026, 8, 1));
 
         assertThatThrownBy(() -> serviceAt(LocalDate.of(2026, 8, 20)).startFixedDate(USER, req))
                 .isInstanceOf(CustomException.class)

--- a/src/test/java/Hampouch/server/domain/challenge/service/ChallengeServiceTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/service/ChallengeServiceTest.java
@@ -567,6 +567,54 @@ class ChallengeServiceTest {
     }
 
     @Test
+    @DisplayName("이번 주기 챌린지가 진행 중이어도 요청이 낡은 초안이면 기존 결과를 주지 않고 거절한다")
+    void startFixedDate_rejectsStaleDraftWhenCycleChallengeIsInProgress() {
+        LocalDate today = LocalDate.of(2026, 9, 5);
+        Challenge source = fixedChallengeWithId(
+                10L, LocalDate.of(2026, 8, 1), 31, 300000, 9677, 1, ChallengeStatus.SUCCESS);
+        Challenge active = fixedChallengeWithId(
+                11L, LocalDate.of(2026, 9, 1), 30, 300000, 10000, 1, ChallengeStatus.IN_PROGRESS);
+        when(challengeRepository.findInProgress(USER)).thenReturn(Optional.of(active));
+        when(challengeRepository.findFirstByUserIdAndIdNotOrderByCreatedAtDescIdDesc(USER, 11L))
+                .thenReturn(Optional.of(source));
+        // 8월 주기 초안을 캐시한 클라이언트가 9월 주기가 진행 중인 상태에서 보낸 요청
+        var req = new StartFixedDateChallengeRequest(10L, LocalDate.of(2026, 8, 1));
+
+        assertThatThrownBy(() -> serviceAt(today).startFixedDate(USER, req))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ChallengeErrorCode.FIXED_DATE_SOURCE_STALE);
+    }
+
+    @Test
+    @DisplayName("이번 주기 챌린지가 자동 취소로 끝났어도 요청이 낡은 초안이면 거절한다")
+    void startFixedDate_rejectsStaleDraftWhenCycleChallengeWasAutoCancelled() {
+        LocalDate today = LocalDate.of(2026, 9, 5);
+        Challenge source = fixedChallengeWithId(
+                10L, LocalDate.of(2026, 8, 1), 31, 300000, 9677, 1, ChallengeStatus.SUCCESS);
+        Challenge cancelled = Challenge.builder()
+                .userId(USER)
+                .durationDays(30)
+                .startDate(LocalDate.of(2026, 9, 1))
+                .activatedDate(LocalDate.of(2026, 9, 4))
+                .budgetTotal(300000)
+                .dailyLimit(10000)
+                .fixedDay(1)
+                .build();
+        ReflectionTestUtils.setField(cancelled, "id", 11L);
+        cancelled.cancelForMissingInput(LocalDate.of(2026, 9, 3));
+        when(challengeRepository.findFirstByUserIdOrderByCreatedAtDescIdDesc(USER))
+                .thenReturn(Optional.of(cancelled));
+        when(challengeRepository.findFirstByUserIdAndIdNotOrderByCreatedAtDescIdDesc(USER, 11L))
+                .thenReturn(Optional.of(source));
+        var req = new StartFixedDateChallengeRequest(10L, LocalDate.of(2026, 8, 1));
+
+        assertThatThrownBy(() -> serviceAt(today).startFixedDate(USER, req))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ChallengeErrorCode.FIXED_DATE_SOURCE_STALE);
+        verify(challengeRepository, never()).save(any());
+    }
+
+    @Test
     @DisplayName("초안 조회도 직전 부분 주기의 한 달 목표를 역산해 보여준다")
     void nextFixedDateChallenge_restoresMonthlyBudgetFromPartialFirstCycle() {
         Challenge source = fixedChallengeWithId(

--- a/src/test/java/Hampouch/server/domain/challenge/service/FixedDateChallengeCycleTest.java
+++ b/src/test/java/Hampouch/server/domain/challenge/service/FixedDateChallengeCycleTest.java
@@ -47,6 +47,26 @@ class FixedDateChallengeCycleTest {
         assertThat(plan.durationDays()).isEqualTo(31);
     }
 
+    @Test
+    @DisplayName("고정일 당일은 주기 시작 경계이고 그 사이 날짜는 부분 주기다")
+    void cycleStartIsOnlyTheFixedDay() {
+        assertThat(FixedDateChallengeCycle.isCycleStart(LocalDate.of(2026, 8, 1), 1)).isTrue();
+        assertThat(FixedDateChallengeCycle.isCycleStart(LocalDate.of(2026, 8, 7), 1)).isFalse();
+        assertThat(FixedDateChallengeCycle.isCycleStart(LocalDate.of(2026, 8, 15), 15)).isTrue();
+        assertThat(FixedDateChallengeCycle.isCycleStart(LocalDate.of(2026, 8, 14), 15)).isFalse();
+    }
+
+    @Test
+    @DisplayName("29~31일 고정은 그 날짜가 없는 달의 말일이 주기 시작 경계가 된다")
+    void cycleStartFallsBackToLastDayOfShortMonth() {
+        // 2026년 2월은 28일까지 — 매월 31일 고정의 2월 경계는 2/28이다
+        assertThat(FixedDateChallengeCycle.isCycleStart(LocalDate.of(2026, 2, 28), 31)).isTrue();
+        assertThat(FixedDateChallengeCycle.isCycleStart(LocalDate.of(2026, 2, 27), 31)).isFalse();
+        // 윤년인 2028년 2월은 29일까지라 경계가 하루 밀린다
+        assertThat(FixedDateChallengeCycle.isCycleStart(LocalDate.of(2028, 2, 29), 31)).isTrue();
+        assertThat(FixedDateChallengeCycle.isCycleStart(LocalDate.of(2028, 2, 28), 31)).isFalse();
+    }
+
     private static void assertFebruaryStartDate(int year, LocalDate expectedStartDate) {
         for (int fixedDay = 29; fixedDay <= 31; fixedDay++) {
             FixedDateChallengeCycle.Plan plan = FixedDateChallengeCycle.startingOn(


### PR DESCRIPTION
## 📎연관된 이슈

- close: #265

## 📄 작업 내용 요약

- 날짜 고정 최초 설정이 고정일 경계에서 시작하지 않으면 부분 주기로 보고, 한 달 목표를 주기 길이에 비례해 배분합니다. 기준이 되는 "한 달"은 30일로 고정했습니다 — 다음 온전 주기의 실제 길이(28~31일)로 나누면 같은 목표라도 설정한 달에 따라 첫 주기 예산이 갈립니다.
- 다음 주기가 이어받을 한 달 목표는 배분을 되돌려 복원합니다. `budgetTotal`이 목표를 담는 유일한 자리라, 배분해 저장한 값을 그대로 물려주면 월 목표가 주기마다 깎입니다.
- `POST /api/challenges/fixed-date/start`가 `startDate`를 받아 서버가 계산한 주기 시작일과 대조합니다. 계산에는 쓰지 않고 초안이 아직 유효한지 확인만 합니다.
- `FixedDateChallengeCycle.isCycleStart(date, fixedDay)`를 추가해 "고정일 경계에서 시작했는가" 판별을 한곳에 모았습니다. 배분·역산 양쪽이 같은 판별을 씁니다.

## 👀 중요 변경 사항

- **`POST /api/challenges/fixed-date/start` 요청에 `startDate`가 필수로 추가됩니다.**

- 초안(`GET /api/challenges/fixed-date/next`)에서 받은 `startDate`를 그대로 실어 보내면 됩니다. 서버가 계산한 주기 시작일과 다르면 409 `FIXED_DATE_SOURCE_STALE`을 반환하므로, 클라이언트는 초안을 다시 조회해 재시도해야 합니다.

- 초안 조회 시각과 입장 시각 사이에 자정이 지나면 서버가 계산하는 주기가 달라지는데, `sourceChallengeId`는 그대로라 기존 검사를 통과했습니다. 9/30 23:58에 조회한 9월 초안으로 10/1 00:01에 입장하면 10월 챌린지가 만들어지고 9월 주기는 챌린지 없이 통째로 건너뛰었습니다.

- **날짜 고정 최초 생성 응답의 `budgetTotal`이 입력값과 다를 수 있습니다.**

- 부분 주기면 배분된 값이 내려갑니다. 8/7에 1일 고정으로 300,000원을 설정하면 첫 주기는 25일이므로 `budgetTotal` 250,000원, 하루 한도 10,000원이 됩니다. 화면은 요청값이 아니라 응답값으로 그려야 합니다.
- 배분 전후 하루 한도 (한 달 목표 300,000원, 고정일 매월 1일):

| 설정일 | 첫 주기 | 변경 전 | 변경 후 |
|---|---|---|---|
| 8/1 | 31일 (온전) | 9,677원 | 9,677원 |
| 8/7 | 25일 | 12,000원 | 10,000원 |
| 8/31 | 1일 | 300,000원 | 10,000원 |

## 🔖 Uncompleted Tasks

- 온보딩 "챌린지 전체 식비 목표" 문구는 이번 범위에서 제외했습니다. 필드 의미가 "한 달 기준
  목표"에 가까워졌지만 흐름 변경은 없어 서버만 먼저 맞췄습니다.
- 409 수신 시 초안을 재조회하는 처리는 클라이언트 작업입니다.

## 📢 To Reviewers

- **월 목표를 컬럼으로 두지 않고 역산한 이유**: 부분 주기는 `create()`에서만 생기고 (입장은 언제나 `containing()`이 잡아준 경계에서 시작하므로 항상 온전 주기), 경계 여부가 `isCycleStart`로 정확히 떨어져서 휴리스틱이 아닙니다. 컬럼을 추가하면 `adjustGoal`·응답
DTO·마이그레이션까지 번지는 데 비해 얻는 게 반올림 정확도뿐이라 과하다고 판단했습니다. 다르게 보시면 말씀해주세요.
- **반올림 손실**: 정수 나눗셈이라 역산이 정확히 떨어지지 않을 수 있습니다. 최악의 경우 (월 목표 100,000원, 첫 주기 1일) 10원이며, 두 번째 주기부터는 온전 주기라 그 값이 그대로 상속돼 누적되지 않습니다.
- **멱등 경로에는 `startDate` 검증을 넣지 않았습니다.** 이미 이번 주기 챌린지가 있다는 뜻이라 잘못된 챌린지를 만드는 게 아니라 실제 존재하는 것을 돌려줍니다. 응답에 `startDate`·`endDate`가 실려 있어 클라이언트가 화면을 갱신할 수 있습니다.
- **`startDate`에 `@FutureOrPresent`를 붙이지 않았습니다.** 늦게 입장하면 주기 시작일이 과거라 붙이면 정상 입장이 400으로 막힙니다.
- 검증을 휴식 재개(`rest.resume`) **앞**에 뒀습니다. 롤백으로도 되돌아가지만 거절되는 요청이 부수효과를 건드리지 않게 순서로 막았습니다.